### PR TITLE
Clean up TD and TH styling

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -183,11 +183,6 @@ table, .table {
   background-color: var(--ifm-table-stripe-background);
 }
 
-.col--th {
-  background-color: var(--ifm-color-secondary);
-  font-weight: var(--ifm-font-weight-bold);
-}
-
 .col--tr {
   background-color: var(--ifm-table-background);
 }
@@ -776,12 +771,6 @@ nav.navbar .navbar__items--right {
 .edfi-doc-item table {
   margin-bottom: 2rem;
   text-align: left;
-}
-
-.edfi-doc-item table th,
-.edfi-doc-item table td {
-  color: var(--ifm-font-color-base);
-  font-weight: 400;
 }
 
 .edfi-doc-item table thead tr {


### PR DESCRIPTION
- Removed unused styles for table headers and document items.
- `<td>` should be in bold, not regular font. I don't like how the header row is indistinguishable from other rows.
 
<img width="1790" height="593" alt="image" src="https://github.com/user-attachments/assets/fa24ebd4-c991-40c6-91d3-e8352ec4e626" />
