### PR TITLE
[DOC-166] Fix DS v5 Assessment domain model reference page

### DIFF
--- a/dataStandard_versioned_docs/version-5/model-reference/assessment-domain/entities-references-and-descriptors.md
+++ b/dataStandard_versioned_docs/version-5/model-reference/assessment-domain/entities-references-and-descriptors.md
@@ -29,42 +29,42 @@ hide_table_of_contents: true
 
 ## Assessment Domain Descriptors
 
-| Entity | Descriptor | Description | Usage Classification | EDFacts Mapping | Commonly Used | Commonly State-Defined |
+| Entity | Descriptor | Description | Usage Classification (see tip below) | EDFacts Mapping | Commonly Used | Commonly State-Defined |
 | --- | --- | --- | --- | --- | --- | --- |
-| Assessment | AcademicSubject | The description of the content or subject area (e.g., arts, mathematics, reading, stenography, or a foreign language) of an assessment. | Local | Yes | Yes |     |
-| AssessedGradeLevel | The grade level(s) for which an assessment is designed. The semantics of null is assumed to mean that the assessment is not associated with any grade level. | Orthodox | Yes | Yes |     |
-| AssessmentCategory | The category of an assessment based on format and content. For example: Achievement test, Advanced placement test, Alternate assessment/grade-level standards, Attitudinal test, Cognitive and perceptual skills test... | Orthodox | Yes | Yes |     |
-| AssessmentIdentificationSystem | A coding scheme that is used for identification and record-keeping purposes by schools, social services, or other agencies to refer to an assessment. | Orthodox |     |     |     |
-| AssessmentPeriod | The period of time in which an assessment is supposed to be administered (e.g., Beginning of Year, Middle of Year, End of Year). | Local |     | Yes |     |
-| AssessmentReportingMethod | The method that the administrator of the assessment uses to report the performance and achievement of all students. It may be a qualitative method such as performance level descriptors or a quantitative method such as a numerical grade or cut score. More than one type of reporting method may be used. | Local |     | Yes | Yes |
-| Language | An indication of the languages in which the assessment is designed. | Orthodox | Yes | Yes | Yes |
-| PerformanceLevel | The performance level(s) defined for the assessment. | Local | Yes | Yes |     |
-| PlatformType | The platforms with which the assessment may be delivered. | Orthodox |     |     |     |
-| PublicationStatus | The publication status of the document (i.e., Adopted, Draft, Published, Deprecated, Unknown). | Orthodox |     |     |     |
-| ResultDatatypeType | The datatype of the result. The results can be expressed as a number, percentile, range, level, etc. | Orthodox |     |     | Yes |
-| AssessmentItem | AssessmentItemCategory | Category or type of the AssessmentItem. For example: Multiple choice, Analytic, Prose... | Orthodox |     | Yes |     |
-| AssessmentScoreRangeLearningStandard | AssessmentReportingMethod | The method that the administrator of the assessment uses to report the performance and achievement of all students. It may be a qualitative method such as performance level descriptors or a quantitative method such as a numerical grade or cut score. More than one type of reporting method may be used. | Local |     |     |     |
-| LearningStandard | AcademicSubject | Subject area for the LearningStandard. | Local | Yes | Yes |     |
-| GradeLevel | The grade levels for the specific learning standard. | Orthodox | Yes | Yes |     |
-| LearningStandardCategory | An additional classification of the type of a specific learning standard. | Orthodox |     |     |     |
-| LearningStandardScope | Signals the scope of usage the standard. Does not necessarily relate the standard to the governing body. | Orthodox |     |     |     |
-| PublicationStatus | The publication status of the document (i.e., Adopted, Draft, Published, Deprecated, Unknown). | Orthodox |     |     |     |
-| LearningStandardEquivalenceAssociation | LearningStandardEquivalenceStrength | A measure that indicates the strength or quality of the equivalence relationship. | Orthodox |     |     |     |
-| ObjectiveAssessment | AcademicSubject | The subject area of the objective assessment. | Local | Yes | Yes |     |
-| AssessmentReportingMethod | The method that the instructor of the class uses to report the performance and achievement of all students. It may be a qualitative method such as individualized teacher comments or a quantitative method such as a letter or numerical grade. In some cases, more than one type of reporting method may be used. | Local |     | Yes | Yes |
-| PerformanceLevel | The performance level(s) defined for the assessment. | Local | Yes | Yes |     |
-| ResultDatatypeType | The datatype of the result. The results can be expressed as a number, percentile, range, level, etc. | Orthodox |     |     | Yes |
-| StudentAssessment | Accommodation | The specific type of special variation used in how an examination is presented, how it is administered, or how the test taker is allowed to respond. This generally refers to changes that do not substantially alter what the examination measures. The proper use of accommodations does not substantially change academic level or performance criteria. For example: Braille, Enlarged monitor view, Extra time ,Large Print, Setting, Oral Administration... | Local |     | Yes |     |
-| AdministrationEnvironment | The environment in which the test was administered. | Orthodox |     |     |     |
-| AdministrationLanguage | The language in which an assessment is written and/or administered. | Orthodox |     |     |     |
-| AssessmentReportingMethod | The method that the administrator of the assessment uses to report the performance and achievement of all students. It may be a qualitative method such as performance level descriptors or a quantitative method such as a numerical grade or cut score. More than one type of reporting method may be used. | Local |     | Yes | Yes |
-| EventCircumstance | An unusual event occurred during the administration of the assessment. This could include fire alarm, student became ill, etc. | Flexible |     |     |     |
-| PerformanceLevel | A specification of which performance level value describes the student proficiency. | Local | Yes | Yes |     |
-| PlatformType | The platform with which the assessment was delivered to the student during the assessment session. | Orthodox |     |     |     |
-| ReasonNotTested | The primary reason student is not tested. For example: Absent, Refusal by parent, Refusal by student, Medical waiver, Illness, Disruptive behavior, LEP Exempt... | Flexible | Yes |     |     |
-| ResultDatatypeType | The datatype of the result. The results can be expressed as a number, percentile, range, level, etc. | Orthodox |     |     | Yes |
-| RetestIndicator | Indicator if the test was retaken. For example: Primary administration, First retest, Second retest... | Flexible |     |     |     |
-| WhenAssessedGradeLevel | The grade level of a student when assessed. | Orthodox |     | Yes |     |
+| Assessment | AcademicSubject | The description of the content or subject area (e.g., arts, mathematics, reading, stenography, or a foreign language) of an assessment. | Local | Yes | Yes |  |
+| Assessment | AssessedGradeLevel | The grade level(s) for which an assessment is designed. The semantics of null is assumed to mean that the assessment is not associated with any grade level. | Orthodox | Yes | Yes |  |
+| Assessment | AssessmentCategory | The category of an assessment based on format and content. For example: Achievement test, Advanced placement test, Alternate assessment/grade-level standards, Attitudinal test, Cognitive and perceptual skills test... | Orthodox | Yes | Yes |  |
+| Assessment | AssessmentIdentificationSystem | A coding scheme that is used for identification and record-keeping purposes by schools, social services, or other agencies to refer to an assessment. | Orthodox |  |  |  |
+| Assessment | AssessmentPeriod | The period of time in which an assessment is supposed to be administered (e.g., Beginning of Year, Middle of Year, End of Year). | Local |  | Yes |  |
+| Assessment | AssessmentReportingMethod | The method that the administrator of the assessment uses to report the performance and achievement of all students. It may be a qualitative method such as performance level descriptors or a quantitative method such as a numerical grade or cut score. More than one type of reporting method may be used. | Local |  | Yes | Yes |
+| Assessment | Language | An indication of the languages in which the assessment is designed. | Orthodox | Yes | Yes | Yes |
+| Assessment | PerformanceLevel | The performance level(s) defined for the assessment. | Local | Yes | Yes |  |
+| Assessment | PlatformType | The platforms with which the assessment may be delivered. | Orthodox |  |  |  |
+| Assessment | PublicationStatus | The publication status of the document (i.e., Adopted, Draft, Published, Deprecated, Unknown). | Orthodox |  |  |  |
+| Assessment | ResultDatatypeType | The datatype of the result. The results can be expressed as a number, percentile, range, level, etc. | Orthodox |  |  | Yes |
+| AssessmentItem | AssessmentItemCategory | Category or type of the AssessmentItem. For example: Multiple choice, Analytic, Prose... | Orthodox |  | Yes |  |
+| AssessmentScoreRangeLearningStandard | AssessmentReportingMethod | The method that the administrator of the assessment uses to report the performance and achievement of all students. It may be a qualitative method such as performance level descriptors or a quantitative method such as a numerical grade or cut score. More than one type of reporting method may be used. | Local |  |  |  |
+| LearningStandard | AcademicSubject | Subject area for the LearningStandard. | Local | Yes | Yes |  |
+| LearningStandard | GradeLevel | The grade levels for the specific learning standard. | Orthodox | Yes | Yes |  |
+| LearningStandard | LearningStandardCategory | An additional classification of the type of a specific learning standard. | Orthodox |  |  |  |
+| LearningStandard | LearningStandardScope | Signals the scope of usage the standard. Does not necessarily relate the standard to the governing body. | Orthodox |  |  |  |
+| LearningStandard | PublicationStatus | The publication status of the document (i.e., Adopted, Draft, Published, Deprecated, Unknown). | Orthodox |  |  |  |
+| LearningStandardEquivalenceAssociation | LearningStandardEquivalenceStrength | A measure that indicates the strength or quality of the equivalence relationship. | Orthodox |  |  |  |
+| ObjectiveAssessment | AcademicSubject | The subject area of the objective assessment. | Local | Yes | Yes |  |
+| ObjectiveAssessment | AssessmentReportingMethod | The method that the instructor of the class uses to report the performance and achievement of all students. It may be a qualitative method such as individualized teacher comments or a quantitative method such as a letter or numerical grade. In some cases, more than one type of reporting method may be used. | Local |  | Yes | Yes |
+| ObjectiveAssessment | PerformanceLevel | The performance level(s) defined for the assessment. | Local | Yes | Yes |  |
+| ObjectiveAssessment | ResultDatatypeType | The datatype of the result. The results can be expressed as a number, percentile, range, level, etc. | Orthodox |  |  | Yes |
+| StudentAssessment | Accommodation | The specific type of special variation used in how an examination is presented, how it is administered, or how the test taker is allowed to respond. This generally refers to changes that do not substantially alter what the examination measures. The proper use of accommodations does not substantially change academic level or performance criteria. For example: Braille, Enlarged monitor view, Extra time ,Large Print, Setting, Oral Administration... | Local |  | Yes |  |
+| StudentAssessment | AdministrationEnvironment | The environment in which the test was administered. | Orthodox |  |  |  |
+| StudentAssessment | AdministrationLanguage | The language in which an assessment is written and/or administered. | Orthodox |  |  |  |
+| StudentAssessment | AssessmentReportingMethod | The method that the administrator of the assessment uses to report the performance and achievement of all students. It may be a qualitative method such as performance level descriptors or a quantitative method such as a numerical grade or cut score. More than one type of reporting method may be used. | Local |  | Yes | Yes |
+| StudentAssessment | EventCircumstance | An unusual event occurred during the administration of the assessment. This could include fire alarm, student became ill, etc. | Flexible |  |  |  |
+| StudentAssessment | PerformanceLevel | A specification of which performance level value describes the student proficiency. | Local | Yes | Yes |  |
+| StudentAssessment | PlatformType | The platform with which the assessment was delivered to the student during the assessment session. | Orthodox |  |  |  |
+| StudentAssessment | ReasonNotTested | The primary reason student is not tested. For example: Absent, Refusal by parent, Refusal by student, Medical waiver, Illness, Disruptive behavior, LEP Exempt... | Flexible | Yes |  |  |
+| StudentAssessment | ResultDatatypeType | The datatype of the result. The results can be expressed as a number, percentile, range, level, etc. | Orthodox |  |  | Yes |
+| StudentAssessment | RetestIndicator | Indicator if the test was retaken. For example: Primary administration, First retest, Second retest... | Flexible |  |  |  |
+| StudentAssessment | WhenAssessedGradeLevel | The grade level of a student when assessed. | Orthodox |  | Yes |  |
 
 :::tip
 


### PR DESCRIPTION
- Fix the error in the Assessment Domain Descriptors table on the [Assessment domain model reference page for DS v5](https://docs.ed-fi.org/reference/data-exchange/data-standard/model-reference/assessment-domain/entities-references-and-descriptors/) that occurred during the process moving TechDoc page from Atlassian page to Docs.Ed-Fi.Org page.