### PR TITLE
[DOC-272] Add brand guidelines to partner program

### DIFF
--- a/docs/partners/1-badging/readme.md
+++ b/docs/partners/1-badging/readme.md
@@ -18,3 +18,13 @@ support. Over time, some badges may act as precursors to new certifications.
 Unlike certification, badges also focus on both Ed-Fi standards as well as Ed-Fi
 technology tools; by contrast, Ed-Fi certifications only focus on Ed-Fi
 standards.
+
+:::info
+
+When describing your product’s integration with the Ed‑Fi Data
+Standard, it’s important to communicate clearly, accurately, and
+consistently with the Ed‑Fi Alliance’s brand, trademark, and
+language guidelines. For more information, see the
+[Ed-Fi Alliance Brand Guidelines for Partners](../brand-guidelines.md).
+
+:::

--- a/docs/partners/2-certification/readme.mdx
+++ b/docs/partners/2-certification/readme.mdx
@@ -2,11 +2,11 @@ import ThemedImage from '@theme/ThemedImage';
 
 # Ed-Fi Certification
 
-Ed-Fi certifications allow product developers to demonstrate a product's
+Ed-Fi Certifications allow product developers to demonstrate a product's
 fidelity to Ed-Fi standards and guidelines, and for purchasers or users to be
 confident that a product conforms to those same Ed-Fi standards and guidelines.
 
-The Ed-Fi certification program was developed from the experience of many
+The Ed-Fi Certification program was developed from the experience of many
 education agencies in certifying Ed-Fi-compliant data exchanges for their
 enterprise systems. The Ed-Fi Alliance has built on that foundation to provide a
 certification that can be used across different agencies and organizations,
@@ -22,6 +22,12 @@ certifications.
   style={{ maxWidth: '360px', display: 'block', margin: '1rem auto 1.25rem' }}
 />
 
-## Program Information
+:::info
 
-This site contains resources and detailed information about Ed-Fi certification.
+When describing your product’s integration with the Ed‑Fi Data
+Standard, it’s important to communicate clearly, accurately, and
+consistently with the Ed‑Fi Alliance’s brand, trademark, and
+language guidelines. For more information, see the
+[Ed-Fi Alliance Brand Guidelines for Partners](../brand-guidelines.md).
+
+:::

--- a/docs/partners/brand-guidelines.md
+++ b/docs/partners/brand-guidelines.md
@@ -1,0 +1,95 @@
+# Ed-Fi Alliance Brand Guidelines
+
+:::tip
+
+Below are extracts of key portions of the Ed-Fi Alliance Brand Guidelines. For the full guidelines, please refer to the [PDF document](https://edfidocs.blob.core.windows.net/$web/assets/partners/Ed-Fi_Alliance_Brand_Guidelines_March26.pdf).
+
+:::
+
+## Talking About Your Integration with the Ed‑Fi Data Standard
+
+**What Partners Need to Know** \
+When describing your product’s integration with the **Ed‑Fi Data Standard**, it’s important to communicate clearly, accurately, and consistently with the Ed‑Fi Alliance’s brand, trademark, and language guidelines. The points below highlight the most critical requirements for partners.
+
+### 1. How to Describe Ed‑Fi Correctly (Language & Terminology)
+
+When referencing Ed‑Fi in documentation, always use **specific, complete terms**—never “Ed‑Fi” by itself.
+
+#### Approved terminology
+
+- **Ed‑Fi Alliance** – the organization that develops, governs, and drives adoption
+- **Ed‑Fi Data Standard** – the common framework that ensures education data is consistent, compatible, and secure
+- **Ed‑Fi Technology Suite** – the interoperable tools used to implement the Data Standard
+- **Ed‑Fi ODS/API** – the combined platform (preferred term in most cases)
+- **Ed‑Fi API** or **Ed‑Fi ODS** – only in API‑specific or ODS‑specific documentation
+
+#### Correct usage examples
+
+- “Our platform implements the **Ed‑Fi Data Standard**.”
+- “This solution integrates with the **Ed‑Fi ODS/API** for secure data exchange.”
+
+#### Verb guidance
+
+- The Ed‑Fi Data Standard is **implemented**
+- The Ed‑Fi Technology Suite is **deployed**
+- The Ed‑Fi Alliance **drives adoption**
+
+This precision helps avoid confusion and ensures consistency across the Ed‑Fi Community. |
+
+### 2. Representing Your Partner Status
+
+If your organization participates in the Ed‑Fi certification or badging program:
+
+- **Ed‑Fi Certified Partner**: Products that **generate** data aligned to the Ed‑Fi Data Standard
+- **Ed‑Fi Badged Partner**: Products that **consume and use** data aligned to the Ed‑Fi Data Standard
+
+Only use **Certified Partner** or **Badged Partner** language if you are licensed to do so under the Ed‑Fi Trademark License Agreement. Partner logos may appear in:
+
+- Technical documentation
+- Product dashboards
+- Websites and marketing materials
+- Presentations and visual aids
+
+Where logos are shown alongside your own, they must be **equal in size and prominence**, with proper spacing and visual separation. _See the full guidelines for detailed logo usage rules._
+
+### 3. Trademark and Attribution Requirements
+
+When referencing Ed‑Fi trademarks in documentation:
+
+- Use the ® symbol on first and prominent uses (e.g., **Ed‑Fi® Data Standard**)
+- Include the required attribution statement, typically in the footer or legal section:
+
+> **“The Ed‑Fi® marks are trademarks of the Ed‑Fi Alliance and are used under license.”**
+
+You may not:
+
+- Incorporate “Ed‑Fi” into your product name, company name, or domain
+- Imply endorsement by the Ed‑Fi Alliance
+- Register domains containing Ed‑Fi marks without written permission
+
+These rules protect both your organization and the integrity of the Ed‑Fi ecosystem |
+
+### 4. Brand Voice When Describing Integrations
+
+When explaining how your product works with the Ed‑Fi Data Standard, the Ed‑Fi Alliance encourages a tone that is:
+
+- **Clear and simple** – minimize jargon and explain value plainly
+- **Approachable and collaborative** – emphasize partnership and community
+- **Inspiring and outcomes‑focused** – connect data interoperability to real benefits for educators and students
+
+Avoid language that is condescending, overly technical for the audience, or implies exclusivity or control over the standard. |
+
+### 5. Visual and Design Considerations (High‑Level)
+
+If your documentation includes Ed‑Fi logos or visual references:
+
+- Use approved logo versions and maintain required clear space
+- Do not modify, recolor, or distort logos
+- Ensure your branding remains primary; Ed‑Fi branding should be present but not dominant
+- Follow accessibility‑friendly design practices for clarity and readability
+
+Detailed specifications (sizes, colors, placement) are provided in the full guidelines. |
+
+## Learn More
+
+This summary highlights the most important considerations for partners describing their Ed‑Fi integrations. For full details—including logo usage, color palettes, typography, certification logo placement, and extended language guidance—please review the complete [Ed‑Fi Alliance Brand Guidelines (March 2026)](https://edfidocs.blob.core.windows.net/$web/assets/partners/Ed-Fi_Alliance_Brand_Guidelines_March26.pdf).

--- a/src/pages/partners.jsx
+++ b/src/pages/partners.jsx
@@ -35,18 +35,28 @@ function Main() {
       <div className="container">
         <div className="row margin-bottom--lg">
           <div className="col">
-            For general information on the Ed-Fi Alliance Partner Program, see{' '}
-            <Link to="https://www.ed-fi.org/partner-program/">
-              Become an Ed-Fi Alliance Partner
-            </Link>{' '}
-            on the main website.
+            <p>
+              For general information on the Ed-Fi Alliance Partner Program, see{' '}
+              <Link to="https://www.ed-fi.org/partner-program/">
+                Become an Ed-Fi Alliance Partner
+              </Link>{' '}
+              on the main website.
+            </p>
+            <p>
+              When describing your product’s integration with the Ed‑Fi Data
+              Standard, it’s important to communicate clearly, accurately, and
+              consistently with the Ed‑Fi Alliance’s brand, trademark, and
+              language guidelines. For more information, see the{' '}
+              <Link to="/partners/brand-guidelines">
+                Ed-Fi Alliance Brand Guidelines for Partners
+              </Link>
+              .
+            </p>
           </div>
         </div>
         <div className="row margin-bottom--lg">
           <div className="col">
-            <Heading as="h2">
-              Certification
-            </Heading>
+            <Heading as="h2">Certification</Heading>
             <p>
               Ed-Fi certifications allow product developers to demonstrate a
               product's fidelity to Ed-Fi standards and guidelines, and for
@@ -70,9 +80,7 @@ function Main() {
             </Link>
           </div>
           <div className="col">
-            <Heading as="h2">
-              Badging
-            </Heading>
+            <Heading as="h2">Badging</Heading>
             <p>
               Ed-Fi Badges allow product developers to demonstrate support for
               Ed-Fi standards and technology, particularly in areas that are not


### PR DESCRIPTION
## Summary

- Adds a new Brand Guidelines page to the partner program documentation
- Updates the Badging and Certification pages to reference the new brand guidelines
- Updates `partners.jsx` to include brand guidelines in the nav/layout

## Test plan

- [ ] Verify brand guidelines page renders correctly
- [ ] Verify links to brand guidelines from Badging and Certification pages work
- [ ] Run `npm run lint` to confirm no linting errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)