### PR TITLE
Disable contextual search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -158,7 +158,7 @@ const config = {
         indexName: 'ed-fi-alliance-ossio',
 
         // Optional: see doc section below
-        contextualSearch: true,
+        contextualSearch: false,
 
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
         externalUrlRegex: 'external\\.com|domain\\.com',


### PR DESCRIPTION
Search is not working right now, and I tracked it down to this setting. We need to research faceting / contextual search more carefully before trying again.