### PR TITLE
Add examples of state extensions to SEA Playbook

### DIFF
--- a/docs/getting-started/sea-playbook/data-governance/developing-state-data-specifications/examples-of-state-extensions.md
+++ b/docs/getting-started/sea-playbook/data-governance/developing-state-data-specifications/examples-of-state-extensions.md
@@ -1,0 +1,13 @@
+
+# Examples of State Extensions
+
+Here are some examples of state-specific extensions to the Ed-Fi Data Standard.
+
+| State | Extension Link |
+| ----- | ------------- |
+| AZ | [www.azed.gov](https://www.azed.gov/information-technology/azeds/developers) |
+| IN | [www.in.gov/doe](https://www.in.gov/doe/it/link-initiative/data-exchange/#Data_Exchange_Ed_Fi_API_Suite_3_v6_0_for_Developers) |
+| NE | [education.ne.gov](https://www.education.ne.gov/dataservices/adviser-resources/#1533221816265-b51e789f-abfc) |
+| SC | [ed.sc.gov](https://ed.sc.gov/data/information-systems/interoperability-resources/ed-fi-in-south-carolina/) |
+| TX | [TX Student Data System](https://www.texasstudentdatasystem.org/tsds/teds/ods-upgrade-data-standards) |
+| WI | [Wisconsin DPI](https://wisconsindpi.atlassian.net/wiki/spaces/widpiedfi/pages/2294032/Data+Domains+Endpoints+Integrations) |


### PR DESCRIPTION
Adds example of State Extensions to the SEA playbook.

This willbe found at docs.ed-fi.org -> Getting Started -> SEA Playbook -> Data Governance -> Developing State Data Specifications