### PR TITLE
[DOC-273] Support Notifications: DocCardList and Enrollment API deprecation

### DIFF
--- a/docs/getting-started/provider-playbook/common-use-cases/readme.md
+++ b/docs/getting-started/provider-playbook/common-use-cases/readme.md
@@ -1,17 +1,5 @@
 # Common Use Cases
 
-## Rostering
-
-**This guide is for vendors who want to assist their clients in setting up an
-Ed-Fi Rostering solution.** An Ed-Fi rostering solution helps organizations of
-all kinds eliminate data gaps and human error by provisioning roster information
-directly from source systems.
-
-* [Rostering Solution Guide Home](./rostering-solution-guide/readme.md)
-
-![Image depicting people working by a big
-phone](https://edfidocs.blob.core.windows.net/$web/img/getting-started/solution-guides/Aaah-Big-Phone@0.33x.png)
-
 ## Assessment Solution Guide
 
 **This guide is for vendors who want to assist their clients in setting up an

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/readme.md
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/readme.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # Rostering Solution Guide
 
 :::note

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/rostering-development-guide.md
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/rostering-development-guide.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # Rostering Development Guide
 
 The Rostering Development Guide provides a step-by-step process that can be used

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/sample-application/change-queries.md
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/sample-application/change-queries.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # Change Queries
 
 Use this guide to download and run the Ed-Fi Roster Application using test data

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/sample-application/enrollment-api.md
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/sample-application/enrollment-api.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # Enrollment API
 
 Use this guide to download and run the Ed-Fi Roster Application using test data

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/sample-application/readme.md
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/sample-application/readme.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # Ed-Fi Roster Sample Application
 
 The Rostering Solution Guide Sample application shows how to access roster

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/sample-application/setup-guide.md
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/sample-application/setup-guide.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # Setup Guide
 
 Full source code for the Roster Starter Kit is available on GitHub as denoted on

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/workflow-in-postman/change-queries-via-postman.md
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/workflow-in-postman/change-queries-via-postman.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # Change Queries via Postman
 
 ## Prerequisites

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/workflow-in-postman/enrollment-api-via-postman.mdx
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/workflow-in-postman/enrollment-api-via-postman.mdx
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/workflow-in-postman/readme.md
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/workflow-in-postman/readme.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # Ed-Fi Roster Workflow in Postman
 
 Postman is a popular application in use by developers to interact with REST API

--- a/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/workflow-in-postman/setting-up-postman.mdx
+++ b/docs/getting-started/provider-playbook/common-use-cases/rostering-solution-guide/workflow-in-postman/setting-up-postman.mdx
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/docs/getting-started/provider-playbook/readme.md
+++ b/docs/getting-started/provider-playbook/readme.md
@@ -62,13 +62,12 @@ Section 5: [Specifics by Provider Type](./specifics-by-provider-type/readme.md)
 
 ## Common Use Case Solution Guides
 
-* [Rostering](./common-use-cases/rostering-solution-guide/readme.md)
 * [Chronic Absenteeism](./common-use-cases/chronic-absenteeism-solution-guide/readme.md)
+* [Assessment Solution Guide](./common-use-cases/assessment-solution-guide/readme.md)
+* [Student Equity Solution Guide](./common-use-cases/student-equity-solution-guide/readme.md)
 
 ## Useful Links
 
 * [Ed-Fi Certification](/partners/certification)
-* [Rostering Solution Guide](https://edfi.atlassian.net/wiki/spaces/SG/pages/20611776/Rostering+Solution+Guide)
-* [Assessment Solution Guide](https://edfi.atlassian.net/wiki/spaces/SG/pages/20611639/Assessment+Solution+Guide)
 * [Ed-Fi ODS / API Sandbox](https://api.ed-fi.org/)
 * [Ed-Fi ODS / API Platform (Latest)](/reference/ods-api)

--- a/docs/reference/0-roadmap/notifications/admin-app-v2.md
+++ b/docs/reference/0-roadmap/notifications/admin-app-v2.md
@@ -5,7 +5,7 @@ June 19, 2023
 ## What Is Happening
 
 As of June 30, 2023, the Ed-Fi Admin App 2.x will have reached the [end of
-support](./readme.md).
+support](./readme.mdx).
 
 ## What Should I Do Now?
 

--- a/docs/reference/0-roadmap/notifications/amt.md
+++ b/docs/reference/0-roadmap/notifications/amt.md
@@ -6,9 +6,9 @@ Oct 11, 2023
 
 The next planned release of Analytics Middle Tier (AMT), version 4.1, will be
 the last fully supported release. From that point, it will be in [maintenance
-mode](./readme.md) until June, 2025. While in maintenance mode, new patch
+mode](./readme.mdx) until June, 2025. While in maintenance mode, new patch
 releases will occur for critical bugs and security updates. In 2025, AMT will
-move to the [Ed-Fi Exchange](https://exchange.ed-fi.org) and the source
+move to the [Ed-Fi Exchange](/getting-started/edfi-exchange) and the source
 repository will be set into archive, signaling that the application support has
 formally ended.
 

--- a/docs/reference/0-roadmap/notifications/data-import.md
+++ b/docs/reference/0-roadmap/notifications/data-import.md
@@ -9,10 +9,10 @@ Updated: Jul 24, 2024 extended the maintenance window from summer 2025 to summer
 
 Data Import version 2.3 will be the last supported release of the application,
 arriving in the second or third quarter of 2024. From that point, it will be
-in [maintenance mode](./readme.md) until June 30, 2026. While in maintenance
+in [maintenance mode](./readme.mdx) until June 30, 2026. While in maintenance
 mode, a new patch release will only occur for critical bugs and security
 updates. In 2026, Data Import will move to the [Ed-Fi
-Exchange](https://exchange.ed-fi.org) and the source repository will be set into
+Exchange](/getting-started/edfi-exchange) and the source repository will be set into
 archive, signaling that the application support has formally ended.
 
 ## Why?

--- a/docs/reference/0-roadmap/notifications/enrollment-api-deprecation.md
+++ b/docs/reference/0-roadmap/notifications/enrollment-api-deprecation.md
@@ -29,4 +29,4 @@ The Enrollment API was designed to support compositing patterns for rostering da
 - **If you're using Enrollment API today**: Begin evaluating a migration to the Ed-Fi OneRoster API. The Enrollment API composite remains functional in ODS/API 7.3.x, giving you time to plan the transition. Contact the Ed-Fi Alliance help desk if you need guidance on migration timelines or technical planning.
 - **Questions or concerns?**: Reach out to the Ed-Fi Alliance via the support contact form or your regional support channel.
 
-See the blog post [Upcoming Ed-Fi OneRoster® Support in ODS/API 7.3.2](../../blog/2026-01-30.md) for more context on the OneRoster release and its integration with the ODS/API.
+See the blog post [Upcoming Ed-Fi OneRoster® Support in ODS/API 7.3.2](/reference/blog/2026-01-30.md) for more context on the OneRoster release and its integration with the ODS/API.

--- a/docs/reference/0-roadmap/notifications/enrollment-api-deprecation.md
+++ b/docs/reference/0-roadmap/notifications/enrollment-api-deprecation.md
@@ -19,13 +19,13 @@ The Enrollment API composite remains functional in ODS/API 7.3.x releases, but w
 The Enrollment API was designed to support compositing patterns for rostering data. The OneRoster 1.2 standard—now integrated directly into the Ed-Fi ODS/API—addresses the same use cases more effectively:
 
 - **Community alignment**: OneRoster is maintained by 1EdTech and used across the K–12 EdTech ecosystem, reducing the need for custom integrations.
-- **Simplified operations**: Agencies can now serve a standards-compliant OneRoster endpoint directly from their Ed-Fi ODS, without maintaining separate rostering infrastructure.
-- **Unified security**: OneRoster and standard Ed-Fi APIs share authentication and authorization, reducing operational complexity.
+- **Simplified operations**: Agencies can now serve a standards-compliant OneRoster endpoint directly from their Ed-Fi ODS database, using the new Ed-Fi OneRoster API application (coming May 2026).
+- **Unified security**: Ed-Fi OneRoster API and the Ed-Fi ODS/API share authentication and authorization, reducing operational complexity.
 - **Broader support**: OneRoster is backed by 1EdTech and a cross-industry Rostering Steering Committee, whereas the Enrollment API composite had limited adoption.
 
 ## Next Steps for Users
 
-- **If you're building new integrations**: Use the Ed-Fi OneRoster API instead of the Enrollment API composite. Documentation and getting started guidance are available in the [Ed-Fi documentation](https://docs.ed-fi.org).
+- **If you're building new integrations**: Use the Ed-Fi OneRoster API instead of the Enrollment API composite. Documentation and getting started guidance are forthcoming.
 - **If you're using Enrollment API today**: Begin evaluating a migration to the Ed-Fi OneRoster API. The Enrollment API composite remains functional in ODS/API 7.3.x, giving you time to plan the transition. Contact the Ed-Fi Alliance help desk if you need guidance on migration timelines or technical planning.
 - **Questions or concerns?**: Reach out to the Ed-Fi Alliance via the support contact form or your regional support channel.
 

--- a/docs/reference/0-roadmap/notifications/enrollment-api-deprecation.md
+++ b/docs/reference/0-roadmap/notifications/enrollment-api-deprecation.md
@@ -29,4 +29,4 @@ The Enrollment API was designed to support compositing patterns for rostering da
 - **If you're using Enrollment API today**: Begin evaluating a migration to the Ed-Fi OneRoster API. The Enrollment API composite remains functional in ODS/API 7.3.x, giving you time to plan the transition. Contact the Ed-Fi Alliance help desk if you need guidance on migration timelines or technical planning.
 - **Questions or concerns?**: Reach out to the Ed-Fi Alliance via the support contact form or your regional support channel.
 
-See the blog post [Upcoming Ed-Fi OneRoster® Support in ODS/API 7.3.2](/reference/blog/2026-01-30.md) for more context on the OneRoster release and its integration with the ODS/API.
+See the blog post [Upcoming Ed-Fi OneRoster® Support in ODS/API 7.3.2](/blog/2026/01/30/) for more context on the OneRoster release and its integration with the ODS/API.

--- a/docs/reference/0-roadmap/notifications/enrollment-api-deprecation.md
+++ b/docs/reference/0-roadmap/notifications/enrollment-api-deprecation.md
@@ -1,0 +1,32 @@
+# Enrollment API Composite Deprecation in Favor of OneRoster Standard
+
+First published: 6 April 2026
+
+## What is Happening
+
+The Ed-Fi Alliance is deprecating the Enrollment API composite component in the ODS/API, effective immediately with the release of ODS/API 7.3.2. The Alliance is adopting the OneRoster 1.2 standard as the canonical API for student rostering use cases.
+
+With ODS/API 7.3.2 and the new Ed-Fi OneRoster API, education agencies and vendors now have a standards-based alternative that integrates seamlessly with the ODS/API and simplifies rostering integrations. The Enrollment API composite will be removed in a future ODS/API release; this provides a transition period for existing implementations to migrate.
+
+:::note
+
+The Enrollment API composite remains functional in ODS/API 7.3.x releases, but will not receive new features or enhancements. Plan your migration accordingly.
+
+:::
+
+## Why?
+
+The Enrollment API was designed to support compositing patterns for rostering data. The OneRoster 1.2 standard—now integrated directly into the Ed-Fi ODS/API—addresses the same use cases more effectively:
+
+- **Community alignment**: OneRoster is maintained by 1EdTech and used across the K–12 EdTech ecosystem, reducing the need for custom integrations.
+- **Simplified operations**: Agencies can now serve a standards-compliant OneRoster endpoint directly from their Ed-Fi ODS, without maintaining separate rostering infrastructure.
+- **Unified security**: OneRoster and standard Ed-Fi APIs share authentication and authorization, reducing operational complexity.
+- **Broader support**: OneRoster is backed by 1EdTech and a cross-industry Rostering Steering Committee, whereas the Enrollment API composite had limited adoption.
+
+## Next Steps for Users
+
+- **If you're building new integrations**: Use the Ed-Fi OneRoster API instead of the Enrollment API composite. Documentation and getting started guidance are available in the [Ed-Fi documentation](https://docs.ed-fi.org).
+- **If you're using Enrollment API today**: Begin evaluating a migration to the Ed-Fi OneRoster API. The Enrollment API composite remains functional in ODS/API 7.3.x, giving you time to plan the transition. Contact the Ed-Fi Alliance help desk if you need guidance on migration timelines or technical planning.
+- **Questions or concerns?**: Reach out to the Ed-Fi Alliance via the support contact form or your regional support channel.
+
+See the blog post [Upcoming Ed-Fi OneRoster® Support in ODS/API 7.3.2](../../blog/2026-01-30.md) for more context on the OneRoster release and its integration with the ODS/API.

--- a/docs/reference/0-roadmap/notifications/readme.mdx
+++ b/docs/reference/0-roadmap/notifications/readme.mdx
@@ -1,3 +1,5 @@
+import DocCardList from '@theme/DocCardList';
+
 # Support Notifications
 
 ## Overview
@@ -85,3 +87,7 @@ support.
   out-of-support products. This is not recommended.
 * Any existing badges/certifications impacted by an out-of-support product will
   remain in place until the credential expires.
+
+## Specific Notices
+
+<DocCardList />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,9 +21,6 @@ const config = {
   organizationName: 'ed-fi-alliance-oss', // Usually your GitHub org/user name.
   projectName: 'ed-fi-alliance-oss.github.io', // Usually your repo name.
 
-  onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
-
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".
@@ -330,6 +327,9 @@ const config = {
   ],
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    }
   },
   themes: ['@docusaurus/theme-mermaid'],
 };

--- a/odsApi_versioned_docs/version-5.4/how-to-guides/how-to-add-api-composites-to-the-ed-fi-ods-api-solution.md
+++ b/odsApi_versioned_docs/version-5.4/how-to-guides/how-to-add-api-composites-to-the-ed-fi-ods-api-solution.md
@@ -1,5 +1,11 @@
 # How To: Add API Composites to the Ed-Fi ODS / API Solution
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 This section outlines the steps necessary to integrate and activate the Ed-Fi
 Composite definitions for use in an Ed-Fi ODS / API. It is assumed that the Ed-Fi
 ODS / API has been successfully downloaded and is running in a local environment
@@ -15,7 +21,7 @@ Each step is outlined in detail, below.
 
 ## Step 1. Create the Composites Project
 
-### Step 1.1. Add a Composite Project Using the Visual Studio Project Template.
+### Step 1.1. Add a Composite Project Using the Visual Studio Project Template
 
 Visual Studio Project Template can be installed by following the steps in the [Project Templates Installation](../getting-started/source-code-installation/project-templates-installation.md) section of this documentation.
 
@@ -28,7 +34,7 @@ Visual Studio Project Template can be installed by following the steps in the [P
 
 ![Image](https://edfi.atlassian.net/wiki/download/thumbnails/22774820/composite-project-template2.png?version=1&modificationDate=1641861363023&cacheVersion=1&api=v2&width=1024&height=680)
 
-### Step 1.2. Update the Marker Interface file.
+### Step 1.2. Update the Marker Interface file
 
 To integrate the Composite with the API, start by ensuring you have a marker
 interface in the root of your Composites project.
@@ -46,7 +52,7 @@ namespace EdFi.Ods.Composites.MyComposites
 }
 ```
 
-### Step 1.3. Update the Composites.xml file to add the appropriate composite definition.
+### Step 1.3. Update the Composites.xml file to add the appropriate composite definition
 
 The Visual Studio Project Template creates an empty sample Composites.xml file, replace its contents with the following:
 
@@ -97,14 +103,14 @@ The `CompositeMetadata` attribute organizationCode is a required attribute and i
 Organization to which the composite belongs. This value is carried from the XML definition
 all the way into the API route definitions. The `organizationCode` in combination with the `Category` name are used to identify the composite being requested from the API.
 
-### Step 1.4. Save the Project.
+### Step 1.4. Save the Project
 
 ## Step 2. Integrate Composites into the Solution
 
 To integrate the Composite Resources into the solution, add a reference to new
 Composites project you constructed in the previous step in the EdFi.Ods.WebApi project (located in the "Entry Points" folder).
 
-## Step 3. Verify Changes 
+## Step 3. Verify Changes
 
 Save all modified files, then run the application and view the Ed-Fi ODS / API
 using Swagger. The following new API Composite resource should be available:
@@ -121,6 +127,7 @@ URLs above (e.g., `/ed-fi/composites/MyComposite/Students`). To successfully ret
 definition) must be present as the first segment of a composite URL.
 
 ## Downloads
+
 The following GitHub link contains source files for the Composite described in
 this article:
 

--- a/odsApi_versioned_docs/version-5.4/platform-dev-guide/extensibility-customization/api-composite-resources.md
+++ b/odsApi_versioned_docs/version-5.4/platform-dev-guide/extensibility-customization/api-composite-resources.md
@@ -1,5 +1,9 @@
 # API Composite Resources
 
+:::warning
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+:::
+
 ## Overview
 
 An Ed-Fi API Composite resource definition enables the Ed-Fi ODS / API to provide subject-oriented
@@ -73,7 +77,7 @@ The basic structure of a Composite Definition is as follows:
       </Composite>
     </Composites>
   </Category>
-  
+
   <Category...
 ```
 
@@ -107,7 +111,7 @@ the Ed-Fi ODS / API. For example, a Composite resource of "Section" defined by
 Ed-Fi with a category `name` of "Enrollment" would be exposed on the following URL:
 
 `http://{host}/api/composites/v1/ed-fi/enrollment/Sections`
-  
+
 Note: The composites feature is now versioned independently of the primary API.
 
 The `name` attribute is used in the routes, and is also normalized (introducing spaces, if

--- a/odsApi_versioned_docs/version-5.4/technical-articles/ods-api-composite-resources-technical-approach.md
+++ b/odsApi_versioned_docs/version-5.4/technical-articles/ods-api-composite-resources-technical-approach.md
@@ -4,6 +4,12 @@ sidebar_position: 5
 
 # ODS / API Composite Resources Technical Approach
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 As part of the evolution of the Ed-Fi ODS / API from primarily supporting data collection use cases to a widening set of data integration use cases, a mechanism is needed for exposing Composite Resources. A Composite
 Resource is a read-only resource which combines data from multiple standard API
 resources in a single call, effectively reducing the "chattiness" of the API

--- a/odsApi_versioned_docs/version-7.1/how-to-guides/how-to-add-api-composites-to-the-ed-fi-ods-api-solution.md
+++ b/odsApi_versioned_docs/version-7.1/how-to-guides/how-to-add-api-composites-to-the-ed-fi-ods-api-solution.md
@@ -1,5 +1,11 @@
 # How To: Add API Composites to the Ed-Fi ODS / API Solution
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 This section outlines the steps necessary to integrate and activate the Ed-Fi Composite definitions for use in an Ed-Fi ODS / API. It is assumed that the Ed-Fi ODS / API has been successfully downloaded and is running in a local environment per the instructions in the [Getting Started](../getting-started/readme.md) documentation.
 
 ## Step 1. Create the Composites Project

--- a/odsApi_versioned_docs/version-7.1/platform-dev-guide/extensibility-customization/api-composite-resources.md
+++ b/odsApi_versioned_docs/version-7.1/platform-dev-guide/extensibility-customization/api-composite-resources.md
@@ -1,5 +1,11 @@
 # API Composite Resources
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 ## Overview
 
 An Ed-Fi API Composite resource definition enables the Ed-Fi ODS / API to

--- a/odsApi_versioned_docs/version-7.1/technical-articles/ods-api-composite-resources-technical-approach.md
+++ b/odsApi_versioned_docs/version-7.1/technical-articles/ods-api-composite-resources-technical-approach.md
@@ -1,5 +1,11 @@
 # ODS / API Composite Resources Technical Approach
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 As part of the evolution of the Ed-Fi ODS / API from primarily supporting _data
 collection_ use cases to a widening set of _data integration_ use cases, a
 mechanism is needed for exposing Composite Resources. A Composite Resource is a

--- a/odsApi_versioned_docs/version-7.2/how-to-guides/how-to-add-api-composites-to-the-ed-fi-ods-api-solution.md
+++ b/odsApi_versioned_docs/version-7.2/how-to-guides/how-to-add-api-composites-to-the-ed-fi-ods-api-solution.md
@@ -1,5 +1,11 @@
 # How To: Add API Composites to the Ed-Fi ODS / API Solution
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 This section outlines the steps necessary to integrate and activate the Ed-Fi
 Composite definitions for use in an Ed-Fi ODS / API. It is assumed that the
 Ed-Fi ODS / API has been successfully downloaded and is running in a local

--- a/odsApi_versioned_docs/version-7.2/platform-dev-guide/extensibility-customization/api-composite-resources.md
+++ b/odsApi_versioned_docs/version-7.2/platform-dev-guide/extensibility-customization/api-composite-resources.md
@@ -1,5 +1,11 @@
 # API Composite Resources
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 ## Overview
 
 An Ed-Fi API Composite resource definition enables the Ed-Fi ODS / API to

--- a/odsApi_versioned_docs/version-7.2/technical-articles/ods-api-composite-resources-technical-approach.md
+++ b/odsApi_versioned_docs/version-7.2/technical-articles/ods-api-composite-resources-technical-approach.md
@@ -1,5 +1,11 @@
 # ODS / API Composite Resources Technical Approach
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 As part of the evolution of the Ed-Fi ODS / API from primarily supporting _data
 collection_ use cases to a widening set of _data integration_ use cases, a
 mechanism is needed for exposing Composite Resources. A Composite Resource is a

--- a/odsApi_versioned_docs/version-7.3/how-to-guides/how-to-add-api-composites-to-the-ed-fi-ods-api-solution.md
+++ b/odsApi_versioned_docs/version-7.3/how-to-guides/how-to-add-api-composites-to-the-ed-fi-ods-api-solution.md
@@ -1,5 +1,11 @@
 # How To: Add API Composites to the Ed-Fi ODS / API Solution
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 This section outlines the steps necessary to integrate and activate the Ed-Fi
 Composite definitions for use in an Ed-Fi ODS / API. It is assumed that the
 Ed-Fi ODS / API has been successfully downloaded and is running in a local

--- a/odsApi_versioned_docs/version-7.3/platform-dev-guide/extensibility-customization/api-composite-resources.md
+++ b/odsApi_versioned_docs/version-7.3/platform-dev-guide/extensibility-customization/api-composite-resources.md
@@ -1,5 +1,11 @@
 # API Composite Resources
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 ## Overview
 
 An Ed-Fi API Composite resource definition enables the Ed-Fi ODS / API to

--- a/odsApi_versioned_docs/version-7.3/technical-articles/ods-api-composite-resources-technical-approach.md
+++ b/odsApi_versioned_docs/version-7.3/technical-articles/ods-api-composite-resources-technical-approach.md
@@ -1,5 +1,11 @@
 # ODS / API Composite Resources Technical Approach
 
+:::warning
+
+The Ed-Fi Alliance is phasing out support for Composite and recommends against implementing any new composites in 2026 or beyond.
+
+:::
+
 As part of the evolution of the Ed-Fi ODS / API from primarily supporting _data
 collection_ use cases to a widening set of _data integration_ use cases, a
 mechanism is needed for exposing Composite Resources. A Composite Resource is a


### PR DESCRIPTION
## Summary

- Add `DocCardList` component to the Support Notifications overview page to automatically render cards for all child notification pages
- Convert `readme.md` to `readme.mdx` to support React components
- Create new Support Notification for Enrollment API Composite deprecation in favor of OneRoster standard
- Unpublish the Rostering Solution Guide, which is no longer relevant
- Add a "do not use" warning on all ODS/API pages about Composites.

## Details

The changes support better discoverability of individual support notifications while introducing a new notification about the deprecation of the Enrollment API composite, which is being superseded by the integrated OneRoster 1.2 API in ODS/API 7.3.2.

## Test Plan

- [x] Run `npm run build` to verify no broken links
- [x] Run `npm run lint` to check for style issues
- [x] Verify Support Notifications page renders correctly with DocCardList
- [x] Confirm all child notification cards appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1283" height="2000" alt="image" src="https://github.com/user-attachments/assets/e5ff31ba-49fd-4da6-8ccc-7d470d74a6a0" />
