### PR TITLE
[DOC-1] Add GTM code to config.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,6 +50,9 @@ const config = {
           editUrl:
             'https://github.com/ed-fi-alliance-oss/ed-fi-alliance-oss.github.io/tree/main/blog/',
         },
+        googleTagManager: {
+          containerId: "GTM-KGR2977"
+        },
         theme: {
           customCss: './src/css/custom.css',
         },


### PR DESCRIPTION
Adds the GTM container Id to track Google Analytics and Hubspot Analytics in one.

Using the "built-in preset config rather than a separate "plugin". Documentation seems to suggest this will be applied as a plugin globally and will not require separate configuration on a product-by-product basis.