### PR TITLE
Add initial scaffolding for Badge Documentation

### DIFF
--- a/docs/ed-fi-badges/1-applying-for-an-ed-fi-badge.md
+++ b/docs/ed-fi-badges/1-applying-for-an-ed-fi-badge.md
@@ -1,0 +1,14 @@
+---
+title: Applying for an Ed-Fi Badge
+---
+
+# Applying for an Ed-Fi Badge
+
+:::tip
+
+🚧 This site is under construction. In the meantime, please see
+[Ed-Fi API Guidelines](https://edfi.atlassian.net/wiki/spaces/EFAPIGUIDE/overview)
+for more information.
+
+:::
+

--- a/docs/ed-fi-badges/2-badging-requirements-for-technology-partners.md
+++ b/docs/ed-fi-badges/2-badging-requirements-for-technology-partners.md
@@ -1,0 +1,35 @@
+---
+author: Ecleamus Ricks
+tags: [Ed-Fi, Badging, Technology Providers]
+description: Requirements for technology providers to be eligible for Ed-Fi badges.
+created: 2024-08-07
+---
+
+# Badging Requirements for Technology Providers
+:::tip
+
+🚧 This site is under construction. In the meantime, please see
+[Ed-Fi API Guidelines](https://edfi.atlassian.net/wiki/spaces/EFAPIGUIDE/overview)
+for more information.
+
+:::
+
+To be eligible for any Ed-Fi badge, the following requirements must be met. Note that requirements for specific badges are described in Available Ed-Fi Badges.
+
+## Partner Program
+Vendors must submit a request to join the Partner Program by providing the information and commitments requested in this online form. Direct any questions to Sean Casey.
+
+## Availability
+The Ed-Fi related functionality that is the basis for the badge must be widely available in the K12 market. "Widely available" means that at minimum the functionality is available for use in an entire US state or purchasable or acquirable by a minimum of 100 school districts. The functionality must also be part of the core product functionality or a standardized option - i.e., it must not require customized development work to make function, but it can require configuration. Availability information must be recorded in the badge application and will be published in the Registry of Ed-Fi Badged Products and Services.
+
+## Actual Usage
+The Ed-Fi related functionality that is the basis for the badge must be in actual usage in a school district. The usage may be a pilot that is planned for production, but must not be a proof-of-concept, "spike" or other transient project not designed and intended to become part of the infrastructure of an education agency.
+
+## Product Updates
+The Ed-Fi related functionality that is the basis for the badge must be maintained across product updates for the duration of the badge. The Alliance may ask for a re-verification of product functionality at any time if there is a question on if the functionality is available and working.
+
+## Use Core Data Entities
+The Ed-Fi related functionality that is the basis for the badge must employ Ed-Fi core data entities – i.e. those in the Ed-Fi Unifying Data Model (latest version is here: Ed-Fi Unifying Data Model) – as part of its core value to users. The integration functionality can include extended elements, but the value to end uses must be clear and apparent if the extensions were not present.
+
+## Changes to Badge Requirements
+The Ed-Fi Alliance may at any time change the requirements for a badge. Such a change will not necessarily require a reapplication, but it does mean that a system that previously received a badge may not be able to meet the requirements the next time the product applies.

--- a/docs/ed-fi-badges/3-registry-of-ed-fi-badged-products-and-services.md
+++ b/docs/ed-fi-badges/3-registry-of-ed-fi-badged-products-and-services.md
@@ -1,0 +1,69 @@
+---
+author: Eric Jansson
+tags: [education Agency,v]
+description: Requirements for technology providers to be eligible for Ed-Fi badges.
+created: 2024-08-07
+title: Registry of Ed-Fi Badged Products and Services
+---
+# Registry of Ed-Fi Badged Products and Services
+:::tip
+
+🚧 This site is under construction. In the meantime, please see
+[Ed-Fi API Guidelines](https://edfi.atlassian.net/wiki/spaces/EFAPIGUIDE/overview)
+for more information.
+
+:::
+
+This page lists products that have been awarded an Ed-Fi badge.
+
+## Ed-Fi Managed ODS / API Platform Badge
+
+| Product Image | Product | Provider | Provider Website | Product Information | Badge Valid Through | Verifying Agencies | Version Compatibility | Product Availability |
+|---------------|---------|----------|------------------|----------------------|---------------------|--------------------|-----------------------|----------------------|
+| !EdGraphDarkLogo | EdGraph | EdWire | edgraph.com | edgraph.com | August 28, 2025 | NEFEC, Sumter County Schools | Ed-Fi ODS API for Suite 3 v3.4, Ed-Fi ODS API for Suite 2 v2.5 and v2.6 | Available to any agency (all sizes) or vendor in the U.S. |
+| !EA-startingblocks-color | StartingBlocks | Education Analytics | edanalytics.org | edanalytics.org/products/starting-blocks | May 12, 2025 | South Carolina DOE, Texas Education Exchange, Vermont Agency of Education | EdFi ODS/API versions 6.x and 7.x, Admin API 1.x and 2.x, Data Standards 4 and 5 | Available to any agency (all sizes) in the U.S. |
+| !k12analytics.png) | K12Analytics | K12Analytics Engineering | k12analyticsengineering.dev | k12analyticsengineering.dev | March 8, 2025 | BreakThrough Schools | Ed-Fi ODS API for Suite 3 v3.1.1 | Available to any agency (all sizes) in the U.S. |
+| !ESPG Stacked-Logo | ESP Solutions Group | ESP Solutions Group | espsolutionsgroup.com | espmsp.com | May 18, 2025 | Wyoming Department of Education (WDE) | Ed-Fi ODS API 2.x and 3.x | Available to any agency (all sizes) in the U.S. |
+| !Edufied_Logo.jpeg) | Edufied Hosting | edufied | edufied.com | edufied.com/about-us | August 30, 2025 | Holdsworth Center, TX, Boston Public Schools, MA, New Mexico PED, NM | Ed-Fi ODS / API Suite 3 v5.3, Ed-Fi ODS / API Suite 3 v7.0, Commitment to continuous support for most recent versions | Available to any agency (all sizes) in the U.S. |
+| !ClassLink Horizontal Logo | ClassLink OneData | ClassLink | classlink.com | classlink.com/products | September 12, 2025 | Clay County, Ennis ISD | Ed-Fi ODS / API for Suite 3 v6.1 | Available to any agency (all sizes) in the U.S. |
+
+## Ed-Fi ODS Platform Consumer Badge
+This badge is for products that interact or use the data from the Ed-Fi ODS platform, but access is not via API. Products using an Ed-Fi API to source data should apply for the Ed-Fi API Consumer Badge.
+
+| Product Image | Product | Provider | Provider Website | Product Information | Badge Valid Through | Verifying Agencies | Version Compatibility | Product Availability |
+|---------------|---------|----------|------------------|----------------------|---------------------|--------------------|-----------------------|----------------------|
+| !EdGraphDarkLogo | EdGraph | EdWire | edgraph.com | edgraph.com | August 28, 2025 | NEFEC, Sumter County Schools | Ed-Fi ODS API for Suite 3 v3.4, Ed-Fi ODS API for Suite 2 v2.5 and v2.6 | Available to any agency (all sizes) or vendor in the U.S. |
+| !EA-startingblocks-color | StartingBlocks | Education Analytics | edanalytics.org | edanalytics.org/products/starting-blocks | May 12, 2025 | South Carolina DOE, Texas Education Exchange, Vermont Agency of Education | EdFi ODS/API versions 6.x and 7.x, Admin API 1.x and 2.x, Data Standards 4 and 5 | Available to any agency (all sizes) in the U.S. |
+| !k12analytics.png) | K12Analytics | K12Analytics Engineering | k12analyticsengineering.dev | k12analyticsengineering.dev | March 8, 2025 | BreakThrough Schools | Ed-Fi ODS API for Suite 3 v3.1.1 | Available to any agency (all sizes) in the U.S. |
+| !ESPG Stacked-Logo | ESP Solutions Group | ESP Solutions Group | espsolutionsgroup.com | espmsp.com | May 18, 2025 | Wyoming Department of Education (WDE) | Ed-Fi ODS API 2.x and 3.x | Available to any agency (all sizes) in the U.S. |
+| !Edufied_Logo.jpeg) | Edufied Hosting | edufied | edufied.com | edufied.com/about-us | August 30, 2025 | Holdsworth Center, TX, Boston Public Schools, MA, New Mexico PED, NM | Ed-Fi ODS / API Suite 3 v5.3, Ed-Fi ODS / API Suite 3 v7.0, Commitment to continuous support for most recent versions | Available to any agency (all sizes) in the U.S. |
+| !ClassLink Horizontal Logo | ClassLink OneData | ClassLink | classlink.com | classlink.com/products | September 12, 2025 | Clay County, Ennis ISD | Ed-Fi ODS / API for Suite 3 v6.1 | Available to any agency (all sizes) in the U.S. |
+
+## Ed-Fi API Consumer Badge
+This badge is for products that read data out of an Ed-Fi defined API and integrate that data into their product offering.
+
+| Product Image | Product | Provider | Provider Website | Product Information | Badge Valid Through | Verifying Agencies | Version Compatibility | Product Availability |
+|---------------|---------|----------|------------------|----------------------|---------------------|--------------------|-----------------------|----------------------|
+| !EdGraphDarkLogo | EdGraph | EdWire | edgraph.com | edgraph.com | August 28, 2025 | NEFEC, Sumter County Schools | Ed-Fi ODS API for Suite 3 v3.4, Ed-Fi ODS API for Suite 2 v2.5 and v2.6 | Available to any agency (all sizes) or vendor in the U.S. |
+| !EA-startingblocks-color | StartingBlocks | Education Analytics | edanalytics.org | edanalytics.org/products/starting-blocks | May 12, 2025 | South Carolina DOE, Texas Education Exchange, Vermont Agency of Education | EdFi ODS/API versions 6.x and 7.x, Admin API 1.x and 2.x, Data Standards 4 and 5 | Available to any agency (all sizes) in the U.S. |
+| !k12analytics.png) | K12Analytics | K12Analytics Engineering | k12analyticsengineering.dev | k12analyticsengineering.dev | March 8, 2025 | BreakThrough Schools | Ed-Fi ODS API for Suite 3 v3.1.1 | Available to any agency (all sizes) in the U.S. |
+| !ESPG Stacked-Logo | ESP Solutions Group | ESP Solutions Group | espsolutionsgroup.com | espmsp.com | May 18, 2025 | Wyoming Department of Education (WDE) | Ed-Fi ODS API 2.x and 3.x | Available to any agency (all sizes) in the U.S. |
+| !Edufied_Logo.jpeg) | Edufied Hosting | edufied | edufied.com | edufied.com/about-us | August 30, 2025 | Holdsworth Center, TX, Boston Public Schools, MA, New Mexico PED, NM | Ed-Fi ODS / API Suite 3 v5.3, Ed-Fi ODS / API Suite 3 v7.0, Commitment to continuous support for most recent versions | Available to any agency (all sizes) in the U.S. |
+| !ClassLink Horizontal Logo | ClassLink OneData | ClassLink | classlink.com | classlink.com/products | September 12, 2025 | Clay County, Ennis ISD | Ed-Fi ODS / API for Suite 3 v6.1 | Available to any agency (all sizes) in the U.S. |
+
+## Ed-Fi Implementation Partner Badge
+The Ed-Fi Systems Implementer Badge is to recognize services organizations doing field implementation work around the Ed-Fi technology stack.
+
+Many agencies are forming short-term project-based relationships to perform specific tasks with Ed-Fi technology - upgrades, system integrations, and strategy consulting.
+
+| Organization Image | Organization | Website | Sample Documentation | Badge Valid Through | Verifying Agencies | Services Performed |
+|--------------------|--------------|---------|----------------------|---------------------|--------------------|--------------------|
+| !EdWise Group | EdWise Group | edwisegroup.com | IDOE Ed-Fi 6.1 Vendor Documentation, IDOE Ed-Fi 6.1 SIS Vendor Badging Scenarios, IDOE Ed-Fi 2.4 to 6.0 Data mapping | Nov 1, 2025 | Indiana DoE, Nebraska DoE | edwisegroup.com/services |
+| !Unicon.png) | Unicon | unicon.net | TPDM Starter Kit Required Data Checklist.xlsx, Evaluation Data Collection Short Form Template with Sample.xlsx, Project Phases.pptx | May 14, 2026 | University of Texas, El Paso, Texas A&M University International University | unicon.net/services/k-20 |
+
+## Related Pages
+- Applying for an Ed-Fi Badge
+- Badging Requirements for Technology Providers
+- Available Ed-Fi Badges
+- Registry of Ed-Fi Certified Products
+

--- a/docs/ed-fi-badges/_category_.json
+++ b/docs/ed-fi-badges/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Ed-Fi Badge"
+}

--- a/docs/ed-fi-badges/available-ed-fi-badges/1- ed-fi-api-consumer-badge.md
+++ b/docs/ed-fi-badges/available-ed-fi-badges/1- ed-fi-api-consumer-badge.md
@@ -1,0 +1,12 @@
+---
+---
+
+# Ed-Fi API Consumer Badge
+:::tip
+
+🚧 This site is under construction. In the meantime, please see
+[Ed-Fi API Guidelines](https://edfi.atlassian.net/wiki/spaces/EFAPIGUIDE/overview)
+for more information.
+
+:::
+

--- a/docs/ed-fi-badges/available-ed-fi-badges/2-ed-fi-ods-platform-consumer-badge.md
+++ b/docs/ed-fi-badges/available-ed-fi-badges/2-ed-fi-ods-platform-consumer-badge.md
@@ -1,0 +1,13 @@
+---
+
+---
+
+# Ed-Fi ODS Platform Consumer Badge
+
+:::tip
+
+🚧 This site is under construction. In the meantime, please see
+[Ed-Fi API Guidelines](https://edfi.atlassian.net/wiki/spaces/EFAPIGUIDE/overview)
+for more information.
+
+:::

--- a/docs/ed-fi-badges/available-ed-fi-badges/3- ed-fi-managed-ods-api-platform-badge.md
+++ b/docs/ed-fi-badges/available-ed-fi-badges/3- ed-fi-managed-ods-api-platform-badge.md
@@ -1,0 +1,49 @@
+---
+author: Eric Jansson
+tags: [Ed-Fi, Managed ODS, API Platform, SaaS]
+description: Requirements and details for the Ed-Fi Managed ODS / API Platform Badge.
+title: Ed-Fi Managed ODS / API Platform Badge
+---
+
+# Ed-Fi Managed ODS / API Platform Badge
+:::tip
+
+🚧 This site is under construction. In the meantime, please see
+[Ed-Fi API Guidelines](https://edfi.atlassian.net/wiki/spaces/EFAPIGUIDE/overview)
+for more information.
+
+:::
+
+The Ed-Fi Managed ODS / API Platform Badge is for products that provide the Ed-Fi Operational Data Store and API (ODS/API) as software-as-a-service (SaaS).
+
+Data integration and use at scale is a challenging problem regardless of platform, and these challenges have particularly been difficult for agencies with lower access to expertise in software development, enterprise data management, or data systems integration. Similarly, many larger agencies are also attempting to outsource aspects of these operations in order to focus more on analytics and business intelligence. This badge highlights product efforts to address these problems.
+
+## Important Info
+Unlike with other Ed-Fi badges, this badge is good for one year and must be renewed annually.
+
+## Requirements
+(info) In addition to the specifics listed below, a product must satisfy all applicable core requirements listed here: Badging Requirements for Technology Providers.
+
+To qualify for this badge, a product must meet the following requirements:
+
+1. **Recent Version**: The product must include a recent, full version of the Ed-Fi Operational Data Store and API. The product must offer – at the minimum – a version of the ODS / API that:
+    - is currently under support,
+    - was released in the past 18 months, and
+    - is part of the most recent Ed-Fi suite (please consult the Ed-Fi Suite Version Matrix for suite information).
+
+2. **No Ecosystem-Facing API Extensions**: The product must offer a version of the Ed-Fi ODS / API that includes no ecosystem-facing API extensions. Extension APIs can be offered as an additional add-on or configuration option to the product, but a customer must be able to request and purchase a non-extended version.
+
+3. **Cloud Platform**: The product must be offered on a cloud platform, such as Microsoft Azure, Amazon Web Services, or Google Cloud. This platform must include management of all operating system, network, and hardware level services, such that management and operations of those services are not the responsibility of the product customer and must be included in the product offering. Example: a virtual machine running in AWS, Google, or Azure for which the customer is responsible for applying security and other patches would not qualify, while a product offered on one of those platforms which was automatically maintained, patched, and monitored would qualify.
+
+4. **Installation and Operation**: Installation and operation of the product within the tenancy of an education agency on a cloud provider platform is allowed, providing that the agency is not responsible for any operations (per 3.a).
+
+5. **Scalability**: The platform must provide for easy, non-disruptive scaling to account for variations in capacity needs.
+
+6. **Subscription Model**: The product must be available by subscription. There can be different subscriptions that correspond to different service levels, add-ons, etc., but those must be covered under the subscription chosen by the customer. There can be "startup" or "setup" fees that are assessed for new customers and cover one-time setup operations. The operations of the managed platform must not require other fees beyond the subscription after setup.
+
+7. **Distinguishing Products**: If an organization has multiple products including non-managed options, those must be distinguished from the managed platform offering in marketing and other material to avoid confusion about what product received the badge.
+
+8. **Upgrades**: The product must include upgrades as part of the subscription fees, and customers must have the option to be no less than 18 months behind the latest Ed-Fi ODS/API release.
+
+9. **Support Levels**: The product must include the option for Tier-2 and Tier-3 support. Tier-1 support for any end-users can be provided via agency systems (e.g., via a LEA help desk or ticketing system), but the product must have an option included in a subscription level for escalations of Tier-1 issues to Tier-2 and Tier-3 support. These higher support levels must cover all operations of the Ed-Fi platform and also system integrations with other systems.
+

--- a/docs/ed-fi-badges/available-ed-fi-badges/4- ed-fi-implementation-partner-badge.md
+++ b/docs/ed-fi-badges/available-ed-fi-badges/4- ed-fi-implementation-partner-badge.md
@@ -1,0 +1,55 @@
+---
+author: David Clements
+tags: [Ed-Fi, Implementation Partner, Best Practices]
+description: Requirements and details for the Ed-Fi Implementation Partner Badge.
+title: Ed-Fi Implementation Partner Badge
+---
+
+# Ed-Fi Implementation Partner Badge
+:::tip
+
+🚧 This site is under construction. In the meantime, please see
+[Ed-Fi API Guidelines](https://edfi.atlassian.net/wiki/spaces/EFAPIGUIDE/overview)
+for more information.
+
+:::
+
+To be awarded this badge, a vendor must be able to demonstrate adherence to Ed-Fi best practices and their services must facilitate Ed-Fi data standards delivery in their customer's solutions.
+
+## Requirements
+:::info
+ In addition to the specifics listed below, a vendor must satisfy all applicable core requirements listed here: Badging Requirements for Technology Providers.
+:::
+
+### Verifications - Quality
+Like other badges, a verifying agency/company is required. The nature of the verification is important due to the custom nature of offering implementation services.
+- The verified vendor implementation must also be badged/certified to qualify as a verification. This is required to ensure that implementation services are following best practices and current certification/badging requirements.
+- Collaboratives or regional service centers can provide verification if their solution is badged as a “Ed-Fi Managed ODS API Platform Badge”.
+- Ed-Fi may use a developer to look at code of the implementation to look for best practices (e.g., look for multi-threading in code to support best practice).
+- Verifications from individual LEAs/SEAs require a deeper validation than other means to ensure adherence to Ed-Fi standards and repeatability. Vendors should consider productizing their service for more streamlined scalability. Part of this verification includes validation that Ed-Fi core components are used, code inspection to validate that best practices are being used, and reviewing processes exist for repeatability.
+
+### Verifications - Quantity
+Unlike other badges, the Implementation Partner badge requires two verifications. Due to the custom nature of implementations, Ed-Fi requires a second verification to demonstrate repeatability in the marketplace.
+
+### Proof of Repeatability
+Implementation partners must demonstrate their services are “productized” for future customers. Examples of evidence include re-usable development packages, re-usable project plans, and/or detailed implementation documentation. These documents can be internal intellectual property but must be shared with Ed-Fi with enough detail to verify their existence and usage.
+
+### Participation in the Ed-Fi Community
+Implementation partners must be in the Ed-Fi partner program. Partnership requires active participation in governance and the community. Implementation partners enable Ed-Fi throughout the community and provide a conduit between their customer base and current Ed-Fi practices.
+
+### Academy Track
+Implementation Partner should have at least one person on staff for each Ed-Fi project that has gone through all the Academy tracks involving Ed-Fi overview and best practices.
+
+### Ed-Fi Project Retrospective Participation
+Any project can be reported to Ed-Fi for a group retrospective. This can be done during mid-project reviews or as the project is closed out. Lessons learned from the retrospective can identify gaps in best practices and will be used to anonymously update Ed-Fi’s best practices and guidance. Badge removal may occur if the retrospective identifies gaps in quality and repeatability by a badged vendor that are not resolved after an appropriate time.
+
+### Provisional Badges
+The requirement for existing successful customers can be a challenging obstacle for new companies entering this space. New companies can apply for a provisional badge which will require a more thorough review for best practices and evidence of repeatability. The badge will be provisional until the appropriate verifications are provided. The first projects will go through the project retrospective process so Ed-Fi can evaluate the project’s implementations against Ed-Fi standards and best practices.
+
+---
+
+**Related pages**
+
+- Available Ed-Fi Badges
+- Ed-Fi Badge Program
+- Ed-Fi Managed ODS API Platform Badge

--- a/docs/ed-fi-badges/available-ed-fi-badges/_category_.json
+++ b/docs/ed-fi-badges/available-ed-fi-badges/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Available Ed-Fi Badges",
+  "position": 1
+}

--- a/docs/ed-fi-badges/available-ed-fi-badges/readme.md
+++ b/docs/ed-fi-badges/available-ed-fi-badges/readme.md
@@ -1,0 +1,16 @@
+---
+author: Eric Jansson
+tags: [Ed-Fi, Badges]
+description: List of available badges provided by the Ed-Fi Alliance.
+title: Available Ed-Fi Badges
+sidebar_position: 1
+---
+
+# Available Ed-Fi Badges
+
+The Ed-Fi Alliance provides the following badges:
+
+- [**Ed-Fi API Consumer Badge**](./1-%20ed-fi-api-consumer-badge.md)
+- [**Ed-Fi Implementation Partner Badge**](./4-%20ed-fi-implementation-partner-badge.md)
+- [**Ed-Fi Managed ODS API Platform Badge**](./3-%20ed-fi-managed-ods-api-platform-badge.md)
+- [**Ed-Fi ODS Platform Consumer Badge**](./2-ed-fi-ods-platform-consumer-badge.md)

--- a/docs/ed-fi-badges/readme.md
+++ b/docs/ed-fi-badges/readme.md
@@ -1,0 +1,28 @@
+---
+description: The Ed-FI Badges
+title: Ed-Fi Badges
+sidebar_position: 0
+---
+
+## Ed-Fi Badges
+
+Ed-Fi Badges allow product developers to demonstrate support for Ed-Fi standards and technology, particularly in areas that are not yet covered by an Ed-Fi Certification. Many products that use Ed-Fi standardized APIs or integrate natively with Ed-Fi technology tools (such as the Ed-Fi Operational Data Store and API) are forging new ground in terms of defining data integration use cases valuable to schools. Badges allow these efforts to be validated and recognized by the community.
+
+Badges are not intended nor should they be used as a "lightweight" certification, either by technology providers or the education agencies they support. Over time, some badges may act as precursors to new certifications. Unlike certification, badges also focus on both Ed-Fi standards as well as Ed-Fi technology tools; by contrast, Ed-Fi certifications only focus on Ed-Fi standards.
+
+### Program Information
+
+This site contains resources and detailed information about the Ed-Fi Badges program.
+
+#### Resources For Vendors
+- [Applying for an Ed-Fi Badge](https://edfi.atlassian.net/wiki/spaces/EDFIBADGE/pages/20611181/Applying+for+an+Ed-Fi+Badge)
+
+#### Resources For Education Agencies
+- [Registry of Ed-Fi Badged Products and Services](https://edfi.atlassian.net/wiki/spaces/EDFIBADGE/pages/20611183/Registry+of+Ed-Fi+Badged+Products+and+Services)
+
+### Available Ed-Fi Badges
+- [**Ed-Fi API Consumer Badge**](./Available%20Ed-Fi%20Badges/1-%20ed-fi-api-consumer-badge.md)
+- [**Ed-Fi Implementation Partner Badge**](./available-ed-fi-badges/4-%20ed-fi-implementation-partner-badge.md)
+- [**Ed-Fi Managed ODS API Platform Badge**](./available-ed-fi-badges/3-%20ed-fi-managed-ods-api-platform-badge.md)
+- [**Ed-Fi ODS Platform Consumer Badge**](./available-ed-fi-badges/2-ed-fi-ods-platform-consumer-badge.md)
+

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,6 +86,17 @@ const config = {
     [
       '@docusaurus/plugin-content-docs',
       {
+        id: 'ed-fi-badges',
+        path: 'docs/ed-fi-badges',
+        editUrl: ({ docPath }) =>
+          `https://github.com/ed-fi-alliance-oss/ed-fi-alliance-oss.github.io/tree/main/${docPath}/`,
+        routeBasePath: 'docs/ed-fi-badges',
+        sidebarPath: './sidebars.js',
+      },
+    ],
+    [
+      '@docusaurus/plugin-content-docs',
+      {
         id: 'community',
         path: 'community',
         editUrl: ({ docPath }) =>
@@ -192,6 +203,11 @@ const config = {
               {
                 href: 'https://exchange.ed-fi.org/',
                 label: 'Exchange',
+                position: 'right',
+              },
+              {
+                href: '/docs/ed-fi-badges',
+                label: 'Ed-Fi Badge Program',
                 position: 'right',
               },
             ],

--- a/reference/1-data-exchange/readme.mdx
+++ b/reference/1-data-exchange/readme.mdx
@@ -1,0 +1,37 @@
+# Data Exchange Standards
+
+:::tip
+
+🚧 This site is under construction. In the meantime, please see
+[Ed-Fi Standards](https://edfi.atlassian.net/wiki/spaces/ETKB/pages/20875600/Ed-Fi+Standards)
+for more information.
+
+:::
+
+
+# The Ed-Fi Data Standard
+
+Visit the [tutorial](./data-exchange/tutorial)
+
+# Current versions
+
+| Suite  | Product & Version   | Release Date   | Status       | License                    |
+|--------|---------------------|----------------|--------------|----------------------------|
+| Suite 3| Data Standard v5.1  | 31 May 2024    | Latest       | Apache License, Version 2.0|
+|        | Data Standard v5.0  | 30 Nov 2023    | Active       |                            |
+|        | Data Standard v5.0-pre2 | 31 Jul 2023 | Use v5.0.0   |                            |
+|        | Data Standard v5.0-pre1 | 28 Apr 2023 | Use v5.0.0   |                            |
+|        | Data Standard v4.0  | 30 Nov 2022    | Active       |                            |
+|        | Data Standard v4.0.0-a | 31 Aug 2022  | Use v4.0.0   |                            |
+|        | Data Standard v3.3.1-b | 12 Nov 2021  | Active       |                            |
+|        | Data Standard v3.3.0-a | 29 Mar 2021  | Unsupported  |                            |
+|        | Data Standard v3.2  | 09 Dec 2020    | Unsupported  |                            |
+|        | Data Standard v3.1  | 05 Feb 2019    | Unsupported  |                            |
+|        | Data Standard v3.0  | 31 May 2018    | Unsupported  |                            |
+| Suite 2| Data Standard v2.2  | 19 Sep 2018    | Unsupported  |                            |
+|        | Data Standard v2.1  | 18 Jan 2018    |              |                            |
+|        | Data Standard v2.0.1 | 15 Dec 2017   |              |                            |
+| Suite 1| Data Standard v1.2  | 13 Nov 2013    | Unsupported  |                            |
+|        | Data Standard v1.1.1 | 23 Apr 2013   |              |                            |
+|        | Data Standard v1.1  | 04 Dec 2012    |              |                            |
+|        | Data Standard v1.0  | 18 Jan 2012    |              |                            |


### PR DESCRIPTION
Adds a `docs/ed-fi-badges` directory to serve as a baseline for other documentation sorces. This provides the following features:

- The Ed-fi badge documentatiaon source is treated as its own doc plugin
- URL slug and routing rules, and sidebar can be controlled at the doc product level
- Versioning (if we should choose to add later) can be controlled on a per doc product level.
- Use of _category_.json to control label and ordering of folders in the sidebar.
- Using Frontmatter to prefix md files and add metadata lik title and sidebar_position to control how the page is displayed.

The goal of this PR is to review and develop the structure and reach a consensus. Pages that are added are WIP - static assets and QA process still need to be detailed 