### PR TITLE
[ONEROSTER-46] OneRoster service documentation (P0 + P1)

### DIFF
--- a/docs/reference/1-data-exchange/readme.md
+++ b/docs/reference/1-data-exchange/readme.md
@@ -35,13 +35,13 @@ API Guidelines](./api-guidelines/).
 
 :::
 
-### 1EdTech OneRoster interoperability
+### 1EdTech OneRoster© interoperability
 
-The [Ed-Fi OneRoster service](../11-oneroster/readme.mdx) serves a 1EdTech
-OneRoster 1.2 rostering API from data in an Ed-Fi ODS. It is released and
+The [Ed-Fi OneRoster© service](../11-oneroster/readme.mdx) serves a 1EdTech
+OneRoster© 1.2 rostering API from data in an Ed-Fi ODS. It is released and
 deployed independently of the Ed-Fi ODS/API, supports Ed-Fi Data Standard 4.0
 and 5.0–5.2, and runs against either PostgreSQL or Microsoft SQL Server. Use
-it when a vendor application expects a OneRoster feed and the rostering
+it when a vendor application expects a OneRoster© feed and the rostering
 source of truth lives in Ed-Fi.
 
 ## Resources

--- a/docs/reference/1-data-exchange/readme.md
+++ b/docs/reference/1-data-exchange/readme.md
@@ -38,11 +38,11 @@ API Guidelines](./api-guidelines/).
 ### 1EdTech OneRoster© interoperability
 
 The [Ed-Fi OneRoster© service](../11-oneroster/readme.mdx) serves a 1EdTech
-OneRoster© 1.2 rostering API from data in an Ed-Fi ODS. It is released and
-deployed independently of the Ed-Fi ODS/API, supports Ed-Fi Data Standard 4.0
-and 5.0–5.2, and runs against either PostgreSQL or Microsoft SQL Server. Use
-it when a vendor application expects a OneRoster© feed and the rostering
-source of truth lives in Ed-Fi.
+OneRoster© v1.2 rostering API from data in an Ed-Fi ODS. It is released and
+deployed independently of the Ed-Fi ODS / API, supports Ed-Fi Data Standard
+4.0 and 5.0 through 5.2, and runs against either PostgreSQL or Microsoft
+SQL Server. Use it when a vendor application expects a OneRoster© feed and
+the rostering source of truth lives in Ed-Fi.
 
 ## Resources
 

--- a/docs/reference/1-data-exchange/readme.md
+++ b/docs/reference/1-data-exchange/readme.md
@@ -35,6 +35,15 @@ API Guidelines](./api-guidelines/).
 
 :::
 
+### 1EdTech OneRoster interoperability
+
+The [Ed-Fi OneRoster service](../11-oneroster/readme.mdx) serves a 1EdTech
+OneRoster 1.2 rostering API from data in an Ed-Fi ODS. It is released and
+deployed independently of the Ed-Fi ODS/API, supports Ed-Fi Data Standard 4.0
+and 5.0–5.2, and runs against either PostgreSQL or Microsoft SQL Server. Use
+it when a vendor application expects a OneRoster feed and the rostering
+source of truth lives in Ed-Fi.
+
 ## Resources
 
 ### Standard Information & Publications

--- a/docs/reference/1-data-exchange/readme.md
+++ b/docs/reference/1-data-exchange/readme.md
@@ -35,13 +35,13 @@ API Guidelines](./api-guidelines/).
 
 :::
 
-### 1EdTech OneRoster© interoperability
+### 1EdTech® OneRoster® interoperability
 
-The [Ed-Fi OneRoster© service](../11-oneroster/readme.mdx) serves a 1EdTech
-OneRoster© v1.2 rostering API from data in an Ed-Fi ODS. It is released and
+The [Ed-Fi OneRoster service](../11-oneroster/readme.mdx) serves a 1EdTech
+OneRoster v1.2 rostering API from data in an Ed-Fi ODS. It is released and
 deployed independently of the Ed-Fi ODS / API, supports Ed-Fi Data Standard
 4.0 and 5.0 through 5.2, and runs against either PostgreSQL or Microsoft
-SQL Server. Use it when a vendor application expects a OneRoster© feed and
+SQL Server. Use it when a vendor application expects a OneRoster feed and
 the rostering source of truth lives in Ed-Fi.
 
 ## Resources

--- a/docs/reference/11-oneroster/configuration/_category_.json
+++ b/docs/reference/11-oneroster/configuration/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Configuration",
+  "position": 5
+}

--- a/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
+++ b/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
@@ -53,7 +53,7 @@ using the IP address of the client. Other routes (`/health-check`,
 `/docs`, `/swagger.json`, `/`) are not rate-limited.
 
 | Variable | Default | Behavior |
-|---|---|---|
+| --- | --- | --- |
 | `RATE_LIMIT_WINDOW_MS` | `60000` (1 minute) | Sliding window length |
 | `RATE_LIMIT_MAX_REQUESTS` | `60` | Max requests per IP per window |
 
@@ -85,7 +85,7 @@ Swagger UI `servers` entry and the JSON returned by `GET /`). Express
 only honors these headers when the application has `trust proxy` enabled.
 
 | `TRUST_PROXY` | Behavior |
-|---|---|
+| --- | --- |
 | `false` (default) | `X-Forwarded-*` headers are ignored. Discovery URLs use the protocol and host the Node process observes directly. |
 | `true` | `X-Forwarded-*` headers are trusted. Discovery URLs reflect the public-facing protocol and host from the proxy. |
 

--- a/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
+++ b/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
@@ -1,24 +1,24 @@
 # CORS, Rate Limiting, and Proxy
 
-The OneRoster© service exposes three cross-cutting runtime controls that
+The OneRoster© service has three cross-cutting runtime controls that
 govern how requests are admitted into the application:
 
 - CORS origin allowlisting (`CORS_ORIGINS`)
 - Per-IP rate limiting on the `/ims/oneroster/*` routes
-  (`RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX_REQUESTS`)
+  (`RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX_REQUESTS`)
 - Trust-proxy behavior when the service sits behind a reverse proxy
   (`TRUST_PROXY`)
 
-All three are controlled by environment variables; see [Environment
-variables](./environment-variables.md) for the full reference. This page
-describes the runtime behavior so operators can predict it and diagnose
-issues.
+All three are controlled by environment variables. See [Environment
+variables](./environment-variables.md) for the full reference. This
+page describes the runtime behavior so operators can predict it and
+diagnose issues.
 
 ## CORS origins
 
-`CORS_ORIGINS` is a comma-separated list of origins (scheme + host + port)
-that the service accepts as CORS origins. The value in the `.env.example`
-is:
+`CORS_ORIGINS` is a comma-separated list of origins (scheme, host, and
+port) that the service accepts as CORS origins. The value in
+`.env.example` is:
 
 ```env
 CORS_ORIGINS=http://localhost:3000
@@ -26,24 +26,25 @@ CORS_ORIGINS=http://localhost:3000
 
 Behavior at startup:
 
-- If `CORS_ORIGINS` is **empty or unset**, the service allows all origins
-  (equivalent to `cors({ origin: true })`). This is convenient for local
-  development but is not recommended for production.
+- If `CORS_ORIGINS` is empty or unset, the service allows all origins
+  (equivalent to `cors({ origin: true })`). This is convenient for
+  local development but is not recommended for production.
 - If `CORS_ORIGINS` is set, the service only allows exact matches from
-  the comma-separated list. Requests with a disallowed `Origin` header
-  are rejected with a CORS error; requests with **no** `Origin` header
-  (curl, Postman, server-to-server) are always allowed through.
+  the comma-separated list. Requests with a disallowed `Origin`
+  header are rejected with a CORS error. Requests with no `Origin`
+  header (curl, Postman, server-to-server) are always allowed
+  through.
 
-Origins are matched on the full string (scheme + host + port) and are not
-wildcard-expanded. To allow a Swagger UI served alongside the ODS/API,
-include its origin, for example:
+Origins are matched on the full string (scheme, host, and port). They
+are not wildcard-expanded. To allow a Swagger UI served alongside the
+ODS / API, include its origin:
 
 ```env
 CORS_ORIGINS=https://oneroster.example.org,https://odsapi.example.org:56641
 ```
 
-Tokens still need to satisfy the JWT validation regardless of origin; CORS
-only decides whether the browser is allowed to read the response.
+JWT validation still applies regardless of origin. CORS only decides
+whether the browser is allowed to read the response.
 
 ## Rate limiting
 
@@ -54,12 +55,12 @@ using the IP address of the client. Other routes (`/health-check`,
 
 | Variable | Default | Behavior |
 | --- | --- | --- |
-| `RATE_LIMIT_WINDOW_MS` | `60000` (1 minute) | Sliding window length |
-| `RATE_LIMIT_MAX_REQUESTS` | `60` | Max requests per IP per window |
+| `RATE_LIMIT_WINDOW_MS` | `60000` (1 minute) | Sliding window length. |
+| `RATE_LIMIT_MAX_REQUESTS` | `60` | Maximum requests per IP per window. |
 
-Default headers follow the RFC draft for rate-limit headers
-(`RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`); legacy
-`X-RateLimit-*` headers are disabled.
+Response headers follow the RFC draft for rate-limit headers
+(`RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`). The
+legacy `X-RateLimit-*` headers are disabled.
 
 When a client exceeds the limit, the service returns an IMS-formatted
 error:
@@ -73,16 +74,17 @@ error:
 ```
 
 For deployments where clients routinely retrieve large result sets
-through pagination, raise `RATE_LIMIT_MAX_REQUESTS` or widen the window
-rather than disabling the limit entirely. Document the adjusted values
-to the integrators consuming the API.
+through pagination, raise `RATE_LIMIT_MAX_REQUESTS` or widen the
+window rather than disabling the limit entirely. Document the
+adjusted values to the integrators consuming the API.
 
 ## Trust proxy
 
-The OneRoster© service reads `X-Forwarded-Proto`, `X-Forwarded-Host`, and
-`X-Forwarded-Prefix` to generate self-referencing discovery URLs (the
-Swagger UI `servers` entry and the JSON returned by `GET /`). Express
-only honors these headers when the application has `trust proxy` enabled.
+The OneRoster© service reads `X-Forwarded-Proto`, `X-Forwarded-Host`,
+and `X-Forwarded-Prefix` to generate self-referencing discovery URLs
+(the Swagger UI `servers` entry and the JSON returned by `GET /`).
+Express only honors these headers when the application has `trust
+proxy` enabled.
 
 | `TRUST_PROXY` | Behavior |
 | --- | --- |
@@ -98,26 +100,28 @@ Set `TRUST_PROXY=true` whenever the service is deployed behind:
 :::warning
 
 Do not set `TRUST_PROXY=true` when the service is exposed directly to
-untrusted networks without a trusted proxy in front of it. In that case
-callers could forge `X-Forwarded-*` headers to influence discovery URLs.
+untrusted networks without a trusted proxy in front of it. In that
+case, callers could forge `X-Forwarded-*` headers to influence
+discovery URLs.
 
 :::
 
 For the ARR reverse-proxy setup on IIS, also register
-`HTTP_X_FORWARDED_PROTO` and `HTTP_X_FORWARDED_HOST` under URL Rewrite →
+`HTTP_X_FORWARDED_PROTO` and `HTTP_X_FORWARDED_HOST` under URL Rewrite
 _View Server Variables_ so the rewrite rules are allowed to set them.
-The IIS deployment guide walks through this step — see [Deploy on
+The IIS deployment guide walks through this step. See [Deploy on
 IIS](../getting-started/deploy-iis.md).
 
 ## How `API_BASE_PATH` interacts with proxy behavior
 
 When the service is hosted under a virtual directory (for example,
-`https://example.org/oneroster`), discovery URLs must include the virtual
-path. The service resolves this in the following order:
+`https://example.org/oneroster`), discovery URLs must include the
+virtual path. The service resolves this in the following order:
 
-1. `X-Forwarded-Prefix` request header (when `TRUST_PROXY=true`)
+1. `X-Forwarded-Prefix` request header, when `TRUST_PROXY=true`
 2. `API_BASE_PATH` environment variable
 3. Empty (service treated as hosted at root)
 
 If the proxy does not emit `X-Forwarded-Prefix`, set `API_BASE_PATH`
-explicitly so the generated URLs include the virtual-directory segment.
+explicitly so the generated URLs include the virtual-directory
+segment.

--- a/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
+++ b/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
@@ -1,6 +1,6 @@
 # CORS, Rate Limiting, and Proxy
 
-The OneRoster© service has three cross-cutting runtime controls that
+The OneRoster® service has three cross-cutting runtime controls that
 govern how requests are admitted into the application:
 
 - CORS origin allowlisting (`CORS_ORIGINS`)
@@ -80,7 +80,7 @@ adjusted values to the integrators consuming the API.
 
 ## Trust proxy
 
-The OneRoster© service reads `X-Forwarded-Proto`, `X-Forwarded-Host`,
+The OneRoster service reads `X-Forwarded-Proto`, `X-Forwarded-Host`,
 and `X-Forwarded-Prefix` to generate self-referencing discovery URLs
 (the Swagger UI `servers` entry and the JSON returned by `GET /`).
 Express only honors these headers when the application has `trust

--- a/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
+++ b/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
@@ -1,0 +1,123 @@
+# CORS, Rate Limiting, and Proxy
+
+The OneRoster service exposes three cross-cutting runtime controls that
+govern how requests are admitted into the application:
+
+- CORS origin allowlisting (`CORS_ORIGINS`)
+- Per-IP rate limiting on the `/ims/oneroster/*` routes
+  (`RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX_REQUESTS`)
+- Trust-proxy behavior when the service sits behind a reverse proxy
+  (`TRUST_PROXY`)
+
+All three are controlled by environment variables; see [Environment
+variables](./environment-variables.md) for the full reference. This page
+describes the runtime behavior so operators can predict it and diagnose
+issues.
+
+## CORS origins
+
+`CORS_ORIGINS` is a comma-separated list of origins (scheme + host + port)
+that the service accepts as CORS origins. The value in the `.env.example`
+is:
+
+```env
+CORS_ORIGINS=http://localhost:3000
+```
+
+Behavior at startup:
+
+- If `CORS_ORIGINS` is **empty or unset**, the service allows all origins
+  (equivalent to `cors({ origin: true })`). This is convenient for local
+  development but is not recommended for production.
+- If `CORS_ORIGINS` is set, the service only allows exact matches from
+  the comma-separated list. Requests with a disallowed `Origin` header
+  are rejected with a CORS error; requests with **no** `Origin` header
+  (curl, Postman, server-to-server) are always allowed through.
+
+Origins are matched on the full string (scheme + host + port) and are not
+wildcard-expanded. To allow a Swagger UI served alongside the ODS/API,
+include its origin, for example:
+
+```env
+CORS_ORIGINS=https://oneroster.example.org,https://odsapi.example.org:56641
+```
+
+Tokens still need to satisfy the JWT validation regardless of origin; CORS
+only decides whether the browser is allowed to read the response.
+
+## Rate limiting
+
+The `/ims/oneroster/*` routes are rate-limited by
+[`express-rate-limit`](https://www.npmjs.com/package/express-rate-limit)
+using the IP address of the client. Other routes (`/health-check`,
+`/docs`, `/swagger.json`, `/`) are not rate-limited.
+
+| Variable | Default | Behavior |
+|---|---|---|
+| `RATE_LIMIT_WINDOW_MS` | `60000` (1 minute) | Sliding window length |
+| `RATE_LIMIT_MAX_REQUESTS` | `60` | Max requests per IP per window |
+
+Default headers follow the RFC draft for rate-limit headers
+(`RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`); legacy
+`X-RateLimit-*` headers are disabled.
+
+When a client exceeds the limit, the service returns an IMS-formatted
+error:
+
+```json
+{
+  "imsx_codeMajor": "failure",
+  "imsx_severity": "error",
+  "imsx_description": "Too many requests. Server is busy, retry later."
+}
+```
+
+For deployments where clients routinely retrieve large result sets
+through pagination, raise `RATE_LIMIT_MAX_REQUESTS` or widen the window
+rather than disabling the limit entirely. Document the adjusted values
+to the integrators consuming the API.
+
+## Trust proxy
+
+The OneRoster service reads `X-Forwarded-Proto`, `X-Forwarded-Host`, and
+`X-Forwarded-Prefix` to generate self-referencing discovery URLs (the
+Swagger UI `servers` entry and the JSON returned by `GET /`). Express
+only honors these headers when the application has `trust proxy` enabled.
+
+| `TRUST_PROXY` | Behavior |
+|---|---|
+| `false` (default) | `X-Forwarded-*` headers are ignored. Discovery URLs use the protocol and host the Node process observes directly. |
+| `true` | `X-Forwarded-*` headers are trusted. Discovery URLs reflect the public-facing protocol and host from the proxy. |
+
+Set `TRUST_PROXY=true` whenever the service is deployed behind:
+
+- IIS (both `iisnode` and ARR reverse-proxy setups)
+- NGINX (including the bundled `compose/nginx-compose.yml`)
+- Any other reverse proxy terminating TLS
+
+:::warning
+
+Do not set `TRUST_PROXY=true` when the service is exposed directly to
+untrusted networks without a trusted proxy in front of it. In that case
+callers could forge `X-Forwarded-*` headers to influence discovery URLs.
+
+:::
+
+For the ARR reverse-proxy setup on IIS, also register
+`HTTP_X_FORWARDED_PROTO` and `HTTP_X_FORWARDED_HOST` under URL Rewrite →
+_View Server Variables_ so the rewrite rules are allowed to set them.
+The IIS deployment guide walks through this step — see [Deploy on
+IIS](../getting-started/deploy-iis.md).
+
+## How `API_BASE_PATH` interacts with proxy behavior
+
+When the service is hosted under a virtual directory (for example,
+`https://example.org/oneroster`), discovery URLs must include the virtual
+path. The service resolves this in the following order:
+
+1. `X-Forwarded-Prefix` request header (when `TRUST_PROXY=true`)
+2. `API_BASE_PATH` environment variable
+3. Empty (service treated as hosted at root)
+
+If the proxy does not emit `X-Forwarded-Prefix`, set `API_BASE_PATH`
+explicitly so the generated URLs include the virtual-directory segment.

--- a/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
+++ b/docs/reference/11-oneroster/configuration/cors-rate-limit-proxy.md
@@ -1,6 +1,6 @@
 # CORS, Rate Limiting, and Proxy
 
-The OneRoster service exposes three cross-cutting runtime controls that
+The OneRoster© service exposes three cross-cutting runtime controls that
 govern how requests are admitted into the application:
 
 - CORS origin allowlisting (`CORS_ORIGINS`)
@@ -79,7 +79,7 @@ to the integrators consuming the API.
 
 ## Trust proxy
 
-The OneRoster service reads `X-Forwarded-Proto`, `X-Forwarded-Host`, and
+The OneRoster© service reads `X-Forwarded-Proto`, `X-Forwarded-Host`, and
 `X-Forwarded-Prefix` to generate self-referencing discovery URLs (the
 Swagger UI `servers` entry and the JSON returned by `GET /`). Express
 only honors these headers when the application has `trust proxy` enabled.

--- a/docs/reference/11-oneroster/configuration/environment-variables.md
+++ b/docs/reference/11-oneroster/configuration/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-The OneRoster© Node service reads configuration from environment
+The OneRoster® Node service reads configuration from environment
 variables, typically supplied via a `.env` file at the application
 root. The sample `.env.example` in the service repository lists every
 variable. The tables below group them by concern and note defaults and
@@ -118,14 +118,14 @@ documented there. Common ones:
 
 | Variable | Purpose |
 | --- | --- |
-| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT` | Credentials shared between the ODS, admin, and OneRoster© containers. |
+| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT` | Credentials shared between the ODS, admin, and OneRoster containers. |
 | `ODS_DB_IMAGE_7X`, `ODS_DB_TAG_7X`, `ODS_API_TAG_7X`, `SWAGGER_TAG_7X`, `ADMIN_DB_TAG_7X` | Pin Ed-Fi image versions. |
 | `BASE_URL`, `V7_SINGLE_API_VIRTUAL_NAME`, `ONEROSTER_API_VIRTUAL_NAME`, `DOCS_VIRTUAL_NAME` | Hostnames used by NGINX routing and TLS. |
 | `SECURITY__JWT__PRIVATEKEY`, `SECURITY__JWT__PUBLICKEY` | JWT signing keys used by the Ed-Fi v7 API. Required before start, or generated via `-GenerateSigningKeys`. |
 | `NODE_EXTRA_CA_CERTS` | Path to the self-signed CA bundled under `compose/ssl`. |
 | `LOGS_FOLDER` | Bind-mounted into the v7 API container. |
 
-These variables govern the Compose stack only. A production OneRoster©
+These variables govern the Compose stack only. A production OneRoster
 deployment reads an externally-operated Ed-Fi ODS and OAuth issuer and
 does not need them.
 

--- a/docs/reference/11-oneroster/configuration/environment-variables.md
+++ b/docs/reference/11-oneroster/configuration/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-The OneRoster Node service reads configuration from environment variables,
+The OneRoster© Node service reads configuration from environment variables,
 typically supplied via a `.env` file at the application root. The sample
 `.env.example` in the service repository lists every variable; the tables
 below group them by concern and note defaults and required / optional
@@ -118,14 +118,14 @@ ones include:
 
 | Variable | Purpose |
 | --- | --- |
-| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT` | Credentials shared between the ODS, admin, and OneRoster containers |
+| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT` | Credentials shared between the ODS, admin, and OneRoster© containers |
 | `ODS_DB_IMAGE_7X`, `ODS_DB_TAG_7X`, `ODS_API_TAG_7X`, `SWAGGER_TAG_7X`, `ADMIN_DB_TAG_7X` | Pin Ed-Fi image versions |
 | `BASE_URL`, `V7_SINGLE_API_VIRTUAL_NAME`, `ONEROSTER_API_VIRTUAL_NAME`, `DOCS_VIRTUAL_NAME` | Hostnames used by NGINX routing and TLS |
 | `SECURITY__JWT__PRIVATEKEY`, `SECURITY__JWT__PUBLICKEY` | JWT signing keys used by the Ed-Fi v7 API (required before start, or generated via `-GenerateSigningKeys`) |
 | `NODE_EXTRA_CA_CERTS` | Path to the self-signed CA bundled under `compose/ssl` |
 | `LOGS_FOLDER` | Bind-mounted into the v7 API container |
 
-These variables govern the Compose stack only; a production OneRoster
+These variables govern the Compose stack only; a production OneRoster©
 deployment wires into an externally-operated Ed-Fi ODS and OAuth issuer
 and does not need them.
 

--- a/docs/reference/11-oneroster/configuration/environment-variables.md
+++ b/docs/reference/11-oneroster/configuration/environment-variables.md
@@ -1,0 +1,143 @@
+# Environment Variables
+
+The OneRoster Node service reads configuration from environment variables,
+typically supplied via a `.env` file at the application root. The sample
+`.env.example` in the service repository lists every variable; the tables
+below group them by concern and note defaults and required / optional
+status.
+
+## Minimum viable configuration
+
+A bare-minimum `.env` for a native PostgreSQL deployment is:
+
+```env
+DB_TYPE=postgres
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASS=P@ssw0rd
+DB_NAME=EdFi_Ods_Populated_Template
+
+OAUTH2_ISSUERBASEURL=https://your-issuer/
+OAUTH2_AUDIENCE=http://localhost:3000
+OAUTH2_TOKENSIGNINGALG=RS256
+```
+
+The server fails to start if `OAUTH2_ISSUERBASEURL` or `OAUTH2_AUDIENCE`
+is missing.
+
+## Application
+
+| Variable | Default | Notes |
+|---|---|---|
+| `PORT` | `3000` | TCP port the Node service listens on |
+| `API_BASE_PATH` | _(empty)_ | Set when the service is hosted under a virtual directory (e.g., `/oneroster` behind IIS). Used to generate deterministic discovery URLs. |
+| `NODE_ENV` | `dev` | Set to `prod` (or empty) for production. Currently influences logging verbosity. |
+| `API_SERVER_URL` | _(empty)_ | Override for the self-reported server URL in Swagger discovery. Rarely needed; prefer `API_BASE_PATH` + forwarded-proto headers. |
+
+## Database
+
+Select the engine with `DB_TYPE`; variables for the _other_ engine are
+ignored.
+
+### Common
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DB_TYPE` | `postgres` | `postgres` or `mssql` |
+
+### PostgreSQL (`DB_TYPE=postgres`)
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DB_HOST` | `localhost` | PostgreSQL server hostname |
+| `DB_PORT` | `5432` | |
+| `DB_USER` | `postgres` | |
+| `DB_PASS` | — | Required |
+| `DB_NAME` | `EdFi_Ods_Populated_Template` | ODS database name |
+| `DB_SSL` | `false` | `true` enables TLS with certificate validation (`rejectUnauthorized: true`) |
+| `DB_SSL_CA` | _(empty)_ | Optional path to a CA PEM file. Only used when `DB_SSL=true`. Startup fails fast if the path is set but unreadable / empty. |
+
+### Microsoft SQL Server (`DB_TYPE=mssql`)
+
+| Variable | Default | Notes |
+|---|---|---|
+| `MSSQL_SERVER` | `localhost` | |
+| `MSSQL_DATABASE` | `EdFi_Ods` | ODS database name |
+| `MSSQL_USER` | `sa` | |
+| `MSSQL_PASSWORD` | — | Required |
+| `MSSQL_PORT` | `1433` | |
+| `MSSQL_ENCRYPT` | `false` | `true` enables TLS |
+| `MSSQL_TRUST_SERVER_CERTIFICATE` | `true` | Set to `false` in production |
+
+## OAuth 2.0 / JWT
+
+See [OAuth and JWT](./oauth-and-jwt.md) for the detailed behavior and
+trade-offs between JWKS and PEM-based verification.
+
+| Variable | Default | Notes |
+|---|---|---|
+| `OAUTH2_ISSUERBASEURL` | — | **Required.** Base URL of the OAuth 2.0 issuer (typically your Ed-Fi ODS/API's `/oauth/` endpoint). The `/.well-known/jwks.json` path is resolved against this when PEM verification is not configured. |
+| `OAUTH2_AUDIENCE` | — | **Required.** Expected `aud` claim on inbound JWTs |
+| `OAUTH2_TOKENSIGNINGALG` | `RS256` | JWT signing algorithm |
+| `OAUTH2_PUBLIC_KEY_PEM` | _(empty)_ | If set, the service verifies JWTs with this PEM public key instead of fetching JWKS. Use `\n` for line breaks when storing in `.env`. |
+
+## Refresh schedule
+
+### PostgreSQL
+
+| Variable | Default | Notes |
+|---|---|---|
+| `PGBOSS_CRON` | `*/15 * * * *` | Cron expression for the pg-boss job that refreshes materialized views. Accepts standard 5-field cron syntax. |
+
+### Microsoft SQL Server
+
+The MSSQL variant does not use `PGBOSS_CRON`. Scheduling is controlled by
+the SQL Server Agent job `OneRoster Data Refresh`; see [Deploy on Microsoft
+SQL Server](../getting-started/deploy-mssql.md) for commands to change the
+cadence.
+
+## CORS, rate limiting, and proxy
+
+See [CORS, rate limiting, and proxy](./cors-rate-limit-proxy.md) for the
+behavior details.
+
+| Variable | Default | Notes |
+|---|---|---|
+| `CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed origins. Leave empty to allow all (not recommended in production). |
+| `RATE_LIMIT_WINDOW_MS` | `60000` | Rate-limit window in milliseconds (`express-rate-limit`) |
+| `RATE_LIMIT_MAX_REQUESTS` | `60` | Max requests per window per IP. (The bundled `.env.example` shows `100`; in the service code the default when unset is `60`.) |
+| `TRUST_PROXY` | `false` | When `true`, the service trusts `X-Forwarded-*` headers — required when running behind IIS, NGINX, or ARR. |
+
+## Docker Compose specific
+
+The Docker Compose stack under `compose/` introduces additional variables
+that are not used by the standalone Node service. These are present in the
+`.env.{dataStandardVersion}.example` files and documented there — common
+ones include:
+
+| Variable | Purpose |
+|---|---|
+| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT` | Credentials shared between the ODS, admin, and OneRoster containers |
+| `ODS_DB_IMAGE_7X`, `ODS_DB_TAG_7X`, `ODS_API_TAG_7X`, `SWAGGER_TAG_7X`, `ADMIN_DB_TAG_7X` | Pin Ed-Fi image versions |
+| `BASE_URL`, `V7_SINGLE_API_VIRTUAL_NAME`, `ONEROSTER_API_VIRTUAL_NAME`, `DOCS_VIRTUAL_NAME` | Hostnames used by NGINX routing and TLS |
+| `SECURITY__JWT__PRIVATEKEY`, `SECURITY__JWT__PUBLICKEY` | JWT signing keys used by the Ed-Fi v7 API (required before start, or generated via `-GenerateSigningKeys`) |
+| `NODE_EXTRA_CA_CERTS` | Path to the self-signed CA bundled under `compose/ssl` |
+| `LOGS_FOLDER` | Bind-mounted into the v7 API container |
+
+These variables govern the Compose stack only; a production OneRoster
+deployment wires into an externally-operated Ed-Fi ODS and OAuth issuer
+and does not need them.
+
+## Quick sanity check
+
+After populating `.env`, confirm the service can start:
+
+```bash
+node server.js
+# The process exits immediately with an error if OAUTH2_AUDIENCE
+# or OAUTH2_ISSUERBASEURL is missing, or if DB_SSL_CA is set but
+# unreadable.
+
+curl -i http://localhost:3000/health-check
+```

--- a/docs/reference/11-oneroster/configuration/environment-variables.md
+++ b/docs/reference/11-oneroster/configuration/environment-variables.md
@@ -29,7 +29,7 @@ is missing.
 ## Application
 
 | Variable | Default | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `PORT` | `3000` | TCP port the Node service listens on |
 | `API_BASE_PATH` | _(empty)_ | Set when the service is hosted under a virtual directory (e.g., `/oneroster` behind IIS). Used to generate deterministic discovery URLs. |
 | `NODE_ENV` | `dev` | Set to `prod` (or empty) for production. Currently influences logging verbosity. |
@@ -43,13 +43,13 @@ ignored.
 ### Common
 
 | Variable | Default | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `DB_TYPE` | `postgres` | `postgres` or `mssql` |
 
 ### PostgreSQL (`DB_TYPE=postgres`)
 
 | Variable | Default | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `DB_HOST` | `localhost` | PostgreSQL server hostname |
 | `DB_PORT` | `5432` | |
 | `DB_USER` | `postgres` | |
@@ -61,7 +61,7 @@ ignored.
 ### Microsoft SQL Server (`DB_TYPE=mssql`)
 
 | Variable | Default | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `MSSQL_SERVER` | `localhost` | |
 | `MSSQL_DATABASE` | `EdFi_Ods` | ODS database name |
 | `MSSQL_USER` | `sa` | |
@@ -76,7 +76,7 @@ See [OAuth and JWT](./oauth-and-jwt.md) for the detailed behavior and
 trade-offs between JWKS and PEM-based verification.
 
 | Variable | Default | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `OAUTH2_ISSUERBASEURL` | — | **Required.** Base URL of the OAuth 2.0 issuer (typically your Ed-Fi ODS/API's `/oauth/` endpoint). The `/.well-known/jwks.json` path is resolved against this when PEM verification is not configured. |
 | `OAUTH2_AUDIENCE` | — | **Required.** Expected `aud` claim on inbound JWTs |
 | `OAUTH2_TOKENSIGNINGALG` | `RS256` | JWT signing algorithm |
@@ -87,7 +87,7 @@ trade-offs between JWKS and PEM-based verification.
 ### PostgreSQL
 
 | Variable | Default | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `PGBOSS_CRON` | `*/15 * * * *` | Cron expression for the pg-boss job that refreshes materialized views. Accepts standard 5-field cron syntax. |
 
 ### Microsoft SQL Server
@@ -103,7 +103,7 @@ See [CORS, rate limiting, and proxy](./cors-rate-limit-proxy.md) for the
 behavior details.
 
 | Variable | Default | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed origins. Leave empty to allow all (not recommended in production). |
 | `RATE_LIMIT_WINDOW_MS` | `60000` | Rate-limit window in milliseconds (`express-rate-limit`) |
 | `RATE_LIMIT_MAX_REQUESTS` | `60` | Max requests per window per IP. (The bundled `.env.example` shows `100`; in the service code the default when unset is `60`.) |
@@ -117,7 +117,7 @@ that are not used by the standalone Node service. These are present in the
 ones include:
 
 | Variable | Purpose |
-|---|---|
+| --- | --- |
 | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT` | Credentials shared between the ODS, admin, and OneRoster containers |
 | `ODS_DB_IMAGE_7X`, `ODS_DB_TAG_7X`, `ODS_API_TAG_7X`, `SWAGGER_TAG_7X`, `ADMIN_DB_TAG_7X` | Pin Ed-Fi image versions |
 | `BASE_URL`, `V7_SINGLE_API_VIRTUAL_NAME`, `ONEROSTER_API_VIRTUAL_NAME`, `DOCS_VIRTUAL_NAME` | Hostnames used by NGINX routing and TLS |

--- a/docs/reference/11-oneroster/configuration/environment-variables.md
+++ b/docs/reference/11-oneroster/configuration/environment-variables.md
@@ -1,14 +1,14 @@
 # Environment Variables
 
-The OneRoster© Node service reads configuration from environment variables,
-typically supplied via a `.env` file at the application root. The sample
-`.env.example` in the service repository lists every variable; the tables
-below group them by concern and note defaults and required / optional
-status.
+The OneRoster© Node service reads configuration from environment
+variables, typically supplied via a `.env` file at the application
+root. The sample `.env.example` in the service repository lists every
+variable. The tables below group them by concern and note defaults and
+required or optional status.
 
 ## Minimum viable configuration
 
-A bare-minimum `.env` for a native PostgreSQL deployment is:
+A minimum `.env` for a native PostgreSQL deployment is:
 
 ```env
 DB_TYPE=postgres
@@ -23,21 +23,21 @@ OAUTH2_AUDIENCE=http://localhost:3000
 OAUTH2_TOKENSIGNINGALG=RS256
 ```
 
-The server fails to start if `OAUTH2_ISSUERBASEURL` or `OAUTH2_AUDIENCE`
-is missing.
+The server fails to start if `OAUTH2_ISSUERBASEURL` or
+`OAUTH2_AUDIENCE` is missing.
 
 ## Application
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `PORT` | `3000` | TCP port the Node service listens on |
-| `API_BASE_PATH` | _(empty)_ | Set when the service is hosted under a virtual directory (e.g., `/oneroster` behind IIS). Used to generate deterministic discovery URLs. |
-| `NODE_ENV` | `dev` | Set to `prod` (or empty) for production. Currently influences logging verbosity. |
-| `API_SERVER_URL` | _(empty)_ | Override for the self-reported server URL in Swagger discovery. Rarely needed; prefer `API_BASE_PATH` + forwarded-proto headers. |
+| `PORT` | `3000` | TCP port the Node service listens on. |
+| `API_BASE_PATH` | _(empty)_ | Set when the service is hosted under a virtual directory (for example, `/oneroster` behind IIS). Used to generate deterministic discovery URLs. |
+| `NODE_ENV` | `dev` | Set to `prod` (or empty) for production. Influences logging verbosity. |
+| `API_SERVER_URL` | _(empty)_ | Override for the self-reported server URL in Swagger discovery. Rarely needed. Prefer `API_BASE_PATH` with forwarded-proto headers. |
 
 ## Database
 
-Select the engine with `DB_TYPE`; variables for the _other_ engine are
+Select the engine with `DB_TYPE`. Variables for the other engine are
 ignored.
 
 ### Common
@@ -50,36 +50,36 @@ ignored.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `DB_HOST` | `localhost` | PostgreSQL server hostname |
+| `DB_HOST` | `localhost` | PostgreSQL server hostname. |
 | `DB_PORT` | `5432` | |
 | `DB_USER` | `postgres` | |
-| `DB_PASS` | — | Required |
-| `DB_NAME` | `EdFi_Ods_Populated_Template` | ODS database name |
-| `DB_SSL` | `false` | `true` enables TLS with certificate validation (`rejectUnauthorized: true`) |
-| `DB_SSL_CA` | _(empty)_ | Optional path to a CA PEM file. Only used when `DB_SSL=true`. Startup fails fast if the path is set but unreadable / empty. |
+| `DB_PASS` | _(none)_ | Required. |
+| `DB_NAME` | `EdFi_Ods_Populated_Template` | ODS database name. |
+| `DB_SSL` | `false` | When `true`, enables TLS with certificate validation (`rejectUnauthorized: true`). |
+| `DB_SSL_CA` | _(empty)_ | Optional path to a CA PEM file. Only used when `DB_SSL=true`. Startup fails fast if the path is set but unreadable or empty. |
 
 ### Microsoft SQL Server (`DB_TYPE=mssql`)
 
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `MSSQL_SERVER` | `localhost` | |
-| `MSSQL_DATABASE` | `EdFi_Ods` | ODS database name |
+| `MSSQL_DATABASE` | `EdFi_Ods` | ODS database name. |
 | `MSSQL_USER` | `sa` | |
-| `MSSQL_PASSWORD` | — | Required |
+| `MSSQL_PASSWORD` | _(none)_ | Required. |
 | `MSSQL_PORT` | `1433` | |
-| `MSSQL_ENCRYPT` | `false` | `true` enables TLS |
-| `MSSQL_TRUST_SERVER_CERTIFICATE` | `true` | Set to `false` in production |
+| `MSSQL_ENCRYPT` | `false` | When `true`, enables TLS. |
+| `MSSQL_TRUST_SERVER_CERTIFICATE` | `true` | Set to `false` in production. |
 
-## OAuth 2.0 / JWT
+## OAuth 2.0 and JWT
 
 See [OAuth and JWT](./oauth-and-jwt.md) for the detailed behavior and
-trade-offs between JWKS and PEM-based verification.
+for the trade-offs between JWKS and PEM-based verification.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `OAUTH2_ISSUERBASEURL` | — | **Required.** Base URL of the OAuth 2.0 issuer (typically your Ed-Fi ODS/API's `/oauth/` endpoint). The `/.well-known/jwks.json` path is resolved against this when PEM verification is not configured. |
-| `OAUTH2_AUDIENCE` | — | **Required.** Expected `aud` claim on inbound JWTs |
-| `OAUTH2_TOKENSIGNINGALG` | `RS256` | JWT signing algorithm |
+| `OAUTH2_ISSUERBASEURL` | _(none)_ | Required. Base URL of the OAuth 2.0 issuer (typically your Ed-Fi ODS / API's `/oauth/` endpoint). The `/.well-known/jwks.json` path is resolved against this when PEM verification is not configured. |
+| `OAUTH2_AUDIENCE` | _(none)_ | Required. Expected `aud` claim on inbound JWTs. |
+| `OAUTH2_TOKENSIGNINGALG` | `RS256` | JWT signing algorithm. |
 | `OAUTH2_PUBLIC_KEY_PEM` | _(empty)_ | If set, the service verifies JWTs with this PEM public key instead of fetching JWKS. Use `\n` for line breaks when storing in `.env`. |
 
 ## Refresh schedule
@@ -92,42 +92,42 @@ trade-offs between JWKS and PEM-based verification.
 
 ### Microsoft SQL Server
 
-The MSSQL variant does not use `PGBOSS_CRON`. Scheduling is controlled by
-the SQL Server Agent job `OneRoster Data Refresh`; see [Deploy on Microsoft
-SQL Server](../getting-started/deploy-mssql.md) for commands to change the
-cadence.
+The SQL Server variant does not use `PGBOSS_CRON`. Scheduling is
+controlled by the SQL Server Agent job `OneRoster Data Refresh`. See
+[Deploy on Microsoft SQL Server](../getting-started/deploy-mssql.md)
+for commands to change the cadence.
 
 ## CORS, rate limiting, and proxy
 
-See [CORS, rate limiting, and proxy](./cors-rate-limit-proxy.md) for the
-behavior details.
+See [CORS, rate limiting, and proxy](./cors-rate-limit-proxy.md) for
+the behavior details.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed origins. Leave empty to allow all (not recommended in production). |
-| `RATE_LIMIT_WINDOW_MS` | `60000` | Rate-limit window in milliseconds (`express-rate-limit`) |
-| `RATE_LIMIT_MAX_REQUESTS` | `60` | Max requests per window per IP. (The bundled `.env.example` shows `100`; in the service code the default when unset is `60`.) |
-| `TRUST_PROXY` | `false` | When `true`, the service trusts `X-Forwarded-*` headers — required when running behind IIS, NGINX, or ARR. |
+| `RATE_LIMIT_WINDOW_MS` | `60000` | Rate-limit window in milliseconds (`express-rate-limit`). |
+| `RATE_LIMIT_MAX_REQUESTS` | `60` | Maximum requests per window per IP. The bundled `.env.example` sets this to `100`. The service code uses `60` as the fallback when the variable is unset. |
+| `TRUST_PROXY` | `false` | When `true`, the service trusts `X-Forwarded-*` headers. Required when running behind IIS, NGINX, or ARR. |
 
 ## Docker Compose specific
 
-The Docker Compose stack under `compose/` introduces additional variables
-that are not used by the standalone Node service. These are present in the
-`.env.{dataStandardVersion}.example` files and documented there — common
-ones include:
+The Docker Compose stack under `compose/` introduces additional
+variables that are not used by the standalone Node service. These are
+present in the `.env.{dataStandardVersion}.example` files and
+documented there. Common ones:
 
 | Variable | Purpose |
 | --- | --- |
-| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT` | Credentials shared between the ODS, admin, and OneRoster© containers |
-| `ODS_DB_IMAGE_7X`, `ODS_DB_TAG_7X`, `ODS_API_TAG_7X`, `SWAGGER_TAG_7X`, `ADMIN_DB_TAG_7X` | Pin Ed-Fi image versions |
-| `BASE_URL`, `V7_SINGLE_API_VIRTUAL_NAME`, `ONEROSTER_API_VIRTUAL_NAME`, `DOCS_VIRTUAL_NAME` | Hostnames used by NGINX routing and TLS |
-| `SECURITY__JWT__PRIVATEKEY`, `SECURITY__JWT__PUBLICKEY` | JWT signing keys used by the Ed-Fi v7 API (required before start, or generated via `-GenerateSigningKeys`) |
-| `NODE_EXTRA_CA_CERTS` | Path to the self-signed CA bundled under `compose/ssl` |
-| `LOGS_FOLDER` | Bind-mounted into the v7 API container |
+| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT` | Credentials shared between the ODS, admin, and OneRoster© containers. |
+| `ODS_DB_IMAGE_7X`, `ODS_DB_TAG_7X`, `ODS_API_TAG_7X`, `SWAGGER_TAG_7X`, `ADMIN_DB_TAG_7X` | Pin Ed-Fi image versions. |
+| `BASE_URL`, `V7_SINGLE_API_VIRTUAL_NAME`, `ONEROSTER_API_VIRTUAL_NAME`, `DOCS_VIRTUAL_NAME` | Hostnames used by NGINX routing and TLS. |
+| `SECURITY__JWT__PRIVATEKEY`, `SECURITY__JWT__PUBLICKEY` | JWT signing keys used by the Ed-Fi v7 API. Required before start, or generated via `-GenerateSigningKeys`. |
+| `NODE_EXTRA_CA_CERTS` | Path to the self-signed CA bundled under `compose/ssl`. |
+| `LOGS_FOLDER` | Bind-mounted into the v7 API container. |
 
-These variables govern the Compose stack only; a production OneRoster©
-deployment wires into an externally-operated Ed-Fi ODS and OAuth issuer
-and does not need them.
+These variables govern the Compose stack only. A production OneRoster©
+deployment reads an externally-operated Ed-Fi ODS and OAuth issuer and
+does not need them.
 
 ## Quick sanity check
 

--- a/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
+++ b/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
@@ -81,7 +81,7 @@ For every request to `/ims/oneroster/rostering/v1p2/*` the service
 validates:
 
 | Claim | Source |
-|---|---|
+| --- | --- |
 | Signature | JWKS key or `OAUTH2_PUBLIC_KEY_PEM` |
 | `iss` | Must match `OAUTH2_ISSUERBASEURL` |
 | `aud` | Must match `OAUTH2_AUDIENCE` |
@@ -103,7 +103,7 @@ Tokens must present at least one of the following scopes (space- or
 comma-separated in the `scope` claim, per OAuth 2.0 conventions):
 
 | Scope | Grants read access to |
-|---|---|
+| --- | --- |
 | `roster-core.readonly` | `academicSessions`, `classes`, `courses`, `enrollments`, `orgs`, `schools`, `terms`, `gradingPeriods`, and the non-demographic fields of `users`, `students`, and `teachers` |
 | `roster-demographics.readonly` | The `/demographics` endpoint |
 | `roster.readonly` | All of the above — equivalent to both `roster-core.readonly` and `roster-demographics.readonly` |

--- a/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
+++ b/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
@@ -1,0 +1,181 @@
+# OAuth and JWT
+
+The OneRoster service requires every request to
+`/ims/oneroster/rostering/v1p2/*` to present a valid OAuth 2.0 bearer
+token. The service does not issue tokens itself — it validates tokens
+issued by an external OAuth 2.0 authorization server, typically the Ed-Fi
+ODS/API's built-in OAuth endpoints.
+
+This page covers:
+
+- How the service locates and validates JWTs (JWKS vs PEM modes)
+- What claims it inspects (`iss`, `aud`, scope)
+- The three OneRoster 1.2 scopes it recognizes
+- How OneRoster clients are wired on the Ed-Fi ODS/API side
+
+For the variable list, see [Environment
+variables](./environment-variables.md).
+
+## Token validation modes
+
+The service supports two verification modes and picks between them at
+startup based on whether `OAUTH2_PUBLIC_KEY_PEM` is set.
+
+### JWKS mode (default)
+
+If `OAUTH2_PUBLIC_KEY_PEM` is empty, the service uses
+[`express-oauth2-jwt-bearer`](https://www.npmjs.com/package/express-oauth2-jwt-bearer)
+to fetch the authorization server's JWKS from
+`{OAUTH2_ISSUERBASEURL}/.well-known/jwks.json` and verify JWTs against it.
+
+Required variables:
+
+- `OAUTH2_ISSUERBASEURL` — base URL of the authorization server (for
+  example, your Ed-Fi ODS/API's OAuth endpoint)
+- `OAUTH2_AUDIENCE` — the expected `aud` claim
+- `OAUTH2_TOKENSIGNINGALG` — typically `RS256`
+
+The JWKS is fetched and cached automatically; no additional configuration
+is required for key rotation beyond what the authorization server already
+supports.
+
+### PEM mode
+
+If `OAUTH2_PUBLIC_KEY_PEM` is set, the service uses the
+[`jose`](https://github.com/panva/jose) library to verify JWT signatures
+against the PEM-encoded public key directly. JWKS discovery is not
+attempted.
+
+Required variables (same as JWKS mode), plus:
+
+- `OAUTH2_PUBLIC_KEY_PEM` — the PEM public key, on a single line, with
+  `\n` between lines and including the `-----BEGIN/END PUBLIC KEY-----`
+  markers
+
+Example:
+
+```env
+OAUTH2_PUBLIC_KEY_PEM=-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A...\n-----END PUBLIC KEY-----
+```
+
+PEM mode is useful when:
+
+- The authorization server does not expose a JWKS endpoint
+- You want a static, air-gapped key bundle distributed with the
+  deployment
+- You are bridging to a non-Ed-Fi IdP that publishes PEM-formatted keys
+
+The public key is imported on first use and cached for subsequent
+verifications.
+
+:::note
+
+If both modes appear configured (`OAUTH2_PUBLIC_KEY_PEM` set), PEM mode
+wins and JWKS is not consulted.
+
+:::
+
+## Claims inspected
+
+For every request to `/ims/oneroster/rostering/v1p2/*` the service
+validates:
+
+| Claim | Source |
+|---|---|
+| Signature | JWKS key or `OAUTH2_PUBLIC_KEY_PEM` |
+| `iss` | Must match `OAUTH2_ISSUERBASEURL` |
+| `aud` | Must match `OAUTH2_AUDIENCE` |
+| `exp` | Must not be in the past |
+
+Tokens that fail any check return HTTP 401 with an IMS-formatted error:
+
+```json
+{
+  "imsx_codeMajor": "failure",
+  "imsx_severity": "error",
+  "imsx_description": "Authentication failed: Invalid or missing token."
+}
+```
+
+## OneRoster 1.2 scopes
+
+Tokens must present at least one of the following scopes (space- or
+comma-separated in the `scope` claim, per OAuth 2.0 conventions):
+
+| Scope | Grants read access to |
+|---|---|
+| `roster-core.readonly` | `academicSessions`, `classes`, `courses`, `enrollments`, `orgs`, `schools`, `terms`, `gradingPeriods`, and the non-demographic fields of `users`, `students`, and `teachers` |
+| `roster-demographics.readonly` | The `/demographics` endpoint |
+| `roster.readonly` | All of the above — equivalent to both `roster-core.readonly` and `roster-demographics.readonly` |
+
+These are the standard OneRoster 1.2 rostering scopes defined in the
+[1EdTech OneRoster 1.2 REST
+specification](https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#OpenAPI_Security).
+
+Vendor applications should request the minimum scope their use case
+requires — `roster-core.readonly` is the correct default unless the app
+needs to read `/demographics`.
+
+## Integration with the Ed-Fi ODS/API
+
+Version 7.3 of the Ed-Fi ODS/API includes a `FeatureManagement:OneRoster`
+setting and supporting claim-set configuration that together enable the
+ODS/API's built-in OAuth endpoint to issue tokens bearing the OneRoster
+scopes above. The ODS/API's token endpoint becomes the
+`OAUTH2_ISSUERBASEURL` the OneRoster service points at; the Ed-Fi Web API
+signs the JWTs, and the OneRoster service validates them via JWKS.
+
+For the ODS/API-side configuration (enabling the feature, creating
+OneRoster claim-set entries, issuing keys and secrets to vendor apps), see
+the ODS/API 7.3 platform developer guide's [Features
+reference](/reference/ods-api/platform-dev-guide/features/).
+
+:::note
+
+**Open question — claim-set wiring.** Whether the OneRoster scopes are
+granted automatically to claim sets when
+`FeatureManagement:OneRoster = true`, or whether an operator must
+manually edit `ClaimSet` / `ResourceClaim` rows, is defined on the
+ODS/API side and should be cross-referenced with the ODS/API 7.3
+integration how-to. This page will be updated to include a direct pointer
+once that documentation is live.
+
+:::
+
+## Issuing tokens outside of the ODS/API
+
+The OneRoster service only validates JWTs — it will accept tokens from
+any OAuth 2.0 authorization server that:
+
+1. Signs with `OAUTH2_TOKENSIGNINGALG` (default `RS256`),
+2. Places `{OAUTH2_ISSUERBASEURL}` in the `iss` claim,
+3. Places `{OAUTH2_AUDIENCE}` in the `aud` claim, and
+4. Includes one of the three OneRoster 1.2 scopes.
+
+This makes it straightforward to bridge to Auth0, Keycloak, Azure AD, or
+any other OIDC-compatible IdP for deployments that prefer a dedicated
+identity provider for OneRoster clients.
+
+## Quick verification
+
+Once the service is running and an issuer is configured, obtain a token
+from the issuer and call the service:
+
+```bash
+# Replace <issuer-token-endpoint>, <client_id>, <client_secret>
+curl -X POST <issuer-token-endpoint> \
+  -d "grant_type=client_credentials" \
+  -d "client_id=<client_id>" \
+  -d "client_secret=<client_secret>" \
+  -d "scope=roster-core.readonly" \
+  -d "audience=<OAUTH2_AUDIENCE>"
+
+# Then:
+curl -i http://localhost:3000/ims/oneroster/rostering/v1p2/orgs \
+  -H "Authorization: Bearer <access_token>"
+```
+
+401 responses with an `imsx_description` of "Authentication failed" on
+valid-looking requests usually indicate an `iss` / `aud` mismatch or a
+missing OneRoster scope; check the decoded token at
+[jwt.io](https://jwt.io) against the values in `.env`.

--- a/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
+++ b/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
@@ -1,6 +1,6 @@
 # OAuth and JWT
 
-The OneRoster© service requires every request to
+The OneRoster® service requires every request to
 `/ims/oneroster/rostering/v1p2/*` to present a valid OAuth 2.0 bearer
 token. The service does not issue tokens. It validates tokens issued
 by an external OAuth 2.0 authorization server, typically the Ed-Fi
@@ -92,7 +92,7 @@ error:
 }
 ```
 
-## OneRoster© v1.2 scopes
+## OneRoster v1.2 scopes
 
 Tokens must present at least one of the following scopes (space- or
 comma-separated in the `scope` claim, per OAuth 2.0 conventions):
@@ -103,8 +103,8 @@ comma-separated in the `scope` claim, per OAuth 2.0 conventions):
 | `roster-demographics.readonly` | The `/demographics` endpoint |
 | `roster.readonly` | All of the above. Equivalent to both `roster-core.readonly` and `roster-demographics.readonly`. |
 
-These are the standard OneRoster© v1.2 rostering scopes defined in the
-[1EdTech OneRoster© v1.2 REST
+These are the standard OneRoster v1.2 rostering scopes defined in the
+[1EdTech® OneRoster v1.2 REST
 specification](https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#OpenAPI_Security).
 
 Vendor applications should request the minimum scope their use case
@@ -116,20 +116,20 @@ needs to read `/demographics`.
 Version 7.3 of the Ed-Fi ODS / API includes a
 `FeatureManagement:OneRoster` setting and supporting claim-set
 configuration that enable the ODS / API's built-in OAuth endpoint to
-issue tokens bearing the OneRoster© scopes above. The ODS / API's
-token endpoint becomes the `OAUTH2_ISSUERBASEURL` the OneRoster©
+issue tokens bearing the OneRoster scopes above. The ODS / API's
+token endpoint becomes the `OAUTH2_ISSUERBASEURL` the OneRoster
 service points at. The Ed-Fi Web API signs the JWTs, and the
-OneRoster© service validates them via JWKS.
+OneRoster service validates them via JWKS.
 
 For the ODS / API-side configuration (enabling the feature, creating
-OneRoster© claim-set entries, issuing keys and secrets to vendor
+OneRoster claim-set entries, issuing keys and secrets to vendor
 apps), see the [Features
 reference](/reference/ods-api/platform-dev-guide/features/) in the
 ODS / API v7.3 platform developer guide.
 
 :::note
 
-**Open question: claim-set wiring.** Whether the OneRoster© scopes are
+**Open question: claim-set wiring.** Whether the OneRoster scopes are
 granted automatically to claim sets when `FeatureManagement:OneRoster
 = true`, or whether an operator must manually edit `ClaimSet` or
 `ResourceClaim` rows, is defined on the ODS / API side. This page will
@@ -140,17 +140,17 @@ live.
 
 ## Issuing tokens outside of the ODS / API
 
-The OneRoster© service only validates JWTs. It will accept tokens from
+The OneRoster service only validates JWTs. It will accept tokens from
 any OAuth 2.0 authorization server that:
 
 1. Signs with `OAUTH2_TOKENSIGNINGALG` (default `RS256`).
 2. Places `{OAUTH2_ISSUERBASEURL}` in the `iss` claim.
 3. Places `{OAUTH2_AUDIENCE}` in the `aud` claim.
-4. Includes one of the three OneRoster© v1.2 scopes.
+4. Includes one of the three OneRoster v1.2 scopes.
 
 This enables bridging to Auth0, Keycloak, Azure AD, or any other
 OIDC-compatible identity provider for deployments that prefer a
-dedicated identity provider for OneRoster© clients.
+dedicated identity provider for OneRoster clients.
 
 ## Quick verification
 
@@ -173,5 +173,5 @@ curl -i http://localhost:3000/ims/oneroster/rostering/v1p2/orgs \
 
 A 401 response with `"imsx_description": "Authentication failed"` on a
 valid-looking request usually indicates an `iss` or `aud` mismatch or
-a missing OneRoster© scope. Check the decoded token at
+a missing OneRoster scope. Check the decoded token at
 [jwt.io](https://jwt.io) against the values in `.env`.

--- a/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
+++ b/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
@@ -2,16 +2,9 @@
 
 The OneRoster© service requires every request to
 `/ims/oneroster/rostering/v1p2/*` to present a valid OAuth 2.0 bearer
-token. The service does not issue tokens itself — it validates tokens
-issued by an external OAuth 2.0 authorization server, typically the Ed-Fi
-ODS/API's built-in OAuth endpoints.
-
-This page covers:
-
-- How the service locates and validates JWTs (JWKS vs PEM modes)
-- What claims it inspects (`iss`, `aud`, scope)
-- The three OneRoster© 1.2 scopes it recognizes
-- How OneRoster© clients are wired on the Ed-Fi ODS/API side
+token. The service does not issue tokens. It validates tokens issued
+by an external OAuth 2.0 authorization server, typically the Ed-Fi
+ODS / API's built-in OAuth endpoints.
 
 For the variable list, see [Environment
 variables](./environment-variables.md).
@@ -26,31 +19,32 @@ startup based on whether `OAUTH2_PUBLIC_KEY_PEM` is set.
 If `OAUTH2_PUBLIC_KEY_PEM` is empty, the service uses
 [`express-oauth2-jwt-bearer`](https://www.npmjs.com/package/express-oauth2-jwt-bearer)
 to fetch the authorization server's JWKS from
-`{OAUTH2_ISSUERBASEURL}/.well-known/jwks.json` and verify JWTs against it.
+`{OAUTH2_ISSUERBASEURL}/.well-known/jwks.json` and verify JWTs against
+it.
 
 Required variables:
 
-- `OAUTH2_ISSUERBASEURL` — base URL of the authorization server (for
-  example, your Ed-Fi ODS/API's OAuth endpoint)
-- `OAUTH2_AUDIENCE` — the expected `aud` claim
-- `OAUTH2_TOKENSIGNINGALG` — typically `RS256`
+- `OAUTH2_ISSUERBASEURL`. Base URL of the authorization server (for
+  example, your Ed-Fi ODS / API's OAuth endpoint).
+- `OAUTH2_AUDIENCE`. The expected `aud` claim.
+- `OAUTH2_TOKENSIGNINGALG`. Typically `RS256`.
 
-The JWKS is fetched and cached automatically; no additional configuration
-is required for key rotation beyond what the authorization server already
-supports.
+The JWKS is fetched and cached automatically. No additional
+configuration is required for key rotation beyond what the
+authorization server already supports.
 
 ### PEM mode
 
 If `OAUTH2_PUBLIC_KEY_PEM` is set, the service uses the
-[`jose`](https://github.com/panva/jose) library to verify JWT signatures
-against the PEM-encoded public key directly. JWKS discovery is not
-attempted.
+[`jose`](https://github.com/panva/jose) library to verify JWT
+signatures against the PEM-encoded public key directly. JWKS discovery
+is not attempted.
 
 Required variables (same as JWKS mode), plus:
 
-- `OAUTH2_PUBLIC_KEY_PEM` — the PEM public key, on a single line, with
+- `OAUTH2_PUBLIC_KEY_PEM`. The PEM public key on a single line, with
   `\n` between lines and including the `-----BEGIN/END PUBLIC KEY-----`
-  markers
+  markers.
 
 Example:
 
@@ -70,8 +64,8 @@ verifications.
 
 :::note
 
-If both modes appear configured (`OAUTH2_PUBLIC_KEY_PEM` set), PEM mode
-wins and JWKS is not consulted.
+If both modes appear configured (`OAUTH2_PUBLIC_KEY_PEM` is set), PEM
+mode wins and JWKS is not consulted.
 
 :::
 
@@ -87,7 +81,8 @@ validates:
 | `aud` | Must match `OAUTH2_AUDIENCE` |
 | `exp` | Must not be in the past |
 
-Tokens that fail any check return HTTP 401 with an IMS-formatted error:
+Tokens that fail any check return HTTP 401 with an IMS-formatted
+error:
 
 ```json
 {
@@ -97,7 +92,7 @@ Tokens that fail any check return HTTP 401 with an IMS-formatted error:
 }
 ```
 
-## OneRoster© 1.2 scopes
+## OneRoster© v1.2 scopes
 
 Tokens must present at least one of the following scopes (space- or
 comma-separated in the `scope` claim, per OAuth 2.0 conventions):
@@ -106,60 +101,61 @@ comma-separated in the `scope` claim, per OAuth 2.0 conventions):
 | --- | --- |
 | `roster-core.readonly` | `academicSessions`, `classes`, `courses`, `enrollments`, `orgs`, `schools`, `terms`, `gradingPeriods`, and the non-demographic fields of `users`, `students`, and `teachers` |
 | `roster-demographics.readonly` | The `/demographics` endpoint |
-| `roster.readonly` | All of the above — equivalent to both `roster-core.readonly` and `roster-demographics.readonly` |
+| `roster.readonly` | All of the above. Equivalent to both `roster-core.readonly` and `roster-demographics.readonly`. |
 
-These are the standard OneRoster© 1.2 rostering scopes defined in the
-[1EdTech OneRoster© 1.2 REST
+These are the standard OneRoster© v1.2 rostering scopes defined in the
+[1EdTech OneRoster© v1.2 REST
 specification](https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#OpenAPI_Security).
 
 Vendor applications should request the minimum scope their use case
-requires — `roster-core.readonly` is the correct default unless the app
+requires. `roster-core.readonly` is the correct default unless the app
 needs to read `/demographics`.
 
-## Integration with the Ed-Fi ODS/API
+## Integration with the Ed-Fi ODS / API
 
-Version 7.3 of the Ed-Fi ODS/API includes a `FeatureManagement:OneRoster`
-setting and supporting claim-set configuration that together enable the
-ODS/API's built-in OAuth endpoint to issue tokens bearing the OneRoster©
-scopes above. The ODS/API's token endpoint becomes the
-`OAUTH2_ISSUERBASEURL` the OneRoster© service points at; the Ed-Fi Web API
-signs the JWTs, and the OneRoster© service validates them via JWKS.
+Version 7.3 of the Ed-Fi ODS / API includes a
+`FeatureManagement:OneRoster` setting and supporting claim-set
+configuration that enable the ODS / API's built-in OAuth endpoint to
+issue tokens bearing the OneRoster© scopes above. The ODS / API's
+token endpoint becomes the `OAUTH2_ISSUERBASEURL` the OneRoster©
+service points at. The Ed-Fi Web API signs the JWTs, and the
+OneRoster© service validates them via JWKS.
 
-For the ODS/API-side configuration (enabling the feature, creating
-OneRoster© claim-set entries, issuing keys and secrets to vendor apps), see
-the ODS/API 7.3 platform developer guide's [Features
-reference](/reference/ods-api/platform-dev-guide/features/).
+For the ODS / API-side configuration (enabling the feature, creating
+OneRoster© claim-set entries, issuing keys and secrets to vendor
+apps), see the [Features
+reference](/reference/ods-api/platform-dev-guide/features/) in the
+ODS / API v7.3 platform developer guide.
 
 :::note
 
-**Open question — claim-set wiring.** Whether the OneRoster© scopes are
-granted automatically to claim sets when
-`FeatureManagement:OneRoster = true`, or whether an operator must
-manually edit `ClaimSet` / `ResourceClaim` rows, is defined on the
-ODS/API side and should be cross-referenced with the ODS/API 7.3
-integration how-to. This page will be updated to include a direct pointer
-once that documentation is live.
+**Open question: claim-set wiring.** Whether the OneRoster© scopes are
+granted automatically to claim sets when `FeatureManagement:OneRoster
+= true`, or whether an operator must manually edit `ClaimSet` or
+`ResourceClaim` rows, is defined on the ODS / API side. This page will
+be updated to include a direct pointer once that documentation is
+live.
 
 :::
 
-## Issuing tokens outside of the ODS/API
+## Issuing tokens outside of the ODS / API
 
-The OneRoster© service only validates JWTs — it will accept tokens from
+The OneRoster© service only validates JWTs. It will accept tokens from
 any OAuth 2.0 authorization server that:
 
-1. Signs with `OAUTH2_TOKENSIGNINGALG` (default `RS256`),
-2. Places `{OAUTH2_ISSUERBASEURL}` in the `iss` claim,
-3. Places `{OAUTH2_AUDIENCE}` in the `aud` claim, and
-4. Includes one of the three OneRoster© 1.2 scopes.
+1. Signs with `OAUTH2_TOKENSIGNINGALG` (default `RS256`).
+2. Places `{OAUTH2_ISSUERBASEURL}` in the `iss` claim.
+3. Places `{OAUTH2_AUDIENCE}` in the `aud` claim.
+4. Includes one of the three OneRoster© v1.2 scopes.
 
-This makes it straightforward to bridge to Auth0, Keycloak, Azure AD, or
-any other OIDC-compatible IdP for deployments that prefer a dedicated
-identity provider for OneRoster© clients.
+This enables bridging to Auth0, Keycloak, Azure AD, or any other
+OIDC-compatible identity provider for deployments that prefer a
+dedicated identity provider for OneRoster© clients.
 
 ## Quick verification
 
-Once the service is running and an issuer is configured, obtain a token
-from the issuer and call the service:
+Once the service is running and an issuer is configured, obtain a
+token from the issuer and call the service:
 
 ```bash
 # Replace <issuer-token-endpoint>, <client_id>, <client_secret>
@@ -175,7 +171,7 @@ curl -i http://localhost:3000/ims/oneroster/rostering/v1p2/orgs \
   -H "Authorization: Bearer <access_token>"
 ```
 
-401 responses with an `imsx_description` of "Authentication failed" on
-valid-looking requests usually indicate an `iss` / `aud` mismatch or a
-missing OneRoster© scope; check the decoded token at
+A 401 response with `"imsx_description": "Authentication failed"` on a
+valid-looking request usually indicates an `iss` or `aud` mismatch or
+a missing OneRoster© scope. Check the decoded token at
 [jwt.io](https://jwt.io) against the values in `.env`.

--- a/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
+++ b/docs/reference/11-oneroster/configuration/oauth-and-jwt.md
@@ -1,6 +1,6 @@
 # OAuth and JWT
 
-The OneRoster service requires every request to
+The OneRoster© service requires every request to
 `/ims/oneroster/rostering/v1p2/*` to present a valid OAuth 2.0 bearer
 token. The service does not issue tokens itself — it validates tokens
 issued by an external OAuth 2.0 authorization server, typically the Ed-Fi
@@ -10,8 +10,8 @@ This page covers:
 
 - How the service locates and validates JWTs (JWKS vs PEM modes)
 - What claims it inspects (`iss`, `aud`, scope)
-- The three OneRoster 1.2 scopes it recognizes
-- How OneRoster clients are wired on the Ed-Fi ODS/API side
+- The three OneRoster© 1.2 scopes it recognizes
+- How OneRoster© clients are wired on the Ed-Fi ODS/API side
 
 For the variable list, see [Environment
 variables](./environment-variables.md).
@@ -97,7 +97,7 @@ Tokens that fail any check return HTTP 401 with an IMS-formatted error:
 }
 ```
 
-## OneRoster 1.2 scopes
+## OneRoster© 1.2 scopes
 
 Tokens must present at least one of the following scopes (space- or
 comma-separated in the `scope` claim, per OAuth 2.0 conventions):
@@ -108,8 +108,8 @@ comma-separated in the `scope` claim, per OAuth 2.0 conventions):
 | `roster-demographics.readonly` | The `/demographics` endpoint |
 | `roster.readonly` | All of the above — equivalent to both `roster-core.readonly` and `roster-demographics.readonly` |
 
-These are the standard OneRoster 1.2 rostering scopes defined in the
-[1EdTech OneRoster 1.2 REST
+These are the standard OneRoster© 1.2 rostering scopes defined in the
+[1EdTech OneRoster© 1.2 REST
 specification](https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#OpenAPI_Security).
 
 Vendor applications should request the minimum scope their use case
@@ -120,19 +120,19 @@ needs to read `/demographics`.
 
 Version 7.3 of the Ed-Fi ODS/API includes a `FeatureManagement:OneRoster`
 setting and supporting claim-set configuration that together enable the
-ODS/API's built-in OAuth endpoint to issue tokens bearing the OneRoster
+ODS/API's built-in OAuth endpoint to issue tokens bearing the OneRoster©
 scopes above. The ODS/API's token endpoint becomes the
-`OAUTH2_ISSUERBASEURL` the OneRoster service points at; the Ed-Fi Web API
-signs the JWTs, and the OneRoster service validates them via JWKS.
+`OAUTH2_ISSUERBASEURL` the OneRoster© service points at; the Ed-Fi Web API
+signs the JWTs, and the OneRoster© service validates them via JWKS.
 
 For the ODS/API-side configuration (enabling the feature, creating
-OneRoster claim-set entries, issuing keys and secrets to vendor apps), see
+OneRoster© claim-set entries, issuing keys and secrets to vendor apps), see
 the ODS/API 7.3 platform developer guide's [Features
 reference](/reference/ods-api/platform-dev-guide/features/).
 
 :::note
 
-**Open question — claim-set wiring.** Whether the OneRoster scopes are
+**Open question — claim-set wiring.** Whether the OneRoster© scopes are
 granted automatically to claim sets when
 `FeatureManagement:OneRoster = true`, or whether an operator must
 manually edit `ClaimSet` / `ResourceClaim` rows, is defined on the
@@ -144,17 +144,17 @@ once that documentation is live.
 
 ## Issuing tokens outside of the ODS/API
 
-The OneRoster service only validates JWTs — it will accept tokens from
+The OneRoster© service only validates JWTs — it will accept tokens from
 any OAuth 2.0 authorization server that:
 
 1. Signs with `OAUTH2_TOKENSIGNINGALG` (default `RS256`),
 2. Places `{OAUTH2_ISSUERBASEURL}` in the `iss` claim,
 3. Places `{OAUTH2_AUDIENCE}` in the `aud` claim, and
-4. Includes one of the three OneRoster 1.2 scopes.
+4. Includes one of the three OneRoster© 1.2 scopes.
 
 This makes it straightforward to bridge to Auth0, Keycloak, Azure AD, or
 any other OIDC-compatible IdP for deployments that prefer a dedicated
-identity provider for OneRoster clients.
+identity provider for OneRoster© clients.
 
 ## Quick verification
 
@@ -177,5 +177,5 @@ curl -i http://localhost:3000/ims/oneroster/rostering/v1p2/orgs \
 
 401 responses with an `imsx_description` of "Authentication failed" on
 valid-looking requests usually indicate an `iss` / `aud` mismatch or a
-missing OneRoster scope; check the decoded token at
+missing OneRoster© scope; check the decoded token at
 [jwt.io](https://jwt.io) against the values in `.env`.

--- a/docs/reference/11-oneroster/configuration/readme.mdx
+++ b/docs/reference/11-oneroster/configuration/readme.mdx
@@ -2,7 +2,7 @@ import DocCardList from '@theme/DocCardList';
 
 # Configuration
 
-The Ed-Fi OneRoster Node service is configured through environment
+The Ed-Fi OneRoster© Node service is configured through environment
 variables (consumed by the process via `.env` or the hosting environment).
 This section is the authoritative reference for every knob:
 
@@ -10,7 +10,7 @@ This section is the authoritative reference for every knob:
   supported variables grouped by concern (database, OAuth, CORS, rate
   limiting, scheduling)
 - [OAuth and JWT](./oauth-and-jwt.md) — token issuance modes, JWKS vs
-  PEM-based verification, OneRoster 1.2 scope expectations, and how the
+  PEM-based verification, OneRoster© 1.2 scope expectations, and how the
   service integrates with the Ed-Fi ODS/API token issuer
 - [CORS, rate limiting, and proxy](./cors-rate-limit-proxy.md) — origin
   allowlisting, request rate limits, and trust-proxy behavior when the

--- a/docs/reference/11-oneroster/configuration/readme.mdx
+++ b/docs/reference/11-oneroster/configuration/readme.mdx
@@ -1,0 +1,23 @@
+import DocCardList from '@theme/DocCardList';
+
+# Configuration
+
+The Ed-Fi OneRoster Node service is configured through environment
+variables (consumed by the process via `.env` or the hosting environment).
+This section is the authoritative reference for every knob:
+
+- [Environment variables](./environment-variables.md) — full table of
+  supported variables grouped by concern (database, OAuth, CORS, rate
+  limiting, scheduling)
+- [OAuth and JWT](./oauth-and-jwt.md) — token issuance modes, JWKS vs
+  PEM-based verification, OneRoster 1.2 scope expectations, and how the
+  service integrates with the Ed-Fi ODS/API token issuer
+- [CORS, rate limiting, and proxy](./cors-rate-limit-proxy.md) — origin
+  allowlisting, request rate limits, and trust-proxy behavior when the
+  service runs behind IIS / NGINX / other reverse proxies
+
+Deployment-specific setup steps are covered under [Getting
+Started](../getting-started/readme.mdx). This section assumes the service
+is already installed and focuses on runtime configuration.
+
+<DocCardList />

--- a/docs/reference/11-oneroster/configuration/readme.mdx
+++ b/docs/reference/11-oneroster/configuration/readme.mdx
@@ -3,21 +3,20 @@ import DocCardList from '@theme/DocCardList';
 # Configuration
 
 The Ed-Fi OneRoster© Node service is configured through environment
-variables (consumed by the process via `.env` or the hosting environment).
-This section is the authoritative reference for every knob:
+variables, supplied via `.env` or the hosting environment. This section
+documents the supported variables and their runtime behavior.
 
-- [Environment variables](./environment-variables.md) — full table of
+- [Environment variables](./environment-variables.md). Full table of
   supported variables grouped by concern (database, OAuth, CORS, rate
-  limiting, scheduling)
-- [OAuth and JWT](./oauth-and-jwt.md) — token issuance modes, JWKS vs
-  PEM-based verification, OneRoster© 1.2 scope expectations, and how the
-  service integrates with the Ed-Fi ODS/API token issuer
-- [CORS, rate limiting, and proxy](./cors-rate-limit-proxy.md) — origin
+  limiting, scheduling).
+- [OAuth and JWT](./oauth-and-jwt.md). Token validation modes, JWKS
+  versus PEM-based verification, OneRoster© v1.2 scope expectations,
+  and integration with the Ed-Fi ODS / API token issuer.
+- [CORS, rate limiting, and proxy](./cors-rate-limit-proxy.md). Origin
   allowlisting, request rate limits, and trust-proxy behavior when the
-  service runs behind IIS / NGINX / other reverse proxies
+  service runs behind IIS, NGINX, or another reverse proxy.
 
 Deployment-specific setup steps are covered under [Getting
-Started](../getting-started/readme.mdx). This section assumes the service
-is already installed and focuses on runtime configuration.
+Started](../getting-started/readme.mdx).
 
 <DocCardList />

--- a/docs/reference/11-oneroster/configuration/readme.mdx
+++ b/docs/reference/11-oneroster/configuration/readme.mdx
@@ -2,7 +2,7 @@ import DocCardList from '@theme/DocCardList';
 
 # Configuration
 
-The Ed-Fi OneRoster© Node service is configured through environment
+The Ed-Fi OneRoster® Node service is configured through environment
 variables, supplied via `.env` or the hosting environment. This section
 documents the supported variables and their runtime behavior.
 
@@ -10,7 +10,7 @@ documents the supported variables and their runtime behavior.
   supported variables grouped by concern (database, OAuth, CORS, rate
   limiting, scheduling).
 - [OAuth and JWT](./oauth-and-jwt.md). Token validation modes, JWKS
-  versus PEM-based verification, OneRoster© v1.2 scope expectations,
+  versus PEM-based verification, OneRoster v1.2 scope expectations,
   and integration with the Ed-Fi ODS / API token issuer.
 - [CORS, rate limiting, and proxy](./cors-rate-limit-proxy.md). Origin
   allowlisting, request rate limits, and trust-proxy behavior when the

--- a/docs/reference/11-oneroster/data-model/_category_.json
+++ b/docs/reference/11-oneroster/data-model/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Data Model",
+  "position": 3
+}

--- a/docs/reference/11-oneroster/data-model/descriptor-mappings.md
+++ b/docs/reference/11-oneroster/data-model/descriptor-mappings.md
@@ -39,7 +39,7 @@ Used by `academic_sessions.sql` to decide which Ed-Fi calendar dates count as
 school days when computing the school-year start and end dates.
 
 | Ed-Fi value | Mapped value | Contributes to school year? |
-|---|---|---|
+| --- | --- | --- |
 | `Emergency day` | `FALSE` | No |
 | `Holiday` | `FALSE` | No |
 | `Instructional day` | `TRUE` | Yes |
@@ -57,7 +57,7 @@ Populates the `type` field on academic session records derived from
 `edfi.session`.
 
 | Ed-Fi value | OneRoster `type` |
-|---|---|
+| --- | --- |
 | `Semester`, `Fall Semester`, `Spring Semester`, `Summer Semester` | `semester` |
 | `Quarter`, `First Quarter`, `Second Quarter`, `Third Quarter`, `Fourth Quarter` | `term` |
 | `MiniTerm` | `term` |
@@ -70,7 +70,7 @@ Populates the `type` field on academic session records derived from
 Populates the `sex` field on `/demographics` records.
 
 | Ed-Fi value | OneRoster `sex` |
-|---|---|
+| --- | --- |
 | `Female` | `female` |
 | `Male` | `male` |
 | `Non-binary` | `other` |
@@ -84,7 +84,7 @@ Populates the five race-flag fields
 `demographicRaceTwoOrMoreRaces` on `/demographics` records.
 
 | Ed-Fi value | OneRoster value |
-|---|---|
+| --- | --- |
 | `American Indian or Alaska Native` | `americanIndianOrAlaskaNative` |
 | `Asian` | `asian` |
 | `Black or African American` | `blackOrAfricanAmerican` |
@@ -100,7 +100,7 @@ Populates the `role` field on staff `/users` records. Twenty-five Ed-Fi
 values ship mapped; the most commonly used are:
 
 | Ed-Fi value (selection) | OneRoster `role` |
-|---|---|
+| --- | --- |
 | `Teacher`, `Elementary Teacher`, `Secondary Teacher`, `Substitute Teacher`, `Instructional Coordinator`, `Ungraded Teacher`, `Pre-Kindergarten Teacher`, `Kindergarten Teacher` | `teacher` |
 | `Paraprofessional/Instructional Aide`, `Instructional Aide` | `aide` |
 | `Counselor`, `School Counselor`, `Elementary School Counselor`, `Secondary School Counselor` | `counselor` |
@@ -143,7 +143,7 @@ unmapped values differently, and implementers should be aware of the
 differences:
 
 | Descriptor | Join style | Unmapped behavior |
-|---|---|---|
+| --- | --- | --- |
 | `CalendarEventDescriptor` | Inner join + `WHERE mappedvalue = 'TRUE'` | Unmapped calendar-event values are not counted as school days. School-year start/end dates are computed from only mapped-TRUE events. |
 | `TermDescriptor` | Inner join | **The entire session is dropped from `/academicSessions`.** Any `edfi.session` whose `TermDescriptor` is unmapped will not appear in OneRoster output. |
 | `SexDescriptor` | Left join | `sex` is emitted as `null` on `/demographics`. The student is still returned. |
@@ -242,7 +242,7 @@ the new mapping takes effect:
   `EXEC oneroster12.sp_refresh_<table_name>;`
   (or `EXEC oneroster12.sp_refresh_all;` to refresh everything)
 
-See [Configuration](../configuration/readme.md) for the scheduled refresh
+See [Configuration](../configuration/readme.mdx) for the scheduled refresh
 cadence.
 
 ## Known unmapped Ed-Fi `StaffClassificationDescriptor` values

--- a/docs/reference/11-oneroster/data-model/descriptor-mappings.md
+++ b/docs/reference/11-oneroster/data-model/descriptor-mappings.md
@@ -1,14 +1,14 @@
 # Descriptor Mappings
 
-Several OneRoster© fields are produced by translating Ed-Fi descriptor
-values (for example, `SexDescriptor.Female`) into OneRoster© enumeration
+Several OneRoster® fields are produced by translating Ed-Fi descriptor
+values (for example, `SexDescriptor.Female`) into OneRoster enumeration
 values (`sex = 'female'`). The translation uses rows in
-`edfi.descriptormapping` that are seeded when the OneRoster© SQL artifacts
+`edfi.descriptormapping` that are seeded when the OneRoster SQL artifacts
 are deployed. Implementations can extend the mapping with their own
 `INSERT` statements.
 
 This page lists the six shipped descriptor mappings, documents what each
-mapping produces in OneRoster© output, describes what happens to Ed-Fi
+mapping produces in OneRoster output, describes what happens to Ed-Fi
 descriptor values that are not in the mapping, and shows the `INSERT`
 template for extending a mapping.
 
@@ -16,11 +16,11 @@ template for extending a mapping.
 
 Two SQL files define the shipped mappings:
 
-- `01_descriptors.sql` inserts the OneRoster©-namespaced descriptor rows
+- `01_descriptors.sql` inserts the OneRoster-namespaced descriptor rows
   (for example, `uri://1edtech.org/oneroster12/SexDescriptor / female`)
   into `edfi.descriptor` so that `edfi.descriptormapping` can reference
   them on the mapped side.
-- `02_descriptorMappings.sql` inserts the Ed-Fi-to-OneRoster© mapping rows
+- `02_descriptorMappings.sql` inserts the Ed-Fi-to-OneRoster mapping rows
   into `edfi.descriptormapping`.
 
 Both files live under
@@ -32,7 +32,7 @@ both.
 
 Each shipped mapping uses a `mappedNamespace` of
 `uri://1edtech.org/oneroster12/{Descriptor}`. The tables below list the
-Ed-Fi value to OneRoster© value pairs and the OneRoster© field each
+Ed-Fi value to OneRoster value pairs and the OneRoster field each
 mapping populates.
 
 ### `CalendarEventDescriptor` (10 shipped entries)
@@ -58,7 +58,7 @@ as school days when computing the school-year start and end dates.
 Populates the `type` field on academic-session records derived from
 `edfi.session`.
 
-| Ed-Fi value | OneRoster© `type` |
+| Ed-Fi value | OneRoster `type` |
 | --- | --- |
 | `Semester`, `Fall Semester`, `Spring Semester`, `Summer Semester` | `semester` |
 | `Quarter`, `First Quarter`, `Second Quarter`, `Third Quarter`, `Fourth Quarter` | `term` |
@@ -71,7 +71,7 @@ Populates the `type` field on academic-session records derived from
 
 Populates the `sex` field on `/demographics` records.
 
-| Ed-Fi value | OneRoster© `sex` |
+| Ed-Fi value | OneRoster `sex` |
 | --- | --- |
 | `Female` | `female` |
 | `Male` | `male` |
@@ -85,7 +85,7 @@ Populates the five race-flag fields on `/demographics` records
 `nativeHawaiianOrOtherPacificIslander`, `white`) and the derived
 `demographicRaceTwoOrMoreRaces` boolean.
 
-| Ed-Fi value | OneRoster© value |
+| Ed-Fi value | OneRoster value |
 | --- | --- |
 | `American Indian or Alaska Native` | `americanIndianOrAlaskaNative` |
 | `Asian` | `asian` |
@@ -102,7 +102,7 @@ Populates the `role` field on staff `/users` records. The most commonly
 used entries are grouped below. The full list is in
 `02_descriptorMappings.sql`.
 
-| Ed-Fi value | OneRoster© `role` |
+| Ed-Fi value | OneRoster `role` |
 | --- | --- |
 | `Teacher`, `Elementary Teacher`, `Secondary Teacher`, `Substitute Teacher`, `Instructional Coordinator`, `Ungraded Teacher`, `Pre-Kindergarten Teacher`, `Kindergarten Teacher` | `teacher` |
 | `Paraprofessional/Instructional Aide`, `Instructional Aide` | `aide` |
@@ -128,14 +128,14 @@ staff-section associations and does not read this mapping.
 
 Until the enrollments view is updated to consume the mapping, extending
 or customizing `ClassroomPositionDescriptor` entries has no effect on
-OneRoster© output.
+OneRoster output.
 
 :::
 
 ## Behavior for unmapped values
 
 An _unmapped_ descriptor is an Ed-Fi descriptor value that has no row in
-`edfi.descriptormapping` whose `mappednamespace` is the OneRoster© v1.2
+`edfi.descriptormapping` whose `mappednamespace` is the OneRoster v1.2
 namespace for that descriptor. This includes Ed-Fi values that ship
 unmapped and locally-added descriptor values that a deployment has not
 mapped itself.
@@ -146,7 +146,7 @@ unmapped values differently:
 | Descriptor | Join style in the view | Unmapped behavior |
 | --- | --- | --- |
 | `CalendarEventDescriptor` | Inner join with `WHERE mappedvalue = 'TRUE'` | Unmapped calendar-event values are not counted as school days. School-year start and end dates are computed only from mapped-`TRUE` events. |
-| `TermDescriptor` | Inner join | **The entire session is dropped from `/academicSessions`.** Any `edfi.session` whose `TermDescriptor` is unmapped will not appear in OneRoster© output. |
+| `TermDescriptor` | Inner join | **The entire session is dropped from `/academicSessions`.** Any `edfi.session` whose `TermDescriptor` is unmapped will not appear in OneRoster output. |
 | `SexDescriptor` | Left join | `sex` is emitted as `null` on `/demographics`. The student is still returned. |
 | `RaceDescriptor` | Left join plus `array_remove(..., null)` | Unmapped race values are dropped from the student's race array. If all of a student's race values are unmapped, every race boolean is `'false'` and `demographicRaceTwoOrMoreRaces = 'false'`. The student is still returned. |
 | `StaffClassificationDescriptor` | Left join plus `coalesce(..., 'teacher')` when the staff member has any `staffSectionAssociation` | If the staff member has any section assignment, their role defaults to `'teacher'` when unmapped. If they have no section assignment and no mapped classification, **they are filtered out of `/users`**. |
@@ -159,7 +159,7 @@ The two high-impact cases are `TermDescriptor` and
 
 - Custom `TermDescriptor` values (for example, district-specific term
   names) require a descriptor mapping or the corresponding sessions will
-  not appear in OneRoster© output.
+  not appear in OneRoster output.
 - A principal or counselor with a non-shipped local classification and no
   section assignments will not appear in `/users` until the descriptor is
   mapped.
@@ -169,7 +169,7 @@ The two high-impact cases are `TermDescriptor` and
 ## Extending a mapping
 
 Additional mappings are added by inserting rows into
-`edfi.descriptormapping`. Use the OneRoster© v1.2 namespace for
+`edfi.descriptormapping`. Use the OneRoster v1.2 namespace for
 `mappednamespace` and the same `mappedvalue` as one of the shipped rows
 for that descriptor so the view's downstream logic continues to work.
 
@@ -234,7 +234,7 @@ ON CONFLICT DO NOTHING;
 
 ### Applying changes
 
-After inserting new `descriptormapping` rows, refresh the OneRoster©
+After inserting new `descriptormapping` rows, refresh the OneRoster
 views so the new mapping takes effect.
 
 On PostgreSQL, run the refresh via pg-boss, or manually:
@@ -274,5 +274,5 @@ that file:
 - `Support Services Staff`
 
 Deployments that use any of these values should add their own mapping
-rows, pointing at the OneRoster© role that best fits their deployment's
+rows, pointing at the OneRoster role that best fits their deployment's
 conventions (commonly `teacher`, `aide`, or `siteAdministrator`).

--- a/docs/reference/11-oneroster/data-model/descriptor-mappings.md
+++ b/docs/reference/11-oneroster/data-model/descriptor-mappings.md
@@ -1,42 +1,44 @@
 # Descriptor Mappings
 
-Several OneRoster© fields are produced by translating Ed-Fi descriptor values
-(for example, `SexDescriptor.Female`) into OneRoster© enumeration values
-(`sex = 'female'`). The translation is done entirely through rows in
-`edfi.descriptormapping`, which are seeded when OneRoster© SQL artifacts are
-deployed and can be extended per implementation.
+Several OneRoster© fields are produced by translating Ed-Fi descriptor
+values (for example, `SexDescriptor.Female`) into OneRoster© enumeration
+values (`sex = 'female'`). The translation uses rows in
+`edfi.descriptormapping` that are seeded when the OneRoster© SQL artifacts
+are deployed. Implementations can extend the mapping with their own
+`INSERT` statements.
 
-This page lists the six shipped descriptor mappings, documents the behavior
-each mapping produces in the OneRoster© output, describes what happens to
-Ed-Fi descriptor values that are _not_ in the mapping, and provides an
-INSERT template for adding custom entries.
+This page lists the six shipped descriptor mappings, documents what each
+mapping produces in OneRoster© output, describes what happens to Ed-Fi
+descriptor values that are not in the mapping, and shows the `INSERT`
+template for extending a mapping.
 
 ## Where descriptor mappings live
 
 Two SQL files define the shipped mappings:
 
-- `01_descriptors.sql` — inserts the OneRoster©-namespaced descriptor rows
-  (for example, `uri://1edtech.org/oneroster12/SexDescriptor / female`) into
-  `edfi.descriptor` so that `edfi.descriptormapping` can reference them as
-  the _mapped_ side.
-- `02_descriptorMappings.sql` — inserts the Ed-Fi-namespaced-to-OneRoster©
-  mapping rows into `edfi.descriptormapping`.
+- `01_descriptors.sql` inserts the OneRoster©-namespaced descriptor rows
+  (for example, `uri://1edtech.org/oneroster12/SexDescriptor / female`)
+  into `edfi.descriptor` so that `edfi.descriptormapping` can reference
+  them on the mapped side.
+- `02_descriptorMappings.sql` inserts the Ed-Fi-to-OneRoster© mapping rows
+  into `edfi.descriptormapping`.
 
 Both files live under
-`standard/{dataStandardVersion}/artifacts/{pgsql,mssql}/core/`. Running the
-deployment script (`deploy-postgres.sh` / `deploy-mssql.js`) executes both.
+`standard/{dataStandardVersion}/artifacts/{pgsql,mssql}/core/`. Running
+the deployment script (`deploy-postgres.sh` or `deploy-mssql.js`) executes
+both.
 
 ## Shipped mappings
 
-Each shipped mapping has a `mappedNamespace` of
+Each shipped mapping uses a `mappedNamespace` of
 `uri://1edtech.org/oneroster12/{Descriptor}`. The tables below list the
-exact Ed-Fi value → OneRoster© value pairs and the OneRoster© field each
+Ed-Fi value to OneRoster© value pairs and the OneRoster© field each
 mapping populates.
 
-### `CalendarEventDescriptor` → instructional-day flag
+### `CalendarEventDescriptor` (10 shipped entries)
 
-Used by `academic_sessions.sql` to decide which Ed-Fi calendar dates count as
-school days when computing the school-year start and end dates.
+Used by `academic_sessions.sql` to decide which Ed-Fi calendar dates count
+as school days when computing the school-year start and end dates.
 
 | Ed-Fi value | Mapped value | Contributes to school year? |
 | --- | --- | --- |
@@ -51,9 +53,9 @@ school days when computing the school-year start and end dates.
 | `Teacher only day` | `FALSE` | No |
 | `Weather day` | `FALSE` | No |
 
-### `TermDescriptor` → OneRoster© `academicSession.type`
+### `TermDescriptor` (16 shipped entries)
 
-Populates the `type` field on academic session records derived from
+Populates the `type` field on academic-session records derived from
 `edfi.session`.
 
 | Ed-Fi value | OneRoster© `type` |
@@ -65,7 +67,7 @@ Populates the `type` field on academic session records derived from
 | `Trimester`, `First Trimester`, `Second Trimester`, `Third Trimester` | `gradingPeriod` |
 | `Year Round` | `schoolYear` |
 
-### `SexDescriptor` → OneRoster© `demographics.sex`
+### `SexDescriptor` (4 shipped entries)
 
 Populates the `sex` field on `/demographics` records.
 
@@ -76,12 +78,12 @@ Populates the `sex` field on `/demographics` records.
 | `Non-binary` | `other` |
 | `Not Selected` | `unspecified` |
 
-### `RaceDescriptor` → OneRoster© race booleans
+### `RaceDescriptor` (5 shipped entries)
 
-Populates the five race-flag fields
+Populates the five race-flag fields on `/demographics` records
 (`americanIndianOrAlaskaNative`, `asian`, `blackOrAfricanAmerican`,
-`nativeHawaiianOrOtherPacificIslander`, `white`) and
-`demographicRaceTwoOrMoreRaces` on `/demographics` records.
+`nativeHawaiianOrOtherPacificIslander`, `white`) and the derived
+`demographicRaceTwoOrMoreRaces` boolean.
 
 | Ed-Fi value | OneRoster© value |
 | --- | --- |
@@ -94,12 +96,13 @@ Populates the five race-flag fields
 A student associated with two or more _mapped_ race values gets
 `demographicRaceTwoOrMoreRaces = 'true'`.
 
-### `StaffClassificationDescriptor` → OneRoster© `user.role`
+### `StaffClassificationDescriptor` (25 shipped entries)
 
-Populates the `role` field on staff `/users` records. Twenty-five Ed-Fi
-values ship mapped; the most commonly used are:
+Populates the `role` field on staff `/users` records. The most commonly
+used entries are grouped below. The full list is in
+`02_descriptorMappings.sql`.
 
-| Ed-Fi value (selection) | OneRoster© `role` |
+| Ed-Fi value | OneRoster© `role` |
 | --- | --- |
 | `Teacher`, `Elementary Teacher`, `Secondary Teacher`, `Substitute Teacher`, `Instructional Coordinator`, `Ungraded Teacher`, `Pre-Kindergarten Teacher`, `Kindergarten Teacher` | `teacher` |
 | `Paraprofessional/Instructional Aide`, `Instructional Aide` | `aide` |
@@ -108,87 +111,85 @@ values ship mapped; the most commonly used are:
 | `School Administrator`, `School Administrative Support Staff`, `School Leader` | `siteAdministrator` |
 | `LEA Administrator`, `LEA Administrative Support Staff`, `LEA System Administrator`, `Superintendent`, `Assistant Superintendent`, `State Administrator` | `districtAdministrator` |
 
-The full list is in `02_descriptorMappings.sql`. Several Ed-Fi staff
-classifications are _deliberately unmapped_ because 1EdTech does not define
-a corresponding OneRoster© role — see _Unmapped values_ below.
+Several Ed-Fi staff classifications are left unmapped in the shipped SQL.
+See _Known unmapped Ed-Fi StaffClassificationDescriptor values_ below.
 
-### `ClassroomPositionDescriptor` → OneRoster© `enrollment.primary`
+### `ClassroomPositionDescriptor` (4 shipped entries)
 
 :::warning
 
 **Shipped but not consumed in the current release.** `01_descriptors.sql`
-and `02_descriptorMappings.sql` seed a `ClassroomPositionDescriptor` mapping
-(`Teacher of Record` → `TRUE`, all others → `FALSE`) so that the service
-can later flag a primary teacher on each staff enrollment. The current
-`enrollments.sql` view hardcodes `role = 'teacher'` and `primary = 'false'`
-for all staff-section associations and does not read this mapping.
+and `02_descriptorMappings.sql` seed a `ClassroomPositionDescriptor`
+mapping (`Teacher of Record` maps to `TRUE`, the three other shipped
+values map to `FALSE`) so that the service can later flag a primary
+teacher on each staff enrollment. The current `enrollments.sql` view
+hardcodes `role = 'teacher'` and `primary = 'false'` for all
+staff-section associations and does not read this mapping.
 
-Until the enrollments view is updated to consume the mapping, extending or
-customizing `ClassroomPositionDescriptor` entries has no effect on
+Until the enrollments view is updated to consume the mapping, extending
+or customizing `ClassroomPositionDescriptor` entries has no effect on
 OneRoster© output.
 
 :::
 
 ## Behavior for unmapped values
 
-An _unmapped_ descriptor is an Ed-Fi descriptor value that either:
+An _unmapped_ descriptor is an Ed-Fi descriptor value that has no row in
+`edfi.descriptormapping` whose `mappednamespace` is the OneRoster© v1.2
+namespace for that descriptor. This includes Ed-Fi values that ship
+unmapped and locally-added descriptor values that a deployment has not
+mapped itself.
 
-- Has no row in `edfi.descriptormapping` whose `mappednamespace` is the
-  OneRoster© 1.2 namespace for that descriptor, or
-- Is a locally-added Ed-Fi descriptor value that a deployment has not
-  explicitly mapped.
+The behavior is not uniform across descriptors. Each view handles
+unmapped values differently:
 
-The service does not have a single answer here — each view handles
-unmapped values differently, and implementers should be aware of the
-differences:
-
-| Descriptor | Join style | Unmapped behavior |
+| Descriptor | Join style in the view | Unmapped behavior |
 | --- | --- | --- |
-| `CalendarEventDescriptor` | Inner join + `WHERE mappedvalue = 'TRUE'` | Unmapped calendar-event values are not counted as school days. School-year start/end dates are computed from only mapped-TRUE events. |
+| `CalendarEventDescriptor` | Inner join with `WHERE mappedvalue = 'TRUE'` | Unmapped calendar-event values are not counted as school days. School-year start and end dates are computed only from mapped-`TRUE` events. |
 | `TermDescriptor` | Inner join | **The entire session is dropped from `/academicSessions`.** Any `edfi.session` whose `TermDescriptor` is unmapped will not appear in OneRoster© output. |
 | `SexDescriptor` | Left join | `sex` is emitted as `null` on `/demographics`. The student is still returned. |
-| `RaceDescriptor` | Left join + `array_remove(..., null)` | Unmapped race values are silently dropped from the student's race array. If _all_ of a student's race values are unmapped, every race boolean is `'false'` and `demographicRaceTwoOrMoreRaces = 'false'`. The student is still returned. |
-| `StaffClassificationDescriptor` | Left join + `coalesce(..., 'teacher')` when staff has any section assignment | If the staff member has _any_ `edfi.staffSectionAssociation`, their role defaults to `'teacher'` when unmapped. If they have no section assignment _and_ no mapped classification, **they are filtered out of `/users`** entirely. |
-| `ClassroomPositionDescriptor` | Not consumed | No effect (see warning above). |
+| `RaceDescriptor` | Left join plus `array_remove(..., null)` | Unmapped race values are dropped from the student's race array. If all of a student's race values are unmapped, every race boolean is `'false'` and `demographicRaceTwoOrMoreRaces = 'false'`. The student is still returned. |
+| `StaffClassificationDescriptor` | Left join plus `coalesce(..., 'teacher')` when the staff member has any `staffSectionAssociation` | If the staff member has any section assignment, their role defaults to `'teacher'` when unmapped. If they have no section assignment and no mapped classification, **they are filtered out of `/users`**. |
+| `ClassroomPositionDescriptor` | Not consumed | No effect. See the warning above. |
 
 :::warning
 
-The two high-impact cases are `TermDescriptor` and `StaffClassificationDescriptor`:
+The two high-impact cases are `TermDescriptor` and
+`StaffClassificationDescriptor`:
 
-- Custom `TermDescriptor` values (for example, district-specific term names)
-  require a descriptor mapping or the corresponding sessions will be invisible
-  to OneRoster© clients.
-- Staff with an unmapped `StaffClassificationDescriptor` who do not teach
-  sections are filtered out. A principal or counselor with a non-shipped
-  local classification and no section assignments will not appear in
-  `/users` until the descriptor is mapped.
+- Custom `TermDescriptor` values (for example, district-specific term
+  names) require a descriptor mapping or the corresponding sessions will
+  not appear in OneRoster© output.
+- A principal or counselor with a non-shipped local classification and no
+  section assignments will not appear in `/users` until the descriptor is
+  mapped.
 
 :::
 
 ## Extending a mapping
 
-Additional mappings are added by inserting rows into `edfi.descriptormapping`.
-Use the OneRoster© 1.2 namespace for the `mappednamespace` and the same
-`mappedvalue` as one of the shipped rows for that descriptor so the view's
-downstream logic keeps working.
+Additional mappings are added by inserting rows into
+`edfi.descriptormapping`. Use the OneRoster© v1.2 namespace for
+`mappednamespace` and the same `mappedvalue` as one of the shipped rows
+for that descriptor so the view's downstream logic continues to work.
 
-### Generic INSERT template
+### Generic `INSERT` template
 
 ```sql
 INSERT INTO edfi.descriptormapping
-    (namespace,                     value,                  mappednamespace,                                 mappedvalue, discriminator)
+    (namespace,             value,           mappednamespace,                                 mappedvalue,         discriminator)
 VALUES
-    ('<ed-fi namespace>',         '<ed-fi value>',         'uri://1edtech.org/oneroster12/<Descriptor>',   '<oneroster value>', 'edfi.<Descriptor>')
+    ('<ed-fi namespace>',   '<ed-fi value>', 'uri://1edtech.org/oneroster12/<Descriptor>',    '<oneroster value>', 'edfi.<Descriptor>')
 ON CONFLICT DO NOTHING;
 ```
 
-For Microsoft SQL Server, replace `ON CONFLICT DO NOTHING` with an
-`IF NOT EXISTS` guard or a MERGE statement.
+On Microsoft SQL Server, replace `ON CONFLICT DO NOTHING` with an
+`IF NOT EXISTS` guard or a `MERGE` statement.
 
 ### Worked examples
 
-Adding a custom state-defined `StaffClassificationDescriptor` value
-`Intervention Specialist` as an aide:
+Map a custom state-defined `StaffClassificationDescriptor` value
+`Intervention Specialist` to `aide`:
 
 ```sql
 INSERT INTO edfi.descriptormapping
@@ -202,7 +203,7 @@ VALUES
 ON CONFLICT DO NOTHING;
 ```
 
-Adding a custom `TermDescriptor` value `Intersession` as a term:
+Map a custom `TermDescriptor` value `Intersession` to `term`:
 
 ```sql
 INSERT INTO edfi.descriptormapping
@@ -216,7 +217,7 @@ VALUES
 ON CONFLICT DO NOTHING;
 ```
 
-Mapping a locally-added `CalendarEventDescriptor` value `Remote instructional
+Map a locally-added `CalendarEventDescriptor` value `Remote instructional
 day` as an instructional day so it counts toward the school year:
 
 ```sql
@@ -233,23 +234,31 @@ ON CONFLICT DO NOTHING;
 
 ### Applying changes
 
-After inserting new `descriptormapping` rows, refresh the OneRoster© views so
-the new mapping takes effect:
+After inserting new `descriptormapping` rows, refresh the OneRoster©
+views so the new mapping takes effect.
 
-- PostgreSQL: run the refresh via pg-boss or manually:
-  `REFRESH MATERIALIZED VIEW CONCURRENTLY oneroster12.<view_name>;`
-- Microsoft SQL Server: run the refresh procedure:
-  `EXEC oneroster12.sp_refresh_<table_name>;`
-  (or `EXEC oneroster12.sp_refresh_all;` to refresh everything)
+On PostgreSQL, run the refresh via pg-boss, or manually:
 
-See [Configuration](../configuration/readme.mdx) for the scheduled refresh
-cadence.
+```sql
+REFRESH MATERIALIZED VIEW CONCURRENTLY oneroster12.<view_name>;
+```
+
+On Microsoft SQL Server, run the refresh procedure for the affected
+entity, or run `sp_refresh_all`:
+
+```sql
+EXEC oneroster12.sp_refresh_<table_name>;
+EXEC oneroster12.sp_refresh_all;
+```
+
+See [Configuration](../configuration/readme.mdx) for the scheduled
+refresh cadence.
 
 ## Known unmapped Ed-Fi `StaffClassificationDescriptor` values
 
-Several Ed-Fi-shipped values have no corresponding OneRoster© `RoleEnum`
-entry and are intentionally left unmapped by the service. They are listed
-(as comments) at the bottom of `02_descriptorMappings.sql`:
+Twelve Ed-Fi-shipped values have no mapping row in
+`02_descriptorMappings.sql`. They are listed as comments at the bottom of
+that file:
 
 - `Librarian/Media Specialist`
 - `Library/Media Support Staff`
@@ -264,6 +273,6 @@ entry and are intentionally left unmapped by the service. They are listed
 - `School Specialist`
 - `Support Services Staff`
 
-Teams using these values should add their own mapping rows pointing at the
-OneRoster© role that best fits their deployment's conventions (commonly
-`teacher`, `aide`, or `siteAdministrator`).
+Deployments that use any of these values should add their own mapping
+rows, pointing at the OneRoster© role that best fits their deployment's
+conventions (commonly `teacher`, `aide`, or `siteAdministrator`).

--- a/docs/reference/11-oneroster/data-model/descriptor-mappings.md
+++ b/docs/reference/11-oneroster/data-model/descriptor-mappings.md
@@ -1,0 +1,269 @@
+# Descriptor Mappings
+
+Several OneRoster fields are produced by translating Ed-Fi descriptor values
+(for example, `SexDescriptor.Female`) into OneRoster enumeration values
+(`sex = 'female'`). The translation is done entirely through rows in
+`edfi.descriptormapping`, which are seeded when OneRoster SQL artifacts are
+deployed and can be extended per implementation.
+
+This page lists the six shipped descriptor mappings, documents the behavior
+each mapping produces in the OneRoster output, describes what happens to
+Ed-Fi descriptor values that are _not_ in the mapping, and provides an
+INSERT template for adding custom entries.
+
+## Where descriptor mappings live
+
+Two SQL files define the shipped mappings:
+
+- `01_descriptors.sql` — inserts the OneRoster-namespaced descriptor rows
+  (for example, `uri://1edtech.org/oneroster12/SexDescriptor / female`) into
+  `edfi.descriptor` so that `edfi.descriptormapping` can reference them as
+  the _mapped_ side.
+- `02_descriptorMappings.sql` — inserts the Ed-Fi-namespaced-to-OneRoster
+  mapping rows into `edfi.descriptormapping`.
+
+Both files live under
+`standard/{dataStandardVersion}/artifacts/{pgsql,mssql}/core/`. Running the
+deployment script (`deploy-postgres.sh` / `deploy-mssql.js`) executes both.
+
+## Shipped mappings
+
+Each shipped mapping has a `mappedNamespace` of
+`uri://1edtech.org/oneroster12/{Descriptor}`. The tables below list the
+exact Ed-Fi value → OneRoster value pairs and the OneRoster field each
+mapping populates.
+
+### `CalendarEventDescriptor` → instructional-day flag
+
+Used by `academic_sessions.sql` to decide which Ed-Fi calendar dates count as
+school days when computing the school-year start and end dates.
+
+| Ed-Fi value | Mapped value | Contributes to school year? |
+|---|---|---|
+| `Emergency day` | `FALSE` | No |
+| `Holiday` | `FALSE` | No |
+| `Instructional day` | `TRUE` | Yes |
+| `Make-up day` | `TRUE` | Yes |
+| `Non-instructional day` | `FALSE` | No |
+| `Other` | `FALSE` | No |
+| `Strike` | `FALSE` | No |
+| `Student late arrival/early dismissal` | `TRUE` | Yes |
+| `Teacher only day` | `FALSE` | No |
+| `Weather day` | `FALSE` | No |
+
+### `TermDescriptor` → OneRoster `academicSession.type`
+
+Populates the `type` field on academic session records derived from
+`edfi.session`.
+
+| Ed-Fi value | OneRoster `type` |
+|---|---|
+| `Semester`, `Fall Semester`, `Spring Semester`, `Summer Semester` | `semester` |
+| `Quarter`, `First Quarter`, `Second Quarter`, `Third Quarter`, `Fourth Quarter` | `term` |
+| `MiniTerm` | `term` |
+| `Other` | `term` |
+| `Trimester`, `First Trimester`, `Second Trimester`, `Third Trimester` | `gradingPeriod` |
+| `Year Round` | `schoolYear` |
+
+### `SexDescriptor` → OneRoster `demographics.sex`
+
+Populates the `sex` field on `/demographics` records.
+
+| Ed-Fi value | OneRoster `sex` |
+|---|---|
+| `Female` | `female` |
+| `Male` | `male` |
+| `Non-binary` | `other` |
+| `Not Selected` | `unspecified` |
+
+### `RaceDescriptor` → OneRoster race booleans
+
+Populates the five race-flag fields
+(`americanIndianOrAlaskaNative`, `asian`, `blackOrAfricanAmerican`,
+`nativeHawaiianOrOtherPacificIslander`, `white`) and
+`demographicRaceTwoOrMoreRaces` on `/demographics` records.
+
+| Ed-Fi value | OneRoster value |
+|---|---|
+| `American Indian or Alaska Native` | `americanIndianOrAlaskaNative` |
+| `Asian` | `asian` |
+| `Black or African American` | `blackOrAfricanAmerican` |
+| `Native Hawaiian or Pacific Islander` | `nativeHawaiianOrOtherPacificIslander` |
+| `White` | `white` |
+
+A student associated with two or more _mapped_ race values gets
+`demographicRaceTwoOrMoreRaces = 'true'`.
+
+### `StaffClassificationDescriptor` → OneRoster `user.role`
+
+Populates the `role` field on staff `/users` records. Twenty-five Ed-Fi
+values ship mapped; the most commonly used are:
+
+| Ed-Fi value (selection) | OneRoster `role` |
+|---|---|
+| `Teacher`, `Elementary Teacher`, `Secondary Teacher`, `Substitute Teacher`, `Instructional Coordinator`, `Ungraded Teacher`, `Pre-Kindergarten Teacher`, `Kindergarten Teacher` | `teacher` |
+| `Paraprofessional/Instructional Aide`, `Instructional Aide` | `aide` |
+| `Counselor`, `School Counselor`, `Elementary School Counselor`, `Secondary School Counselor` | `counselor` |
+| `Principal`, `Assistant Principal` | `principal` |
+| `School Administrator`, `School Administrative Support Staff`, `School Leader` | `siteAdministrator` |
+| `LEA Administrator`, `LEA Administrative Support Staff`, `LEA System Administrator`, `Superintendent`, `Assistant Superintendent`, `State Administrator` | `districtAdministrator` |
+
+The full list is in `02_descriptorMappings.sql`. Several Ed-Fi staff
+classifications are _deliberately unmapped_ because 1EdTech does not define
+a corresponding OneRoster role — see _Unmapped values_ below.
+
+### `ClassroomPositionDescriptor` → OneRoster `enrollment.primary`
+
+:::warning
+
+**Shipped but not consumed in the current release.** `01_descriptors.sql`
+and `02_descriptorMappings.sql` seed a `ClassroomPositionDescriptor` mapping
+(`Teacher of Record` → `TRUE`, all others → `FALSE`) so that the service
+can later flag a primary teacher on each staff enrollment. The current
+`enrollments.sql` view hardcodes `role = 'teacher'` and `primary = 'false'`
+for all staff-section associations and does not read this mapping.
+
+Until the enrollments view is updated to consume the mapping, extending or
+customizing `ClassroomPositionDescriptor` entries has no effect on
+OneRoster output.
+
+:::
+
+## Behavior for unmapped values
+
+An _unmapped_ descriptor is an Ed-Fi descriptor value that either:
+
+- Has no row in `edfi.descriptormapping` whose `mappednamespace` is the
+  OneRoster 1.2 namespace for that descriptor, or
+- Is a locally-added Ed-Fi descriptor value that a deployment has not
+  explicitly mapped.
+
+The service does not have a single answer here — each view handles
+unmapped values differently, and implementers should be aware of the
+differences:
+
+| Descriptor | Join style | Unmapped behavior |
+|---|---|---|
+| `CalendarEventDescriptor` | Inner join + `WHERE mappedvalue = 'TRUE'` | Unmapped calendar-event values are not counted as school days. School-year start/end dates are computed from only mapped-TRUE events. |
+| `TermDescriptor` | Inner join | **The entire session is dropped from `/academicSessions`.** Any `edfi.session` whose `TermDescriptor` is unmapped will not appear in OneRoster output. |
+| `SexDescriptor` | Left join | `sex` is emitted as `null` on `/demographics`. The student is still returned. |
+| `RaceDescriptor` | Left join + `array_remove(..., null)` | Unmapped race values are silently dropped from the student's race array. If _all_ of a student's race values are unmapped, every race boolean is `'false'` and `demographicRaceTwoOrMoreRaces = 'false'`. The student is still returned. |
+| `StaffClassificationDescriptor` | Left join + `coalesce(..., 'teacher')` when staff has any section assignment | If the staff member has _any_ `edfi.staffSectionAssociation`, their role defaults to `'teacher'` when unmapped. If they have no section assignment _and_ no mapped classification, **they are filtered out of `/users`** entirely. |
+| `ClassroomPositionDescriptor` | Not consumed | No effect (see warning above). |
+
+:::warning
+
+The two high-impact cases are `TermDescriptor` and `StaffClassificationDescriptor`:
+
+- Custom `TermDescriptor` values (for example, district-specific term names)
+  require a descriptor mapping or the corresponding sessions will be invisible
+  to OneRoster clients.
+- Staff with an unmapped `StaffClassificationDescriptor` who do not teach
+  sections are filtered out. A principal or counselor with a non-shipped
+  local classification and no section assignments will not appear in
+  `/users` until the descriptor is mapped.
+
+:::
+
+## Extending a mapping
+
+Additional mappings are added by inserting rows into `edfi.descriptormapping`.
+Use the OneRoster 1.2 namespace for the `mappednamespace` and the same
+`mappedvalue` as one of the shipped rows for that descriptor so the view's
+downstream logic keeps working.
+
+### Generic INSERT template
+
+```sql
+INSERT INTO edfi.descriptormapping
+    (namespace,                     value,                  mappednamespace,                                 mappedvalue, discriminator)
+VALUES
+    ('<ed-fi namespace>',         '<ed-fi value>',         'uri://1edtech.org/oneroster12/<Descriptor>',   '<oneroster value>', 'edfi.<Descriptor>')
+ON CONFLICT DO NOTHING;
+```
+
+For Microsoft SQL Server, replace `ON CONFLICT DO NOTHING` with an
+`IF NOT EXISTS` guard or a MERGE statement.
+
+### Worked examples
+
+Adding a custom state-defined `StaffClassificationDescriptor` value
+`Intervention Specialist` as an aide:
+
+```sql
+INSERT INTO edfi.descriptormapping
+    (namespace, value, mappednamespace, mappedvalue, discriminator)
+VALUES
+    ('uri://mystate.gov/StaffClassificationDescriptor',
+     'Intervention Specialist',
+     'uri://1edtech.org/oneroster12/StaffClassificationDescriptor',
+     'aide',
+     'edfi.StaffClassificationDescriptor')
+ON CONFLICT DO NOTHING;
+```
+
+Adding a custom `TermDescriptor` value `Intersession` as a term:
+
+```sql
+INSERT INTO edfi.descriptormapping
+    (namespace, value, mappednamespace, mappedvalue, discriminator)
+VALUES
+    ('uri://ed-fi.org/TermDescriptor',
+     'Intersession',
+     'uri://1edtech.org/oneroster12/TermDescriptor',
+     'term',
+     'edfi.TermDescriptor')
+ON CONFLICT DO NOTHING;
+```
+
+Mapping a locally-added `CalendarEventDescriptor` value `Remote instructional
+day` as an instructional day so it counts toward the school year:
+
+```sql
+INSERT INTO edfi.descriptormapping
+    (namespace, value, mappednamespace, mappedvalue, discriminator)
+VALUES
+    ('uri://mydistrict.edu/CalendarEventDescriptor',
+     'Remote instructional day',
+     'uri://1edtech.org/oneroster12/CalendarEventDescriptor',
+     'TRUE',
+     'edfi.CalendarEventDescriptor')
+ON CONFLICT DO NOTHING;
+```
+
+### Applying changes
+
+After inserting new `descriptormapping` rows, refresh the OneRoster views so
+the new mapping takes effect:
+
+- PostgreSQL: run the refresh via pg-boss or manually:
+  `REFRESH MATERIALIZED VIEW CONCURRENTLY oneroster12.<view_name>;`
+- Microsoft SQL Server: run the refresh procedure:
+  `EXEC oneroster12.sp_refresh_<table_name>;`
+  (or `EXEC oneroster12.sp_refresh_all;` to refresh everything)
+
+See [Configuration](../configuration/readme.md) for the scheduled refresh
+cadence.
+
+## Known unmapped Ed-Fi `StaffClassificationDescriptor` values
+
+Several Ed-Fi-shipped values have no corresponding OneRoster `RoleEnum`
+entry and are intentionally left unmapped by the service. They are listed
+(as comments) at the bottom of `02_descriptorMappings.sql`:
+
+- `Librarian/Media Specialist`
+- `Library/Media Support Staff`
+- `School Psychologist`
+- `Student Support Services Staff (w/o Psychology)`
+- `All Other Support Staff`
+- `Instr Coordinator and Supervisor to the Staff`
+- `Missing`
+- `LEA Specialist`
+- `Operational Support`
+- `Other`
+- `School Specialist`
+- `Support Services Staff`
+
+Teams using these values should add their own mapping rows pointing at the
+OneRoster role that best fits their deployment's conventions (commonly
+`teacher`, `aide`, or `siteAdministrator`).

--- a/docs/reference/11-oneroster/data-model/descriptor-mappings.md
+++ b/docs/reference/11-oneroster/data-model/descriptor-mappings.md
@@ -1,13 +1,13 @@
 # Descriptor Mappings
 
-Several OneRoster fields are produced by translating Ed-Fi descriptor values
-(for example, `SexDescriptor.Female`) into OneRoster enumeration values
+Several OneRoster© fields are produced by translating Ed-Fi descriptor values
+(for example, `SexDescriptor.Female`) into OneRoster© enumeration values
 (`sex = 'female'`). The translation is done entirely through rows in
-`edfi.descriptormapping`, which are seeded when OneRoster SQL artifacts are
+`edfi.descriptormapping`, which are seeded when OneRoster© SQL artifacts are
 deployed and can be extended per implementation.
 
 This page lists the six shipped descriptor mappings, documents the behavior
-each mapping produces in the OneRoster output, describes what happens to
+each mapping produces in the OneRoster© output, describes what happens to
 Ed-Fi descriptor values that are _not_ in the mapping, and provides an
 INSERT template for adding custom entries.
 
@@ -15,11 +15,11 @@ INSERT template for adding custom entries.
 
 Two SQL files define the shipped mappings:
 
-- `01_descriptors.sql` — inserts the OneRoster-namespaced descriptor rows
+- `01_descriptors.sql` — inserts the OneRoster©-namespaced descriptor rows
   (for example, `uri://1edtech.org/oneroster12/SexDescriptor / female`) into
   `edfi.descriptor` so that `edfi.descriptormapping` can reference them as
   the _mapped_ side.
-- `02_descriptorMappings.sql` — inserts the Ed-Fi-namespaced-to-OneRoster
+- `02_descriptorMappings.sql` — inserts the Ed-Fi-namespaced-to-OneRoster©
   mapping rows into `edfi.descriptormapping`.
 
 Both files live under
@@ -30,7 +30,7 @@ deployment script (`deploy-postgres.sh` / `deploy-mssql.js`) executes both.
 
 Each shipped mapping has a `mappedNamespace` of
 `uri://1edtech.org/oneroster12/{Descriptor}`. The tables below list the
-exact Ed-Fi value → OneRoster value pairs and the OneRoster field each
+exact Ed-Fi value → OneRoster© value pairs and the OneRoster© field each
 mapping populates.
 
 ### `CalendarEventDescriptor` → instructional-day flag
@@ -51,12 +51,12 @@ school days when computing the school-year start and end dates.
 | `Teacher only day` | `FALSE` | No |
 | `Weather day` | `FALSE` | No |
 
-### `TermDescriptor` → OneRoster `academicSession.type`
+### `TermDescriptor` → OneRoster© `academicSession.type`
 
 Populates the `type` field on academic session records derived from
 `edfi.session`.
 
-| Ed-Fi value | OneRoster `type` |
+| Ed-Fi value | OneRoster© `type` |
 | --- | --- |
 | `Semester`, `Fall Semester`, `Spring Semester`, `Summer Semester` | `semester` |
 | `Quarter`, `First Quarter`, `Second Quarter`, `Third Quarter`, `Fourth Quarter` | `term` |
@@ -65,25 +65,25 @@ Populates the `type` field on academic session records derived from
 | `Trimester`, `First Trimester`, `Second Trimester`, `Third Trimester` | `gradingPeriod` |
 | `Year Round` | `schoolYear` |
 
-### `SexDescriptor` → OneRoster `demographics.sex`
+### `SexDescriptor` → OneRoster© `demographics.sex`
 
 Populates the `sex` field on `/demographics` records.
 
-| Ed-Fi value | OneRoster `sex` |
+| Ed-Fi value | OneRoster© `sex` |
 | --- | --- |
 | `Female` | `female` |
 | `Male` | `male` |
 | `Non-binary` | `other` |
 | `Not Selected` | `unspecified` |
 
-### `RaceDescriptor` → OneRoster race booleans
+### `RaceDescriptor` → OneRoster© race booleans
 
 Populates the five race-flag fields
 (`americanIndianOrAlaskaNative`, `asian`, `blackOrAfricanAmerican`,
 `nativeHawaiianOrOtherPacificIslander`, `white`) and
 `demographicRaceTwoOrMoreRaces` on `/demographics` records.
 
-| Ed-Fi value | OneRoster value |
+| Ed-Fi value | OneRoster© value |
 | --- | --- |
 | `American Indian or Alaska Native` | `americanIndianOrAlaskaNative` |
 | `Asian` | `asian` |
@@ -94,12 +94,12 @@ Populates the five race-flag fields
 A student associated with two or more _mapped_ race values gets
 `demographicRaceTwoOrMoreRaces = 'true'`.
 
-### `StaffClassificationDescriptor` → OneRoster `user.role`
+### `StaffClassificationDescriptor` → OneRoster© `user.role`
 
 Populates the `role` field on staff `/users` records. Twenty-five Ed-Fi
 values ship mapped; the most commonly used are:
 
-| Ed-Fi value (selection) | OneRoster `role` |
+| Ed-Fi value (selection) | OneRoster© `role` |
 | --- | --- |
 | `Teacher`, `Elementary Teacher`, `Secondary Teacher`, `Substitute Teacher`, `Instructional Coordinator`, `Ungraded Teacher`, `Pre-Kindergarten Teacher`, `Kindergarten Teacher` | `teacher` |
 | `Paraprofessional/Instructional Aide`, `Instructional Aide` | `aide` |
@@ -110,9 +110,9 @@ values ship mapped; the most commonly used are:
 
 The full list is in `02_descriptorMappings.sql`. Several Ed-Fi staff
 classifications are _deliberately unmapped_ because 1EdTech does not define
-a corresponding OneRoster role — see _Unmapped values_ below.
+a corresponding OneRoster© role — see _Unmapped values_ below.
 
-### `ClassroomPositionDescriptor` → OneRoster `enrollment.primary`
+### `ClassroomPositionDescriptor` → OneRoster© `enrollment.primary`
 
 :::warning
 
@@ -125,7 +125,7 @@ for all staff-section associations and does not read this mapping.
 
 Until the enrollments view is updated to consume the mapping, extending or
 customizing `ClassroomPositionDescriptor` entries has no effect on
-OneRoster output.
+OneRoster© output.
 
 :::
 
@@ -134,7 +134,7 @@ OneRoster output.
 An _unmapped_ descriptor is an Ed-Fi descriptor value that either:
 
 - Has no row in `edfi.descriptormapping` whose `mappednamespace` is the
-  OneRoster 1.2 namespace for that descriptor, or
+  OneRoster© 1.2 namespace for that descriptor, or
 - Is a locally-added Ed-Fi descriptor value that a deployment has not
   explicitly mapped.
 
@@ -145,7 +145,7 @@ differences:
 | Descriptor | Join style | Unmapped behavior |
 | --- | --- | --- |
 | `CalendarEventDescriptor` | Inner join + `WHERE mappedvalue = 'TRUE'` | Unmapped calendar-event values are not counted as school days. School-year start/end dates are computed from only mapped-TRUE events. |
-| `TermDescriptor` | Inner join | **The entire session is dropped from `/academicSessions`.** Any `edfi.session` whose `TermDescriptor` is unmapped will not appear in OneRoster output. |
+| `TermDescriptor` | Inner join | **The entire session is dropped from `/academicSessions`.** Any `edfi.session` whose `TermDescriptor` is unmapped will not appear in OneRoster© output. |
 | `SexDescriptor` | Left join | `sex` is emitted as `null` on `/demographics`. The student is still returned. |
 | `RaceDescriptor` | Left join + `array_remove(..., null)` | Unmapped race values are silently dropped from the student's race array. If _all_ of a student's race values are unmapped, every race boolean is `'false'` and `demographicRaceTwoOrMoreRaces = 'false'`. The student is still returned. |
 | `StaffClassificationDescriptor` | Left join + `coalesce(..., 'teacher')` when staff has any section assignment | If the staff member has _any_ `edfi.staffSectionAssociation`, their role defaults to `'teacher'` when unmapped. If they have no section assignment _and_ no mapped classification, **they are filtered out of `/users`** entirely. |
@@ -157,7 +157,7 @@ The two high-impact cases are `TermDescriptor` and `StaffClassificationDescripto
 
 - Custom `TermDescriptor` values (for example, district-specific term names)
   require a descriptor mapping or the corresponding sessions will be invisible
-  to OneRoster clients.
+  to OneRoster© clients.
 - Staff with an unmapped `StaffClassificationDescriptor` who do not teach
   sections are filtered out. A principal or counselor with a non-shipped
   local classification and no section assignments will not appear in
@@ -168,7 +168,7 @@ The two high-impact cases are `TermDescriptor` and `StaffClassificationDescripto
 ## Extending a mapping
 
 Additional mappings are added by inserting rows into `edfi.descriptormapping`.
-Use the OneRoster 1.2 namespace for the `mappednamespace` and the same
+Use the OneRoster© 1.2 namespace for the `mappednamespace` and the same
 `mappedvalue` as one of the shipped rows for that descriptor so the view's
 downstream logic keeps working.
 
@@ -233,7 +233,7 @@ ON CONFLICT DO NOTHING;
 
 ### Applying changes
 
-After inserting new `descriptormapping` rows, refresh the OneRoster views so
+After inserting new `descriptormapping` rows, refresh the OneRoster© views so
 the new mapping takes effect:
 
 - PostgreSQL: run the refresh via pg-boss or manually:
@@ -247,7 +247,7 @@ cadence.
 
 ## Known unmapped Ed-Fi `StaffClassificationDescriptor` values
 
-Several Ed-Fi-shipped values have no corresponding OneRoster `RoleEnum`
+Several Ed-Fi-shipped values have no corresponding OneRoster© `RoleEnum`
 entry and are intentionally left unmapped by the service. They are listed
 (as comments) at the bottom of `02_descriptorMappings.sql`:
 
@@ -265,5 +265,5 @@ entry and are intentionally left unmapped by the service. They are listed
 - `Support Services Staff`
 
 Teams using these values should add their own mapping rows pointing at the
-OneRoster role that best fits their deployment's conventions (commonly
+OneRoster© role that best fits their deployment's conventions (commonly
 `teacher`, `aide`, or `siteAdministrator`).

--- a/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
+++ b/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
@@ -12,7 +12,7 @@ mappings](./descriptor-mappings.md) for how individual descriptor-backed
 fields (sex, race, term type, staff role) are resolved.
 
 | OneRoster endpoint | `oneroster12` object | Primary Ed-Fi sources | Defined in |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `/academicSessions`, `/academicSessions/{id}` | `academicsessions` | `edfi.session`, `edfi.school`, `edfi.calendardate`, `edfi.calendardatecalendarevent` | `academic_sessions.sql` |
 | `/classes`, `/classes/{id}` | `classes` | `edfi.section`, `edfi.courseoffering`, `edfi.school`, `edfi.sectionclassperiod` | `classes.sql` |
 | `/courses`, `/courses/{id}` | `courses` | `edfi.course`, `edfi.courseoffering` | `courses.sql` |
@@ -36,7 +36,7 @@ builds these deterministically from Ed-Fi natural keys using MD5 (PostgreSQL
 `md5()`, Microsoft SQL Server `HASHBYTES('MD5', ...)`):
 
 | Record | `sourcedId` input |
-|---|---|
+| --- | --- |
 | School | `md5(schoolId)` |
 | LEA (district) | `md5(localEducationAgencyId)` |
 | SEA (state) | `md5(stateEducationAgencyId)` |

--- a/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
+++ b/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
@@ -1,17 +1,17 @@
 # Endpoint to Ed-Fi Source Mapping
 
-Each OneRoster endpoint is served from a derived `oneroster12` object that is
+Each OneRoster© endpoint is served from a derived `oneroster12` object that is
 built from one or more Ed-Fi ODS tables. On PostgreSQL the objects are
 materialized views; on Microsoft SQL Server they are tables populated by
 refresh stored procedures. Both variants follow the same logical mapping.
 
-The table below lists every OneRoster 1.2 rostering endpoint implemented by
+The table below lists every OneRoster© 1.2 rostering endpoint implemented by
 the service, the primary Ed-Fi entities it reads from, and the SQL artifact
 that defines the derivation. See [Descriptor
 mappings](./descriptor-mappings.md) for how individual descriptor-backed
 fields (sex, race, term type, staff role) are resolved.
 
-| OneRoster endpoint | `oneroster12` object | Primary Ed-Fi sources | Defined in |
+| OneRoster© endpoint | `oneroster12` object | Primary Ed-Fi sources | Defined in |
 | --- | --- | --- | --- |
 | `/academicSessions`, `/academicSessions/{id}` | `academicsessions` | `edfi.session`, `edfi.school`, `edfi.calendardate`, `edfi.calendardatecalendarevent` | `academic_sessions.sql` |
 | `/classes`, `/classes/{id}` | `classes` | `edfi.section`, `edfi.courseoffering`, `edfi.school`, `edfi.sectionclassperiod` | `classes.sql` |
@@ -26,12 +26,12 @@ fields (sex, race, term type, staff role) are resolved.
 | `/terms`, `/terms/{id}` | `academicsessions` (filtered) | see `/academicSessions` | `academic_sessions.sql` |
 | `/users`, `/users/{id}` | `users` | `edfi.student`, `edfi.staff`, `edfi.contact` plus their school / EdOrg associations; `edfi.studentSchoolAssociation`, `edfi.staffSchoolAssociation`, `edfi.staffEducationOrganizationAssignmentAssociation`, `edfi.studentContactAssociation` | `users.sql` |
 
-The SQL artifacts live in the OneRoster service repository under
+The SQL artifacts live in the OneRoster© service repository under
 `standard/{dataStandardVersion}/artifacts/{pgsql,mssql}/core/`.
 
 ## `sourcedId` construction
 
-OneRoster requires a globally unique `sourcedId` on every record. The service
+OneRoster© requires a globally unique `sourcedId` on every record. The service
 builds these deterministically from Ed-Fi natural keys using MD5 (PostgreSQL
 `md5()`, Microsoft SQL Server `HASHBYTES('MD5', ...)`):
 
@@ -55,7 +55,7 @@ across refreshes so long as the source Ed-Fi identifiers do not change.
 
 ## Ed-Fi natural key metadata
 
-Every OneRoster record includes a `metadata.edfi` object that echoes the
+Every OneRoster© record includes a `metadata.edfi` object that echoes the
 source resource name and its natural key values, for example:
 
 ```json
@@ -74,12 +74,12 @@ source resource name and its natural key values, for example:
 }
 ```
 
-This lets integrators trace a OneRoster record back to the underlying Ed-Fi
+This lets integrators trace a OneRoster© record back to the underlying Ed-Fi
 resource without joining on the hashed `sourcedId`.
 
 ## What is not mapped
 
-The following OneRoster fields are intentionally `null` in the current
+The following OneRoster© fields are intentionally `null` in the current
 release. They require Ed-Fi extensions or configuration that are not
 uniformly available across deployments:
 

--- a/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
+++ b/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
@@ -1,17 +1,17 @@
 # Endpoint to Ed-Fi Source Mapping
 
-Each OneRoster© endpoint is served from a derived `oneroster12` object that
+Each OneRoster® endpoint is served from a derived `oneroster12` object that
 is built from one or more Ed-Fi ODS tables. On PostgreSQL the objects are
 materialized views. On Microsoft SQL Server they are tables populated by
 refresh stored procedures. Both variants follow the same logical mapping.
 
-The table below lists every OneRoster© v1.2 rostering endpoint implemented
+The table below lists every OneRoster v1.2 rostering endpoint implemented
 by the service, the primary Ed-Fi entities it reads from, and the SQL
 artifact that defines the derivation. For how individual
 descriptor-backed fields (sex, race, term type, staff role) are resolved,
 see [Descriptor mappings](./descriptor-mappings.md).
 
-| OneRoster© endpoint | `oneroster12` object | Primary Ed-Fi sources | Defined in |
+| OneRoster endpoint | `oneroster12` object | Primary Ed-Fi sources | Defined in |
 | --- | --- | --- | --- |
 | `/academicSessions`, `/academicSessions/{id}` | `academicsessions` | `edfi.session`, `edfi.school`, `edfi.calendardate`, `edfi.calendardatecalendarevent` | `academic_sessions.sql` |
 | `/classes`, `/classes/{id}` | `classes` | `edfi.section`, `edfi.courseoffering`, `edfi.school`, `edfi.sectionclassperiod` | `classes.sql` |
@@ -26,12 +26,12 @@ see [Descriptor mappings](./descriptor-mappings.md).
 | `/terms`, `/terms/{id}` | `academicsessions` (filtered) | see `/academicSessions` | `academic_sessions.sql` |
 | `/users`, `/users/{id}` | `users` | `edfi.student`, `edfi.staff`, `edfi.contact` plus their school / EdOrg associations (`edfi.studentSchoolAssociation`, `edfi.staffSchoolAssociation`, `edfi.staffEducationOrganizationAssignmentAssociation`, `edfi.studentContactAssociation`) | `users.sql` |
 
-The SQL artifacts live in the OneRoster© service repository under
+The SQL artifacts live in the OneRoster service repository under
 `standard/{dataStandardVersion}/artifacts/{pgsql,mssql}/core/`.
 
 ## `sourcedId` construction
 
-OneRoster© requires a globally unique `sourcedId` on every record. The
+OneRoster requires a globally unique `sourcedId` on every record. The
 service builds these deterministically from Ed-Fi natural keys using MD5
 (PostgreSQL `md5()`, Microsoft SQL Server `HASHBYTES('MD5', ...)`).
 
@@ -55,7 +55,7 @@ across refreshes so long as the source Ed-Fi identifiers do not change.
 
 ## Ed-Fi natural key metadata
 
-Every OneRoster© record includes a `metadata.edfi` object that echoes the
+Every OneRoster record includes a `metadata.edfi` object that echoes the
 source resource name and its natural key values. An example from a class
 record:
 
@@ -75,13 +75,13 @@ record:
 }
 ```
 
-An integrator can use this to trace a OneRoster© record back to the
+An integrator can use this to trace a OneRoster record back to the
 underlying Ed-Fi resource without having to reconstruct the hashed
 `sourcedId`.
 
 ## What is not mapped
 
-The following OneRoster© fields are `null` in the current release. Most
+The following OneRoster fields are `null` in the current release. Most
 require Ed-Fi extensions or configuration that is not uniformly available
 across deployments.
 

--- a/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
+++ b/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
@@ -1,15 +1,15 @@
 # Endpoint to Ed-Fi Source Mapping
 
-Each OneRoster© endpoint is served from a derived `oneroster12` object that is
-built from one or more Ed-Fi ODS tables. On PostgreSQL the objects are
-materialized views; on Microsoft SQL Server they are tables populated by
+Each OneRoster© endpoint is served from a derived `oneroster12` object that
+is built from one or more Ed-Fi ODS tables. On PostgreSQL the objects are
+materialized views. On Microsoft SQL Server they are tables populated by
 refresh stored procedures. Both variants follow the same logical mapping.
 
-The table below lists every OneRoster© 1.2 rostering endpoint implemented by
-the service, the primary Ed-Fi entities it reads from, and the SQL artifact
-that defines the derivation. See [Descriptor
-mappings](./descriptor-mappings.md) for how individual descriptor-backed
-fields (sex, race, term type, staff role) are resolved.
+The table below lists every OneRoster© v1.2 rostering endpoint implemented
+by the service, the primary Ed-Fi entities it reads from, and the SQL
+artifact that defines the derivation. For how individual
+descriptor-backed fields (sex, race, term type, staff role) are resolved,
+see [Descriptor mappings](./descriptor-mappings.md).
 
 | OneRoster© endpoint | `oneroster12` object | Primary Ed-Fi sources | Defined in |
 | --- | --- | --- | --- |
@@ -24,16 +24,16 @@ fields (sex, race, term type, staff role) are resolved.
 | `/students`, `/students/{id}` | `users` (filtered to `role = 'student'`) | see `/users` | `users.sql` |
 | `/teachers`, `/teachers/{id}` | `users` (filtered to `role = 'teacher'`) | see `/users` | `users.sql` |
 | `/terms`, `/terms/{id}` | `academicsessions` (filtered) | see `/academicSessions` | `academic_sessions.sql` |
-| `/users`, `/users/{id}` | `users` | `edfi.student`, `edfi.staff`, `edfi.contact` plus their school / EdOrg associations; `edfi.studentSchoolAssociation`, `edfi.staffSchoolAssociation`, `edfi.staffEducationOrganizationAssignmentAssociation`, `edfi.studentContactAssociation` | `users.sql` |
+| `/users`, `/users/{id}` | `users` | `edfi.student`, `edfi.staff`, `edfi.contact` plus their school / EdOrg associations (`edfi.studentSchoolAssociation`, `edfi.staffSchoolAssociation`, `edfi.staffEducationOrganizationAssignmentAssociation`, `edfi.studentContactAssociation`) | `users.sql` |
 
 The SQL artifacts live in the OneRoster© service repository under
 `standard/{dataStandardVersion}/artifacts/{pgsql,mssql}/core/`.
 
 ## `sourcedId` construction
 
-OneRoster© requires a globally unique `sourcedId` on every record. The service
-builds these deterministically from Ed-Fi natural keys using MD5 (PostgreSQL
-`md5()`, Microsoft SQL Server `HASHBYTES('MD5', ...)`):
+OneRoster© requires a globally unique `sourcedId` on every record. The
+service builds these deterministically from Ed-Fi natural keys using MD5
+(PostgreSQL `md5()`, Microsoft SQL Server `HASHBYTES('MD5', ...)`).
 
 | Record | `sourcedId` input |
 | --- | --- |
@@ -56,7 +56,8 @@ across refreshes so long as the source Ed-Fi identifiers do not change.
 ## Ed-Fi natural key metadata
 
 Every OneRoster© record includes a `metadata.edfi` object that echoes the
-source resource name and its natural key values, for example:
+source resource name and its natural key values. An example from a class
+record:
 
 ```json
 {
@@ -74,14 +75,15 @@ source resource name and its natural key values, for example:
 }
 ```
 
-This lets integrators trace a OneRoster© record back to the underlying Ed-Fi
-resource without joining on the hashed `sourcedId`.
+An integrator can use this to trace a OneRoster© record back to the
+underlying Ed-Fi resource without having to reconstruct the hashed
+`sourcedId`.
 
 ## What is not mapped
 
-The following OneRoster© fields are intentionally `null` in the current
-release. They require Ed-Fi extensions or configuration that are not
-uniformly available across deployments:
+The following OneRoster© fields are `null` in the current release. Most
+require Ed-Fi extensions or configuration that is not uniformly available
+across deployments.
 
 - `class.grades`, `class.subjects`, `class.subjectCodes` (sections)
 - `course.grades`, `course.subjects`, `course.subjectCodes` (courses; SCED
@@ -89,8 +91,7 @@ uniformly available across deployments:
 - `user.sms`, `user.phone`, `user.password`, `user.agentSourceIds`,
   `user.userProfiles`, `user.pronouns`, `user.preferredMiddleName`
 
-The `enrollment.role` field is currently fixed to `'teacher'` for staff
-enrollments and `'student'` for student enrollments; the shipped
-`ClassroomPositionDescriptor` mapping is seeded but not consumed by the
-enrollments view. See [Descriptor mappings](./descriptor-mappings.md) for
-details.
+The `enrollment.role` field is fixed to `'teacher'` for staff enrollments
+and `'student'` for student enrollments. The shipped
+`ClassroomPositionDescriptor` mapping is seeded but not read by the
+enrollments view. See [Descriptor mappings](./descriptor-mappings.md).

--- a/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
+++ b/docs/reference/11-oneroster/data-model/endpoint-source-mapping.md
@@ -1,0 +1,96 @@
+# Endpoint to Ed-Fi Source Mapping
+
+Each OneRoster endpoint is served from a derived `oneroster12` object that is
+built from one or more Ed-Fi ODS tables. On PostgreSQL the objects are
+materialized views; on Microsoft SQL Server they are tables populated by
+refresh stored procedures. Both variants follow the same logical mapping.
+
+The table below lists every OneRoster 1.2 rostering endpoint implemented by
+the service, the primary Ed-Fi entities it reads from, and the SQL artifact
+that defines the derivation. See [Descriptor
+mappings](./descriptor-mappings.md) for how individual descriptor-backed
+fields (sex, race, term type, staff role) are resolved.
+
+| OneRoster endpoint | `oneroster12` object | Primary Ed-Fi sources | Defined in |
+|---|---|---|---|
+| `/academicSessions`, `/academicSessions/{id}` | `academicsessions` | `edfi.session`, `edfi.school`, `edfi.calendardate`, `edfi.calendardatecalendarevent` | `academic_sessions.sql` |
+| `/classes`, `/classes/{id}` | `classes` | `edfi.section`, `edfi.courseoffering`, `edfi.school`, `edfi.sectionclassperiod` | `classes.sql` |
+| `/courses`, `/courses/{id}` | `courses` | `edfi.course`, `edfi.courseoffering` | `courses.sql` |
+| `/demographics`, `/demographics/{id}` | `demographics` | `edfi.student`, `edfi.studenteducationorganizationassociation`, `edfi.studenteducationorganizationassociationrace` | `demographics.sql` |
+| `/enrollments`, `/enrollments/{id}` | `enrollments` | `edfi.staffSectionAssociation`, `edfi.studentSectionAssociation`, `edfi.section` | `enrollments.sql` |
+| `/gradingPeriods`, `/gradingPeriods/{id}` | `academicsessions` (filtered) | see `/academicSessions` | `academic_sessions.sql` |
+| `/orgs`, `/orgs/{id}` | `orgs` | `edfi.school`, `edfi.localEducationAgency`, `edfi.stateEducationAgency`, `edfi.educationOrganization` | `orgs.sql` |
+| `/schools`, `/schools/{id}` | `orgs` (filtered to `type = 'school'`) | see `/orgs` | `orgs.sql` |
+| `/students`, `/students/{id}` | `users` (filtered to `role = 'student'`) | see `/users` | `users.sql` |
+| `/teachers`, `/teachers/{id}` | `users` (filtered to `role = 'teacher'`) | see `/users` | `users.sql` |
+| `/terms`, `/terms/{id}` | `academicsessions` (filtered) | see `/academicSessions` | `academic_sessions.sql` |
+| `/users`, `/users/{id}` | `users` | `edfi.student`, `edfi.staff`, `edfi.contact` plus their school / EdOrg associations; `edfi.studentSchoolAssociation`, `edfi.staffSchoolAssociation`, `edfi.staffEducationOrganizationAssignmentAssociation`, `edfi.studentContactAssociation` | `users.sql` |
+
+The SQL artifacts live in the OneRoster service repository under
+`standard/{dataStandardVersion}/artifacts/{pgsql,mssql}/core/`.
+
+## `sourcedId` construction
+
+OneRoster requires a globally unique `sourcedId` on every record. The service
+builds these deterministically from Ed-Fi natural keys using MD5 (PostgreSQL
+`md5()`, Microsoft SQL Server `HASHBYTES('MD5', ...)`):
+
+| Record | `sourcedId` input |
+|---|---|
+| School | `md5(schoolId)` |
+| LEA (district) | `md5(localEducationAgencyId)` |
+| SEA (state) | `md5(stateEducationAgencyId)` |
+| Course | `md5(educationOrganizationId + '-' + courseCode)` |
+| Class (section) | `md5(localCourseCode + '-' + schoolId + '-' + sectionIdentifier + '-' + sessionName)` |
+| Academic session (term) | `md5(schoolId + '-' + sessionName)` |
+| Academic session (school year) | `md5(schoolYear)` |
+| Student user | `md5('STU-' + studentUniqueId + '-' + educationOrganizationId)` |
+| Staff user | `md5('STA-' + staffUniqueId + '-' + schoolId)` |
+| Parent / contact user | `md5('PAR-' + contactUniqueId + '-' + schoolId)` |
+| Student enrollment | `md5(studentUniqueId + '-' + localCourseCode + '-' + schoolId + '-' + sectionIdentifier + '-' + sessionName + '-' + beginDate)` |
+| Staff enrollment | `md5(staffUniqueId + '-' + localCourseCode + '-' + schoolId + '-' + sectionIdentifier + '-' + sessionName + '-' + beginDate)` |
+
+Because the inputs are Ed-Fi natural keys, `sourcedId` values remain stable
+across refreshes so long as the source Ed-Fi identifiers do not change.
+
+## Ed-Fi natural key metadata
+
+Every OneRoster record includes a `metadata.edfi` object that echoes the
+source resource name and its natural key values, for example:
+
+```json
+{
+  "metadata": {
+    "edfi": {
+      "resource": "sections",
+      "naturalKey": {
+        "localCourseCode": "ALG-I",
+        "schoolId": 255901001,
+        "sectionIdentifier": "25RM1-ALG-I-001",
+        "sessionName": "2024-2025 Fall Semester"
+      }
+    }
+  }
+}
+```
+
+This lets integrators trace a OneRoster record back to the underlying Ed-Fi
+resource without joining on the hashed `sourcedId`.
+
+## What is not mapped
+
+The following OneRoster fields are intentionally `null` in the current
+release. They require Ed-Fi extensions or configuration that are not
+uniformly available across deployments:
+
+- `class.grades`, `class.subjects`, `class.subjectCodes` (sections)
+- `course.grades`, `course.subjects`, `course.subjectCodes` (courses; SCED
+  codes are not generally populated in Ed-Fi ODSs)
+- `user.sms`, `user.phone`, `user.password`, `user.agentSourceIds`,
+  `user.userProfiles`, `user.pronouns`, `user.preferredMiddleName`
+
+The `enrollment.role` field is currently fixed to `'teacher'` for staff
+enrollments and `'student'` for student enrollments; the shipped
+`ClassroomPositionDescriptor` mapping is seeded but not consumed by the
+enrollments view. See [Descriptor mappings](./descriptor-mappings.md) for
+details.

--- a/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
+++ b/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
@@ -1,8 +1,8 @@
 # Org and Agency Mapping
 
-The OneRoster© v1.2 `/orgs` endpoint exposes schools, districts, and state
+The OneRoster® v1.2 `/orgs` endpoint exposes schools, districts, and state
 agencies from an Ed-Fi ODS, keeping the parent / child hierarchy intact.
-This page documents how OneRoster© org records are derived, how the `type`
+This page documents how OneRoster org records are derived, how the `type`
 field is assigned, and how custom or non-standard Ed-Fi education
 organizations are treated.
 
@@ -12,16 +12,16 @@ or the equivalent `mssql/core/` script (refresh procedure).
 
 ## Source entities and `type` derivation
 
-OneRoster© `org.type` is derived from the Ed-Fi entity table that each row
+OneRoster `org.type` is derived from the Ed-Fi entity table that each row
 comes from. No descriptor value participates in the decision.
 
-| OneRoster© `type` | Ed-Fi source table | OneRoster© `identifier` | `sourcedId` input |
+| OneRoster `type` | Ed-Fi source table | OneRoster `identifier` | `sourcedId` input |
 | --- | --- | --- | --- |
 | `school` | `edfi.school` joined to `edfi.educationOrganization` on `schoolId` | `schoolId` | `md5(schoolId)` |
 | `district` | `edfi.localEducationAgency` joined on `localEducationAgencyId` | `localEducationAgencyId` | `md5(localEducationAgencyId)` |
 | `state` | `edfi.stateEducationAgency` joined on `stateEducationAgencyId` | `stateEducationAgencyId` | `md5(stateEducationAgencyId)` |
 
-The OneRoster© v1.2 `OrgType` enumeration also defines `local` and
+The OneRoster v1.2 `OrgType` enumeration also defines `local` and
 `national`. Neither value is emitted by the service. Every row produced by
 `orgs.sql` is one of `school`, `district`, or `state`.
 
@@ -38,7 +38,7 @@ Each row also includes:
 :::info
 
 **Custom `EducationOrganizationCategoryDescriptor` values have no effect on
-OneRoster© `org.type`.** The view keys off which Ed-Fi entity table the row
+OneRoster `org.type`.** The view keys off which Ed-Fi entity table the row
 lives in (`edfi.school`, `edfi.localEducationAgency`, or
 `edfi.stateEducationAgency`). It does not read
 `edfi.descriptor` for `EducationOrganizationCategory`.
@@ -47,20 +47,20 @@ lives in (`edfi.school`, `edfi.localEducationAgency`, or
 
 Implications:
 
-- An `edfi.school` row is always emitted as OneRoster© `type = 'school'`,
+- An `edfi.school` row is always emitted as OneRoster `type = 'school'`,
   regardless of the `EducationOrganizationCategoryDescriptor` assigned to
   it.
 - Deployments with custom school or LEA categories (for example, charter
   school networks) do not need to add any descriptor mapping to have those
   organizations appear correctly in `/orgs`.
 - There is no supported way, in the current release, to project Ed-Fi rows
-  into OneRoster© `type = 'local'` or `type = 'national'`. Teams that
-  require those values should raise an issue against the OneRoster©
+  into OneRoster `type = 'local'` or `type = 'national'`. Teams that
+  require those values should raise an issue against the OneRoster
   service.
 
 ## Parent / children composition
 
-OneRoster© `parent` and `children` are assembled from the Ed-Fi ODS
+OneRoster `parent` and `children` are assembled from the Ed-Fi ODS
 `educationOrganization` hierarchy.
 
 ### Schools
@@ -119,9 +119,9 @@ transitively through the SEA's LEAs.
 (for example `educationServiceCenter`, `organizationDepartment`,
 `postSecondaryInstitution`, `communityOrganization`, `communityProvider`)
 have rows in `edfi.educationOrganization` but no row in the three tables
-above, so they are not emitted to OneRoster© `/orgs`.
+above, so they are not emitted to OneRoster `/orgs`.
 
-If an implementation needs to expose an intermediate unit as a OneRoster©
+If an implementation needs to expose an intermediate unit as a OneRoster
 organization, a workable approach is to record it as an Ed-Fi
 `localEducationAgency` (setting `stateEducationAgencyId` as appropriate)
 and associate its schools through `edfi.school.localEducationAgencyId`.
@@ -133,7 +133,7 @@ This uses only the supported mapping and keeps the hierarchy intact.
 `edfi.educationOrganization`. A school that exists in `edfi.school` but
 has no matching row in `edfi.educationOrganization` will not appear in
 `/orgs`. This is uncommon in a healthy ODS but can arise from partial
-imports. If schools are missing from OneRoster© output, confirm that
+imports. If schools are missing from OneRoster output, confirm that
 `edfi.educationOrganization` contains a row for each `schoolId`.
 
 ## Authorization scope

--- a/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
+++ b/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
@@ -16,7 +16,7 @@ OneRoster `org.type` is derived from the Ed-Fi _entity table_ each row comes
 from, not from any descriptor value:
 
 | OneRoster `type` | Ed-Fi source table | OneRoster `identifier` | `sourcedId` input |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `school` | `edfi.school` (joined to `edfi.educationOrganization` on `schoolId`) | `schoolId` | `md5(schoolId)` |
 | `district` | `edfi.localEducationAgency` (joined on `localEducationAgencyId`) | `localEducationAgencyId` | `md5(localEducationAgencyId)` |
 | `state` | `edfi.stateEducationAgency` (joined on `stateEducationAgencyId`) | `stateEducationAgencyId` | `md5(stateEducationAgencyId)` |

--- a/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
+++ b/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
@@ -1,0 +1,151 @@
+# Org and Agency Mapping
+
+The OneRoster 1.2 `/orgs` endpoint exposes schools, districts, and state
+agencies from an Ed-Fi ODS, keeping parent/child hierarchy intact. This page
+documents how the OneRoster org records are derived, how the `type` field is
+assigned, and how custom or non-standard Ed-Fi education organizations are
+treated.
+
+The derivation is defined in `orgs.sql` under
+`standard/{dataStandardVersion}/artifacts/pgsql/core/` (materialized view) or
+the equivalent `mssql/core/` script (refresh procedure).
+
+## Source entities and `type` derivation
+
+OneRoster `org.type` is derived from the Ed-Fi _entity table_ each row comes
+from, not from any descriptor value:
+
+| OneRoster `type` | Ed-Fi source table | OneRoster `identifier` | `sourcedId` input |
+|---|---|---|---|
+| `school` | `edfi.school` (joined to `edfi.educationOrganization` on `schoolId`) | `schoolId` | `md5(schoolId)` |
+| `district` | `edfi.localEducationAgency` (joined on `localEducationAgencyId`) | `localEducationAgencyId` | `md5(localEducationAgencyId)` |
+| `state` | `edfi.stateEducationAgency` (joined on `stateEducationAgencyId`) | `stateEducationAgencyId` | `md5(stateEducationAgencyId)` |
+
+The OneRoster 1.2 `OrgType` enumeration also defines `local` and `national`.
+These are not emitted by the service — every row produced by `orgs.sql` is
+one of `school`, `district`, or `state`.
+
+Each row also includes:
+
+- `status = 'active'` (hardcoded)
+- `name` from `educationOrganization.nameOfInstitution`
+- `dateLastModified` from `educationOrganization.lastModifiedDate`
+- `metadata.edfi.resource` set to `schools`, `localEducationAgencies`, or
+  `stateEducationAgencies` with the natural key echoed back
+
+## Custom `EducationOrganizationCategoryDescriptor` values
+
+:::info
+
+**Custom `EducationOrganizationCategoryDescriptor` values have no effect on
+OneRoster `org.type`.** The view keys entirely off which Ed-Fi entity table
+the row lives in — `edfi.school`, `edfi.localEducationAgency`, or
+`edfi.stateEducationAgency`. `edfi.descriptor` / `EducationOrganizationCategory`
+is not referenced by `orgs.sql`.
+
+:::
+
+Practical implications:
+
+- An Ed-Fi `school` row is always emitted as OneRoster `type = 'school'`,
+  regardless of the `EducationOrganizationCategoryDescriptor` assigned to it.
+- Deployments with custom school or LEA categories (e.g., charter school
+  networks, intermediate units) do not need to add any descriptor mapping to
+  have those organizations appear correctly in `/orgs`.
+- There is no supported way, in the current release, to project Ed-Fi rows
+  into OneRoster `type = 'local'` or `type = 'national'`. Teams that require
+  those values should raise an issue against the OneRoster service.
+
+## Parent / children composition
+
+OneRoster `parent` and `children` are assembled from the Ed-Fi ODS
+`educationOrganization` hierarchy.
+
+### Schools
+
+Each school's `parent` is its LEA when
+`edfi.school.localEducationAgencyId` is populated:
+
+```json
+{
+  "parent": {
+    "href": "/orgs/<md5(localEducationAgencyId)>",
+    "sourcedId": "<md5(localEducationAgencyId)>",
+    "type": "org"
+  },
+  "children": null
+}
+```
+
+A school with no `localEducationAgencyId` is emitted with `parent = null`.
+Schools always emit `children = null`.
+
+### LEAs (districts)
+
+Each LEA's `parent` is its SEA when
+`edfi.localEducationAgency.stateEducationAgencyId` is populated. `children`
+is a JSON array of all `edfi.school` rows whose `localEducationAgencyId`
+matches this LEA:
+
+```json
+{
+  "parent": {
+    "href": "/orgs/<md5(stateEducationAgencyId)>",
+    "sourcedId": "<md5(stateEducationAgencyId)>",
+    "type": "org"
+  },
+  "children": [
+    { "href": "/orgs/<md5(schoolId1)>", "sourcedId": "...", "type": "org" },
+    { "href": "/orgs/<md5(schoolId2)>", "sourcedId": "...", "type": "org" }
+  ]
+}
+```
+
+An LEA with no `stateEducationAgencyId` is emitted with `parent = null`.
+
+### SEAs (states)
+
+SEAs never have a parent; `parent` is always `null`. `children` is a JSON
+array of all LEAs whose `stateEducationAgencyId` matches this SEA. Schools do
+_not_ appear directly in a SEA's `children`; they are reached transitively
+through the SEA's LEAs.
+
+## Intermediate education agencies and non-hierarchical org types
+
+Ed-Fi supports several education-organization entity types that are not
+materialized into OneRoster `/orgs`:
+
+- `edfi.educationServiceCenter`
+- `educationOrganizationNetworkAssociation`
+- `communityOrganization` (where the extension is installed)
+
+These rows are present in `edfi.educationOrganization` but have no `school`,
+`localEducationAgency`, or `stateEducationAgency` row, so they are dropped by
+the `orgs.sql` join pattern.
+
+If an implementation needs to expose intermediate units, the recommended path
+is:
+
+1. Record the intermediate unit as a OneRoster `district` by populating
+   `edfi.localEducationAgency` for it (setting `stateEducationAgencyId` as
+   appropriate).
+2. Associate its downstream schools via `edfi.school.localEducationAgencyId`.
+
+This keeps OneRoster `/orgs` hierarchy consistent while using only the
+supported mapping.
+
+## Schools without EdOrg rows
+
+`orgs.sql` uses an inner join between `edfi.school` and
+`edfi.educationOrganization`. A school that is present in `edfi.school` but
+has no matching row in `edfi.educationOrganization` will not appear in
+`/orgs`. This is uncommon in a healthy ODS but can arise from partial
+imports; if schools are missing from OneRoster output, confirm that
+`edfi.educationOrganization` contains a row for each `schoolId`.
+
+## Authorization scope
+
+`orgs.sql` indexes the materialized view by `educationOrganizationId` so that
+row-level authorization in the service can filter on the Ed-Fi EdOrg. See
+[OAuth and JWT](../configuration/oauth-and-jwt.md) for the scope model that
+governs which org rows a given token is allowed to read.

--- a/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
+++ b/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
@@ -1,8 +1,8 @@
 # Org and Agency Mapping
 
-The OneRoster 1.2 `/orgs` endpoint exposes schools, districts, and state
+The OneRoster© 1.2 `/orgs` endpoint exposes schools, districts, and state
 agencies from an Ed-Fi ODS, keeping parent/child hierarchy intact. This page
-documents how the OneRoster org records are derived, how the `type` field is
+documents how the OneRoster© org records are derived, how the `type` field is
 assigned, and how custom or non-standard Ed-Fi education organizations are
 treated.
 
@@ -12,16 +12,16 @@ the equivalent `mssql/core/` script (refresh procedure).
 
 ## Source entities and `type` derivation
 
-OneRoster `org.type` is derived from the Ed-Fi _entity table_ each row comes
+OneRoster© `org.type` is derived from the Ed-Fi _entity table_ each row comes
 from, not from any descriptor value:
 
-| OneRoster `type` | Ed-Fi source table | OneRoster `identifier` | `sourcedId` input |
+| OneRoster© `type` | Ed-Fi source table | OneRoster© `identifier` | `sourcedId` input |
 | --- | --- | --- | --- |
 | `school` | `edfi.school` (joined to `edfi.educationOrganization` on `schoolId`) | `schoolId` | `md5(schoolId)` |
 | `district` | `edfi.localEducationAgency` (joined on `localEducationAgencyId`) | `localEducationAgencyId` | `md5(localEducationAgencyId)` |
 | `state` | `edfi.stateEducationAgency` (joined on `stateEducationAgencyId`) | `stateEducationAgencyId` | `md5(stateEducationAgencyId)` |
 
-The OneRoster 1.2 `OrgType` enumeration also defines `local` and `national`.
+The OneRoster© 1.2 `OrgType` enumeration also defines `local` and `national`.
 These are not emitted by the service — every row produced by `orgs.sql` is
 one of `school`, `district`, or `state`.
 
@@ -38,7 +38,7 @@ Each row also includes:
 :::info
 
 **Custom `EducationOrganizationCategoryDescriptor` values have no effect on
-OneRoster `org.type`.** The view keys entirely off which Ed-Fi entity table
+OneRoster© `org.type`.** The view keys entirely off which Ed-Fi entity table
 the row lives in — `edfi.school`, `edfi.localEducationAgency`, or
 `edfi.stateEducationAgency`. `edfi.descriptor` / `EducationOrganizationCategory`
 is not referenced by `orgs.sql`.
@@ -47,18 +47,18 @@ is not referenced by `orgs.sql`.
 
 Practical implications:
 
-- An Ed-Fi `school` row is always emitted as OneRoster `type = 'school'`,
+- An Ed-Fi `school` row is always emitted as OneRoster© `type = 'school'`,
   regardless of the `EducationOrganizationCategoryDescriptor` assigned to it.
 - Deployments with custom school or LEA categories (e.g., charter school
   networks, intermediate units) do not need to add any descriptor mapping to
   have those organizations appear correctly in `/orgs`.
 - There is no supported way, in the current release, to project Ed-Fi rows
-  into OneRoster `type = 'local'` or `type = 'national'`. Teams that require
-  those values should raise an issue against the OneRoster service.
+  into OneRoster© `type = 'local'` or `type = 'national'`. Teams that require
+  those values should raise an issue against the OneRoster© service.
 
 ## Parent / children composition
 
-OneRoster `parent` and `children` are assembled from the Ed-Fi ODS
+OneRoster© `parent` and `children` are assembled from the Ed-Fi ODS
 `educationOrganization` hierarchy.
 
 ### Schools
@@ -113,7 +113,7 @@ through the SEA's LEAs.
 ## Intermediate education agencies and non-hierarchical org types
 
 Ed-Fi supports several education-organization entity types that are not
-materialized into OneRoster `/orgs`:
+materialized into OneRoster© `/orgs`:
 
 - `edfi.educationServiceCenter`
 - `educationOrganizationNetworkAssociation`
@@ -126,12 +126,12 @@ the `orgs.sql` join pattern.
 If an implementation needs to expose intermediate units, the recommended path
 is:
 
-1. Record the intermediate unit as a OneRoster `district` by populating
+1. Record the intermediate unit as a OneRoster© `district` by populating
    `edfi.localEducationAgency` for it (setting `stateEducationAgencyId` as
    appropriate).
 2. Associate its downstream schools via `edfi.school.localEducationAgencyId`.
 
-This keeps OneRoster `/orgs` hierarchy consistent while using only the
+This keeps OneRoster© `/orgs` hierarchy consistent while using only the
 supported mapping.
 
 ## Schools without EdOrg rows
@@ -140,7 +140,7 @@ supported mapping.
 `edfi.educationOrganization`. A school that is present in `edfi.school` but
 has no matching row in `edfi.educationOrganization` will not appear in
 `/orgs`. This is uncommon in a healthy ODS but can arise from partial
-imports; if schools are missing from OneRoster output, confirm that
+imports; if schools are missing from OneRoster© output, confirm that
 `edfi.educationOrganization` contains a row for each `schoolId`.
 
 ## Authorization scope

--- a/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
+++ b/docs/reference/11-oneroster/data-model/org-and-agency-mapping.md
@@ -1,29 +1,29 @@
 # Org and Agency Mapping
 
-The OneRoster© 1.2 `/orgs` endpoint exposes schools, districts, and state
-agencies from an Ed-Fi ODS, keeping parent/child hierarchy intact. This page
-documents how the OneRoster© org records are derived, how the `type` field is
-assigned, and how custom or non-standard Ed-Fi education organizations are
-treated.
+The OneRoster© v1.2 `/orgs` endpoint exposes schools, districts, and state
+agencies from an Ed-Fi ODS, keeping the parent / child hierarchy intact.
+This page documents how OneRoster© org records are derived, how the `type`
+field is assigned, and how custom or non-standard Ed-Fi education
+organizations are treated.
 
 The derivation is defined in `orgs.sql` under
-`standard/{dataStandardVersion}/artifacts/pgsql/core/` (materialized view) or
-the equivalent `mssql/core/` script (refresh procedure).
+`standard/{dataStandardVersion}/artifacts/pgsql/core/` (materialized view)
+or the equivalent `mssql/core/` script (refresh procedure).
 
 ## Source entities and `type` derivation
 
-OneRoster© `org.type` is derived from the Ed-Fi _entity table_ each row comes
-from, not from any descriptor value:
+OneRoster© `org.type` is derived from the Ed-Fi entity table that each row
+comes from. No descriptor value participates in the decision.
 
 | OneRoster© `type` | Ed-Fi source table | OneRoster© `identifier` | `sourcedId` input |
 | --- | --- | --- | --- |
-| `school` | `edfi.school` (joined to `edfi.educationOrganization` on `schoolId`) | `schoolId` | `md5(schoolId)` |
-| `district` | `edfi.localEducationAgency` (joined on `localEducationAgencyId`) | `localEducationAgencyId` | `md5(localEducationAgencyId)` |
-| `state` | `edfi.stateEducationAgency` (joined on `stateEducationAgencyId`) | `stateEducationAgencyId` | `md5(stateEducationAgencyId)` |
+| `school` | `edfi.school` joined to `edfi.educationOrganization` on `schoolId` | `schoolId` | `md5(schoolId)` |
+| `district` | `edfi.localEducationAgency` joined on `localEducationAgencyId` | `localEducationAgencyId` | `md5(localEducationAgencyId)` |
+| `state` | `edfi.stateEducationAgency` joined on `stateEducationAgencyId` | `stateEducationAgencyId` | `md5(stateEducationAgencyId)` |
 
-The OneRoster© 1.2 `OrgType` enumeration also defines `local` and `national`.
-These are not emitted by the service — every row produced by `orgs.sql` is
-one of `school`, `district`, or `state`.
+The OneRoster© v1.2 `OrgType` enumeration also defines `local` and
+`national`. Neither value is emitted by the service. Every row produced by
+`orgs.sql` is one of `school`, `district`, or `state`.
 
 Each row also includes:
 
@@ -31,30 +31,32 @@ Each row also includes:
 - `name` from `educationOrganization.nameOfInstitution`
 - `dateLastModified` from `educationOrganization.lastModifiedDate`
 - `metadata.edfi.resource` set to `schools`, `localEducationAgencies`, or
-  `stateEducationAgencies` with the natural key echoed back
+  `stateEducationAgencies`, with the Ed-Fi natural key echoed back
 
 ## Custom `EducationOrganizationCategoryDescriptor` values
 
 :::info
 
 **Custom `EducationOrganizationCategoryDescriptor` values have no effect on
-OneRoster© `org.type`.** The view keys entirely off which Ed-Fi entity table
-the row lives in — `edfi.school`, `edfi.localEducationAgency`, or
-`edfi.stateEducationAgency`. `edfi.descriptor` / `EducationOrganizationCategory`
-is not referenced by `orgs.sql`.
+OneRoster© `org.type`.** The view keys off which Ed-Fi entity table the row
+lives in (`edfi.school`, `edfi.localEducationAgency`, or
+`edfi.stateEducationAgency`). It does not read
+`edfi.descriptor` for `EducationOrganizationCategory`.
 
 :::
 
-Practical implications:
+Implications:
 
-- An Ed-Fi `school` row is always emitted as OneRoster© `type = 'school'`,
-  regardless of the `EducationOrganizationCategoryDescriptor` assigned to it.
-- Deployments with custom school or LEA categories (e.g., charter school
-  networks, intermediate units) do not need to add any descriptor mapping to
-  have those organizations appear correctly in `/orgs`.
+- An `edfi.school` row is always emitted as OneRoster© `type = 'school'`,
+  regardless of the `EducationOrganizationCategoryDescriptor` assigned to
+  it.
+- Deployments with custom school or LEA categories (for example, charter
+  school networks) do not need to add any descriptor mapping to have those
+  organizations appear correctly in `/orgs`.
 - There is no supported way, in the current release, to project Ed-Fi rows
-  into OneRoster© `type = 'local'` or `type = 'national'`. Teams that require
-  those values should raise an issue against the OneRoster© service.
+  into OneRoster© `type = 'local'` or `type = 'national'`. Teams that
+  require those values should raise an issue against the OneRoster©
+  service.
 
 ## Parent / children composition
 
@@ -83,9 +85,9 @@ Schools always emit `children = null`.
 ### LEAs (districts)
 
 Each LEA's `parent` is its SEA when
-`edfi.localEducationAgency.stateEducationAgencyId` is populated. `children`
-is a JSON array of all `edfi.school` rows whose `localEducationAgencyId`
-matches this LEA:
+`edfi.localEducationAgency.stateEducationAgencyId` is populated.
+`children` is a JSON array of every `edfi.school` row whose
+`localEducationAgencyId` matches this LEA:
 
 ```json
 {
@@ -105,47 +107,38 @@ An LEA with no `stateEducationAgencyId` is emitted with `parent = null`.
 
 ### SEAs (states)
 
-SEAs never have a parent; `parent` is always `null`. `children` is a JSON
-array of all LEAs whose `stateEducationAgencyId` matches this SEA. Schools do
-_not_ appear directly in a SEA's `children`; they are reached transitively
-through the SEA's LEAs.
+SEAs never have a parent. `parent` is always `null`. `children` is a JSON
+array of every LEA whose `stateEducationAgencyId` matches this SEA.
+Schools do not appear directly in an SEA's `children`. They are reached
+transitively through the SEA's LEAs.
 
-## Intermediate education agencies and non-hierarchical org types
+## Other Ed-Fi education organization types
 
-Ed-Fi supports several education-organization entity types that are not
-materialized into OneRoster© `/orgs`:
+`orgs.sql` reads only from `edfi.school`, `edfi.localEducationAgency`, and
+`edfi.stateEducationAgency`. Other Ed-Fi education organization subtypes
+(for example `educationServiceCenter`, `organizationDepartment`,
+`postSecondaryInstitution`, `communityOrganization`, `communityProvider`)
+have rows in `edfi.educationOrganization` but no row in the three tables
+above, so they are not emitted to OneRoster© `/orgs`.
 
-- `edfi.educationServiceCenter`
-- `educationOrganizationNetworkAssociation`
-- `communityOrganization` (where the extension is installed)
+If an implementation needs to expose an intermediate unit as a OneRoster©
+organization, a workable approach is to record it as an Ed-Fi
+`localEducationAgency` (setting `stateEducationAgencyId` as appropriate)
+and associate its schools through `edfi.school.localEducationAgencyId`.
+This uses only the supported mapping and keeps the hierarchy intact.
 
-These rows are present in `edfi.educationOrganization` but have no `school`,
-`localEducationAgency`, or `stateEducationAgency` row, so they are dropped by
-the `orgs.sql` join pattern.
-
-If an implementation needs to expose intermediate units, the recommended path
-is:
-
-1. Record the intermediate unit as a OneRoster© `district` by populating
-   `edfi.localEducationAgency` for it (setting `stateEducationAgencyId` as
-   appropriate).
-2. Associate its downstream schools via `edfi.school.localEducationAgencyId`.
-
-This keeps OneRoster© `/orgs` hierarchy consistent while using only the
-supported mapping.
-
-## Schools without EdOrg rows
+## Schools without `educationOrganization` rows
 
 `orgs.sql` uses an inner join between `edfi.school` and
-`edfi.educationOrganization`. A school that is present in `edfi.school` but
+`edfi.educationOrganization`. A school that exists in `edfi.school` but
 has no matching row in `edfi.educationOrganization` will not appear in
 `/orgs`. This is uncommon in a healthy ODS but can arise from partial
-imports; if schools are missing from OneRoster© output, confirm that
+imports. If schools are missing from OneRoster© output, confirm that
 `edfi.educationOrganization` contains a row for each `schoolId`.
 
 ## Authorization scope
 
-`orgs.sql` indexes the materialized view by `educationOrganizationId` so that
-row-level authorization in the service can filter on the Ed-Fi EdOrg. See
-[OAuth and JWT](../configuration/oauth-and-jwt.md) for the scope model that
-governs which org rows a given token is allowed to read.
+`orgs.sql` indexes the materialized view by `educationOrganizationId` so
+that row-level authorization in the service can filter on the Ed-Fi
+EdOrg. See [OAuth and JWT](../configuration/oauth-and-jwt.md) for the
+scope model that governs which org rows a given token is allowed to read.

--- a/docs/reference/11-oneroster/data-model/readme.mdx
+++ b/docs/reference/11-oneroster/data-model/readme.mdx
@@ -2,16 +2,16 @@ import DocCardList from '@theme/DocCardList';
 
 # Data Model
 
-The OneRoster service exposes a OneRoster 1.2 Rostering API whose records are
+The OneRoster© service exposes a OneRoster© 1.2 Rostering API whose records are
 derived from Ed-Fi ODS entities at refresh time. This section documents how
-each OneRoster endpoint is assembled from Ed-Fi sources, how education
+each OneRoster© endpoint is assembled from Ed-Fi sources, how education
 organization hierarchies are materialized, and how Ed-Fi descriptors are
-mapped to OneRoster enumerations.
+mapped to OneRoster© enumerations.
 
 These pages describe _what comes out of the service_. For runtime behavior of
 the refresh job (cadence, orchestration) see
-[Configuration](../configuration/readme.mdx). For the shape of each OneRoster
-response, the authoritative reference is the [1EdTech OneRoster 1.2
+[Configuration](../configuration/readme.mdx). For the shape of each OneRoster©
+response, the authoritative reference is the [1EdTech OneRoster© 1.2
 specification](https://www.imsglobal.org/spec/oneroster/v1p2).
 
 <DocCardList />

--- a/docs/reference/11-oneroster/data-model/readme.mdx
+++ b/docs/reference/11-oneroster/data-model/readme.mdx
@@ -10,7 +10,7 @@ mapped to OneRoster enumerations.
 
 These pages describe _what comes out of the service_. For runtime behavior of
 the refresh job (cadence, orchestration) see
-[Configuration](../configuration/readme.md). For the shape of each OneRoster
+[Configuration](../configuration/readme.mdx). For the shape of each OneRoster
 response, the authoritative reference is the [1EdTech OneRoster 1.2
 specification](https://www.imsglobal.org/spec/oneroster/v1p2).
 

--- a/docs/reference/11-oneroster/data-model/readme.mdx
+++ b/docs/reference/11-oneroster/data-model/readme.mdx
@@ -1,0 +1,17 @@
+import DocCardList from '@theme/DocCardList';
+
+# Data Model
+
+The OneRoster service exposes a OneRoster 1.2 Rostering API whose records are
+derived from Ed-Fi ODS entities at refresh time. This section documents how
+each OneRoster endpoint is assembled from Ed-Fi sources, how education
+organization hierarchies are materialized, and how Ed-Fi descriptors are
+mapped to OneRoster enumerations.
+
+These pages describe _what comes out of the service_. For runtime behavior of
+the refresh job (cadence, orchestration) see
+[Configuration](../configuration/readme.md). For the shape of each OneRoster
+response, the authoritative reference is the [1EdTech OneRoster 1.2
+specification](https://www.imsglobal.org/spec/oneroster/v1p2).
+
+<DocCardList />

--- a/docs/reference/11-oneroster/data-model/readme.mdx
+++ b/docs/reference/11-oneroster/data-model/readme.mdx
@@ -2,14 +2,14 @@ import DocCardList from '@theme/DocCardList';
 
 # Data Model
 
-The OneRoster© service exposes a OneRoster© v1.2 Rostering API whose records
+The OneRoster® service exposes a OneRoster v1.2 Rostering API whose records
 are derived from Ed-Fi ODS entities at refresh time. The pages in this
-section document how each OneRoster© endpoint is assembled from Ed-Fi
+section document how each OneRoster endpoint is assembled from Ed-Fi
 sources, how education organization hierarchies are materialized, and how
-Ed-Fi descriptors are mapped to OneRoster© enumerations.
+Ed-Fi descriptors are mapped to OneRoster enumerations.
 
-For the shape of each OneRoster© response, the authoritative reference is
-the [1EdTech OneRoster© v1.2
+For the shape of each OneRoster response, the authoritative reference is
+the [1EdTech® OneRoster v1.2
 specification](https://www.imsglobal.org/spec/oneroster/v1p2). For runtime
 behavior of the refresh job (cadence, orchestration), see
 [Configuration](../configuration/readme.mdx).

--- a/docs/reference/11-oneroster/data-model/readme.mdx
+++ b/docs/reference/11-oneroster/data-model/readme.mdx
@@ -2,16 +2,16 @@ import DocCardList from '@theme/DocCardList';
 
 # Data Model
 
-The OneRoster© service exposes a OneRoster© 1.2 Rostering API whose records are
-derived from Ed-Fi ODS entities at refresh time. This section documents how
-each OneRoster© endpoint is assembled from Ed-Fi sources, how education
-organization hierarchies are materialized, and how Ed-Fi descriptors are
-mapped to OneRoster© enumerations.
+The OneRoster© service exposes a OneRoster© v1.2 Rostering API whose records
+are derived from Ed-Fi ODS entities at refresh time. The pages in this
+section document how each OneRoster© endpoint is assembled from Ed-Fi
+sources, how education organization hierarchies are materialized, and how
+Ed-Fi descriptors are mapped to OneRoster© enumerations.
 
-These pages describe _what comes out of the service_. For runtime behavior of
-the refresh job (cadence, orchestration) see
-[Configuration](../configuration/readme.mdx). For the shape of each OneRoster©
-response, the authoritative reference is the [1EdTech OneRoster© 1.2
-specification](https://www.imsglobal.org/spec/oneroster/v1p2).
+For the shape of each OneRoster© response, the authoritative reference is
+the [1EdTech OneRoster© v1.2
+specification](https://www.imsglobal.org/spec/oneroster/v1p2). For runtime
+behavior of the refresh job (cadence, orchestration), see
+[Configuration](../configuration/readme.mdx).
 
 <DocCardList />

--- a/docs/reference/11-oneroster/getting-started/_category_.json
+++ b/docs/reference/11-oneroster/getting-started/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Getting Started",
+  "position": 2
+}

--- a/docs/reference/11-oneroster/getting-started/deploy-iis.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-iis.md
@@ -1,6 +1,6 @@
 # Deploy on IIS (Windows)
 
-This page walks through hosting the Ed-Fi OneRoster Node service on
+This page walks through hosting the Ed-Fi OneRoster© Node service on
 Internet Information Services (IIS). Two architectures are supported:
 
 - **`iisnode`** — IIS owns the Node worker process lifecycle. Simplest to
@@ -21,7 +21,7 @@ Microsoft SQL Server](./deploy-mssql.md).
 - **Node.js** 18 LTS or later, with `npm` on the system `PATH`
 - Administrator access to the server
 - Connectivity from the server to the Ed-Fi ODS (PostgreSQL or SQL Server)
-- A free TCP port for the OneRoster API (default 3000)
+- A free TCP port for the OneRoster© API (default 3000)
 
 ### Required IIS components
 
@@ -76,7 +76,7 @@ OAUTH2_PUBLIC_KEY_PEM=
 
 :::note
 
-If IIS serves OneRoster under a virtual directory such as `/oneroster`,
+If IIS serves OneRoster© under a virtual directory such as `/oneroster`,
 set `API_BASE_PATH=/oneroster` in `.env` so self-referencing URLs
 (Swagger discovery, etc.) are generated correctly.
 
@@ -384,7 +384,7 @@ Useful WinSW commands:
 
 ## TLS / HTTPS
 
-To serve OneRoster over HTTPS, install or import a certificate into the
+To serve OneRoster© over HTTPS, install or import a certificate into the
 Windows certificate store and add an HTTPS binding (port 443) to the IIS
 site through **Bindings…** in IIS Manager. Both architectures benefit;
 with the reverse-proxy architecture, HTTPS is terminated at IIS and the

--- a/docs/reference/11-oneroster/getting-started/deploy-iis.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-iis.md
@@ -393,7 +393,7 @@ back-end Node service continues to listen on plain HTTP loopback.
 ## Troubleshooting
 
 | Symptom | First thing to check |
-|---|---|
+| --- | --- |
 | HTTP 500 on any request | `C:\inetpub\oneroster\logs\*.log` (iisnode stdout) |
 | HTTP 404 on all routes | URL Rewrite module installed; `web.config` rewrite rules present; application pool's .NET CLR version is **No Managed Code** |
 | Self-referencing URLs (Swagger discovery) use `http` instead of `https` | `HTTP_X_FORWARDED_PROTO` is registered under **View Server Variables**; `TRUST_PROXY=true` in `.env` |

--- a/docs/reference/11-oneroster/getting-started/deploy-iis.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-iis.md
@@ -1,0 +1,415 @@
+# Deploy on IIS (Windows)
+
+This page walks through hosting the Ed-Fi OneRoster Node service on
+Internet Information Services (IIS). Two architectures are supported:
+
+- **`iisnode`** — IIS owns the Node worker process lifecycle. Simplest to
+  install, recommended when you already host other IIS Node applications.
+- **Reverse proxy (ARR)** — Node runs as a Windows service under WinSW;
+  IIS handles TLS, routing, and forwards requests to Node over loopback.
+  Preferred for production deployments that need independent Node process
+  management.
+
+This page covers the shared prerequisites and both patterns. For database
+deployment, see [Deploy on PostgreSQL](./deploy-postgres.md) or [Deploy on
+Microsoft SQL Server](./deploy-mssql.md).
+
+## Prerequisites
+
+- **Windows Server 2016** or later (2019 / 2022 recommended)
+- **IIS 8.5** or later
+- **Node.js** 18 LTS or later, with `npm` on the system `PATH`
+- Administrator access to the server
+- Connectivity from the server to the Ed-Fi ODS (PostgreSQL or SQL Server)
+- A free TCP port for the OneRoster API (default 3000)
+
+### Required IIS components
+
+- **iisnode** — required for the `iisnode` architecture. Install from the
+  [iisnode GitHub releases](https://github.com/Azure/iisnode/releases),
+  then run `iisreset`.
+- **URL Rewrite module** — required for both architectures. Install from
+  [Microsoft](https://www.iis.net/downloads/microsoft/url-rewrite).
+- **Application Request Routing (ARR)** — required only for the reverse
+  proxy architecture. Install from
+  [Microsoft](https://www.iis.net/downloads/microsoft/application-request-routing).
+
+## Application preparation (both architectures)
+
+Clone the repository and install dependencies to your chosen application
+folder:
+
+```powershell
+git clone https://github.com/Ed-Fi-Alliance-OSS/edfi-oneroster.git C:\inetpub\oneroster
+cd C:\inetpub\oneroster
+npm install --production
+npm run build
+```
+
+Create `.env` at the application root
+(`C:\inetpub\oneroster\.env`). See [Environment
+variables](../configuration/environment-variables.md) for the full
+reference; a minimal PostgreSQL variant looks like:
+
+```env
+DB_TYPE=postgres
+DB_HOST=your-postgres-host.example.org
+DB_PORT=5432
+DB_NAME=EdFi_Ods
+DB_USER=postgres
+DB_PASS=your_password
+DB_SSL=false
+
+NODE_ENV=production
+PORT=3000
+API_BASE_PATH=
+PGBOSS_CRON=*/15 * * * *
+
+CORS_ORIGINS=http://localhost:3000,http://localhost:56641
+TRUST_PROXY=true
+
+OAUTH2_ISSUERBASEURL=https://your-issuer/
+OAUTH2_AUDIENCE=https://oneroster.example.org
+OAUTH2_TOKENSIGNINGALG=RS256
+OAUTH2_PUBLIC_KEY_PEM=
+```
+
+:::note
+
+If IIS serves OneRoster under a virtual directory such as `/oneroster`,
+set `API_BASE_PATH=/oneroster` in `.env` so self-referencing URLs
+(Swagger discovery, etc.) are generated correctly.
+
+:::
+
+### Lock down the `.env` file
+
+The `.env` file contains database credentials and JWT validation settings;
+restrict access to it:
+
+```powershell
+$envPath = "C:\inetpub\oneroster\.env"
+icacls $envPath /inheritance:r
+icacls $envPath /grant:r "SYSTEM:(F)"
+icacls $envPath /grant:r "Administrators:(F)"
+icacls $envPath /grant:r "IIS AppPool\OneRosterPool:(F)"
+```
+
+The `web.config` samples below also block `.env` / `.yml` / `.yaml` files
+from being served over HTTP.
+
+## Architecture A: hosting with `iisnode`
+
+IIS runs the Node worker itself via the `iisnode` module. The bundled
+`web.config` already wires up the handler and rewrite rules.
+
+### Step 1 — Create the Application Pool
+
+1. Open **IIS Manager** → **Application Pools** → **Add Application Pool**
+2. Name: `OneRosterPool`
+3. **.NET CLR version**: **No Managed Code** (important for Node)
+4. **Managed pipeline mode**: Integrated
+5. Open **Advanced Settings** on the pool and set:
+   - **Start Mode**: `AlwaysRunning`
+   - **Idle Time-out (minutes)**: `0`
+   - **Regular Time Interval (minutes)**: `0`
+
+### Step 2 — Create the website
+
+1. **Sites** → **Add Website…**
+2. Configure:
+   - **Site name**: `OneRoster`
+   - **Application pool**: `OneRosterPool`
+   - **Physical path**: `C:\inetpub\oneroster`
+   - **Binding**: `http`, port `80` (or another free port)
+   - **Host name**: `oneroster` (or a DNS name dedicated to this API)
+
+If you use a host name such as `oneroster` on a single server, add a
+matching DNS record or a hosts-file entry (`127.0.0.1   oneroster`).
+
+Remove any legacy virtual directory mappings under **Default Web Site** to
+avoid duplicate routes.
+
+### Step 3 — Create `web.config`
+
+`web.config` at `C:\inetpub\oneroster\web.config` should contain the
+following. The configuration wires `iisnode` to `server.js`, adds URL
+Rewrite rules that preserve original protocol and host, blocks `.env`
+from being served, and sets basic security headers.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+
+    <!-- IIS Node Configuration -->
+    <iisnode watchedFiles="web.config;*.js"
+      nodeProcessCountPerApplication="1"
+      maxConcurrentRequestsPerProcess="1024"
+      maxNamedPipeConnectionRetry="100"
+      initialRequestBufferSize="4096"
+      maxRequestBufferSize="65536"
+      uncFileChangesPollingInterval="5000"
+      gracefulShutdownTimeout="60000"
+      loggingEnabled="true"
+      logDirectory=".\logs"
+      debuggingEnabled="false"
+      devErrorsEnabled="false"
+      idlePageOutTimePeriod="0" />
+
+    <handlers>
+      <add name="iisnode" path="server.js" verb="*"
+           modules="iisnode" resourceType="Unspecified" />
+    </handlers>
+
+    <rewrite>
+      <rules>
+        <rule name="Health Check" stopProcessing="true">
+          <match url="^health-check/?$" />
+          <action type="Rewrite" url="server.js" />
+        </rule>
+
+        <rule name="Node App HTTPS" stopProcessing="true">
+          <match url=".*" />
+          <conditions>
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{HTTPS}" pattern="^ON$" />
+          </conditions>
+          <serverVariables>
+            <set name="HTTP_X_FORWARDED_PROTO" value="https" />
+            <set name="HTTP_X_FORWARDED_HOST" value="{HTTP_HOST}" />
+          </serverVariables>
+          <action type="Rewrite" url="server.js" />
+        </rule>
+
+        <rule name="Node App HTTP" stopProcessing="true">
+          <match url=".*" />
+          <conditions>
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{HTTPS}" pattern="^OFF$" />
+          </conditions>
+          <serverVariables>
+            <set name="HTTP_X_FORWARDED_PROTO" value="http" />
+            <set name="HTTP_X_FORWARDED_HOST" value="{HTTP_HOST}" />
+          </serverVariables>
+          <action type="Rewrite" url="server.js" />
+        </rule>
+      </rules>
+    </rewrite>
+
+    <security>
+      <requestFiltering>
+        <fileExtensions>
+          <add fileExtension=".env" allowed="false" />
+          <add fileExtension=".yml" allowed="false" />
+          <add fileExtension=".yaml" allowed="false" />
+        </fileExtensions>
+      </requestFiltering>
+    </security>
+
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Content-Type-Options" value="nosniff" />
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+        <add name="X-XSS-Protection" value="1; mode=block" />
+      </customHeaders>
+    </httpProtocol>
+
+  </system.webServer>
+</configuration>
+```
+
+### Step 4 — Register forwarded-header server variables
+
+For the URL Rewrite rules above to set `HTTP_X_FORWARDED_PROTO` and
+`HTTP_X_FORWARDED_HOST`, register them as allowed server variables:
+
+1. **IIS Manager** → your site → **URL Rewrite**
+2. **View Server Variables** (right panel)
+3. Add `HTTP_X_FORWARDED_PROTO` and `HTTP_X_FORWARDED_HOST`
+
+### Step 5 — Grant directory permissions
+
+```powershell
+$appPath = "C:\inetpub\oneroster"
+$appPool = "OneRosterPool"
+icacls $appPath /grant "IIS AppPool\${appPool}:(OI)(CI)F" /T /C
+```
+
+### Step 6 — Warm up and verify
+
+With `iisnode`, the application starts on the first request.
+
+```powershell
+Invoke-WebRequest -Uri "http://localhost/health-check" -UseBasicParsing
+Get-Content C:\inetpub\oneroster\logs\*.log -Tail 50
+```
+
+## Architecture B: reverse proxy to a Node Windows service
+
+This architecture runs Node independently (e.g., as a Windows service on
+port 3000) and uses IIS with ARR + URL Rewrite to terminate TLS and
+forward traffic to it.
+
+```text
+Client → IIS (80/443) → ARR + URL Rewrite → Node (localhost:3000)
+```
+
+### Step 1 — Install Required IIS Modules
+
+Install the URL Rewrite module and Application Request Routing (ARR) from
+Microsoft (see _Required IIS components_ above). After install, both
+features should appear in IIS Manager at the server level.
+
+### Step 2 — Enable the proxy in ARR
+
+1. In IIS Manager, click the server node
+2. Open **Application Request Routing Cache**
+3. Click **Server Proxy Settings** (right panel)
+4. Check **Enable proxy**, then **Apply**
+
+### Step 3 — Create the IIS site
+
+1. **Sites** → **Add Website**
+2. Configure:
+   - **Site name**: `NodeProxy` (or similar)
+   - **Physical path**: `C:\inetpub\node-proxy` (just a placeholder for
+     `web.config`)
+   - **Binding**: HTTP on port `8082` (or 80), HTTPS on port 443 if you
+     want TLS termination
+
+### Step 4 — Configure the reverse proxy rules
+
+At `C:\inetpub\node-proxy\web.config`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <rewrite>
+      <rules>
+
+        <rule name="ReverseProxyHttps" stopProcessing="true">
+          <match url="(.*)" />
+          <conditions>
+            <add input="{HTTPS}" pattern="^ON$" />
+          </conditions>
+          <serverVariables>
+            <set name="HTTP_X_FORWARDED_PROTO" value="https" />
+            <set name="HTTP_X_FORWARDED_HOST" value="{HTTP_HOST}" />
+          </serverVariables>
+          <action type="Rewrite"
+                  url="http://localhost:3000/{R:1}"
+                  appendQueryString="true" />
+        </rule>
+
+        <rule name="ReverseProxyHttp" stopProcessing="true">
+          <match url="(.*)" />
+          <conditions>
+            <add input="{HTTPS}" pattern="^OFF$" />
+          </conditions>
+          <serverVariables>
+            <set name="HTTP_X_FORWARDED_PROTO" value="http" />
+            <set name="HTTP_X_FORWARDED_HOST" value="{HTTP_HOST}" />
+          </serverVariables>
+          <action type="Rewrite"
+                  url="http://localhost:3000/{R:1}"
+                  appendQueryString="true" />
+        </rule>
+
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>
+```
+
+Register `HTTP_X_FORWARDED_PROTO` and `HTTP_X_FORWARDED_HOST` under the
+site's URL Rewrite → **View Server Variables** so the rules are allowed to
+set them.
+
+### Step 5 — Run Node as a Windows service with WinSW
+
+Running Node as a Windows service makes it start on boot, run in the
+background, and restart on failure. Both `NSSM` and `PM2` are possible
+alternatives; WinSW is recommended because it is actively maintained and
+XML-configured.
+
+1. Download `WinSW-x64.exe` from the [WinSW
+   releases](https://github.com/winsw/winsw/releases)
+2. Create `C:\services\oneroster-api\` and copy the binary there as
+   `OneRosterApi.exe`
+3. Create `OneRosterApi.xml` next to it:
+
+   ```xml
+   <service>
+     <id>OneRosterApi</id>
+     <name>OneRoster API</name>
+     <description>Node.js OneRoster API Service</description>
+     <executable>C:\Program Files\nodejs\node.exe</executable>
+     <arguments>server.js</arguments>
+     <workingdirectory>C:\inetpub\oneroster</workingdirectory>
+     <logpath>C:\services\oneroster-api\logs</logpath>
+     <log mode="roll" />
+     <startmode>Automatic</startmode>
+     <onfailure action="restart" delay="10 sec"/>
+   </service>
+   ```
+
+4. Install and start from an elevated PowerShell:
+
+   ```powershell
+   cd C:\services\oneroster-api
+   .\OneRosterApi.exe install
+   .\OneRosterApi.exe start
+   ```
+
+5. Confirm the service is running in `services.msc` and that it restarts
+   on reboot (`Startup type = Automatic`).
+
+### Step 6 — Verify
+
+```text
+Direct Node:       http://localhost:3000/health-check
+Through IIS proxy: http://localhost:8082/health-check
+```
+
+Useful WinSW commands:
+
+```powershell
+.\OneRosterApi.exe stop
+.\OneRosterApi.exe start
+.\OneRosterApi.exe restart
+.\OneRosterApi.exe uninstall
+```
+
+## TLS / HTTPS
+
+To serve OneRoster over HTTPS, install or import a certificate into the
+Windows certificate store and add an HTTPS binding (port 443) to the IIS
+site through **Bindings…** in IIS Manager. Both architectures benefit;
+with the reverse-proxy architecture, HTTPS is terminated at IIS and the
+back-end Node service continues to listen on plain HTTP loopback.
+
+## Troubleshooting
+
+| Symptom | First thing to check |
+|---|---|
+| HTTP 500 on any request | `C:\inetpub\oneroster\logs\*.log` (iisnode stdout) |
+| HTTP 404 on all routes | URL Rewrite module installed; `web.config` rewrite rules present; application pool's .NET CLR version is **No Managed Code** |
+| Self-referencing URLs (Swagger discovery) use `http` instead of `https` | `HTTP_X_FORWARDED_PROTO` is registered under **View Server Variables**; `TRUST_PROXY=true` in `.env` |
+| Database connection failures | `Test-NetConnection` to the DB host on 5432 / 1433; verify credentials in `.env` |
+| App seems to "sleep" after idle | Application pool `Idle Time-out = 0`; `Start Mode = AlwaysRunning`; site-level `Preload Enabled = true`; iisnode `idlePageOutTimePeriod="0"` |
+
+To enable detailed iisnode error pages for a short debugging window
+(development only — revert before production):
+
+```xml
+<iisnode
+  loggingEnabled="true"
+  devErrorsEnabled="true"
+  debuggingEnabled="true" />
+```
+
+Run `iisreset` (or recycle the app pool) so IIS reloads the new
+configuration, then flip the flags back to `false` once the issue is
+diagnosed.

--- a/docs/reference/11-oneroster/getting-started/deploy-iis.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-iis.md
@@ -3,41 +3,43 @@
 This page walks through hosting the Ed-Fi OneRoster© Node service on
 Internet Information Services (IIS). Two architectures are supported:
 
-- **`iisnode`** — IIS owns the Node worker process lifecycle. Simplest to
-  install, recommended when you already host other IIS Node applications.
-- **Reverse proxy (ARR)** — Node runs as a Windows service under WinSW;
-  IIS handles TLS, routing, and forwards requests to Node over loopback.
-  Preferred for production deployments that need independent Node process
-  management.
+- **`iisnode`**. IIS owns the Node worker process lifecycle. Simplest
+  to install. A good choice when you already host other IIS Node
+  applications.
+- **Reverse proxy (ARR)**. Node runs as a Windows service under WinSW.
+  IIS handles TLS, routing, and forwards requests to Node over
+  loopback. A good choice for production deployments that need
+  independent Node process management.
 
-This page covers the shared prerequisites and both patterns. For database
-deployment, see [Deploy on PostgreSQL](./deploy-postgres.md) or [Deploy on
-Microsoft SQL Server](./deploy-mssql.md).
+This page covers the shared prerequisites and both patterns. For
+database deployment, see [Deploy on PostgreSQL](./deploy-postgres.md) or
+[Deploy on Microsoft SQL Server](./deploy-mssql.md).
 
 ## Prerequisites
 
-- **Windows Server 2016** or later (2019 / 2022 recommended)
-- **IIS 8.5** or later
-- **Node.js** 18 LTS or later, with `npm` on the system `PATH`
+- Windows Server 2016 or later (2019 or 2022 recommended)
+- IIS 8.5 or later
+- Node.js 18 LTS or later, with `npm` on the system `PATH`
 - Administrator access to the server
-- Connectivity from the server to the Ed-Fi ODS (PostgreSQL or SQL Server)
+- Connectivity from the server to the Ed-Fi ODS (PostgreSQL or SQL
+  Server)
 - A free TCP port for the OneRoster© API (default 3000)
 
 ### Required IIS components
 
-- **iisnode** — required for the `iisnode` architecture. Install from the
-  [iisnode GitHub releases](https://github.com/Azure/iisnode/releases),
+- **iisnode**, required for the `iisnode` architecture. Install from
+  the [iisnode GitHub releases](https://github.com/Azure/iisnode/releases),
   then run `iisreset`.
-- **URL Rewrite module** — required for both architectures. Install from
+- **URL Rewrite module**, required for both architectures. Install from
   [Microsoft](https://www.iis.net/downloads/microsoft/url-rewrite).
-- **Application Request Routing (ARR)** — required only for the reverse
+- **Application Request Routing (ARR)**, required only for the reverse
   proxy architecture. Install from
   [Microsoft](https://www.iis.net/downloads/microsoft/application-request-routing).
 
 ## Application preparation (both architectures)
 
-Clone the repository and install dependencies to your chosen application
-folder:
+Clone the repository and install dependencies to your chosen
+application folder:
 
 ```powershell
 git clone https://github.com/Ed-Fi-Alliance-OSS/edfi-oneroster.git C:\inetpub\oneroster
@@ -49,7 +51,7 @@ npm run build
 Create `.env` at the application root
 (`C:\inetpub\oneroster\.env`). See [Environment
 variables](../configuration/environment-variables.md) for the full
-reference; a minimal PostgreSQL variant looks like:
+reference. A minimal PostgreSQL variant looks like:
 
 ```env
 DB_TYPE=postgres
@@ -76,16 +78,17 @@ OAUTH2_PUBLIC_KEY_PEM=
 
 :::note
 
-If IIS serves OneRoster© under a virtual directory such as `/oneroster`,
-set `API_BASE_PATH=/oneroster` in `.env` so self-referencing URLs
-(Swagger discovery, etc.) are generated correctly.
+If IIS serves OneRoster© under a virtual directory such as
+`/oneroster`, set `API_BASE_PATH=/oneroster` in `.env` so
+self-referencing URLs (such as Swagger discovery) are generated
+correctly.
 
 :::
 
 ### Lock down the `.env` file
 
-The `.env` file contains database credentials and JWT validation settings;
-restrict access to it:
+The `.env` file contains database credentials and JWT validation
+settings. Restrict access to it:
 
 ```powershell
 $envPath = "C:\inetpub\oneroster\.env"
@@ -95,17 +98,18 @@ icacls $envPath /grant:r "Administrators:(F)"
 icacls $envPath /grant:r "IIS AppPool\OneRosterPool:(F)"
 ```
 
-The `web.config` samples below also block `.env` / `.yml` / `.yaml` files
-from being served over HTTP.
+The `web.config` samples below also block `.env`, `.yml`, and `.yaml`
+files from being served over HTTP.
 
 ## Architecture A: hosting with `iisnode`
 
 IIS runs the Node worker itself via the `iisnode` module. The bundled
 `web.config` already wires up the handler and rewrite rules.
 
-### Step 1 — Create the Application Pool
+### Step 1. Create the application pool
 
-1. Open **IIS Manager** → **Application Pools** → **Add Application Pool**
+1. Open **IIS Manager**, then **Application Pools**, then **Add
+   Application Pool**.
 2. Name: `OneRosterPool`
 3. **.NET CLR version**: **No Managed Code** (important for Node)
 4. **Managed pipeline mode**: Integrated
@@ -114,9 +118,9 @@ IIS runs the Node worker itself via the `iisnode` module. The bundled
    - **Idle Time-out (minutes)**: `0`
    - **Regular Time Interval (minutes)**: `0`
 
-### Step 2 — Create the website
+### Step 2. Create the website
 
-1. **Sites** → **Add Website…**
+1. **Sites** > **Add Website**.
 2. Configure:
    - **Site name**: `OneRoster`
    - **Application pool**: `OneRosterPool`
@@ -127,15 +131,15 @@ IIS runs the Node worker itself via the `iisnode` module. The bundled
 If you use a host name such as `oneroster` on a single server, add a
 matching DNS record or a hosts-file entry (`127.0.0.1   oneroster`).
 
-Remove any legacy virtual directory mappings under **Default Web Site** to
-avoid duplicate routes.
+Remove any legacy virtual directory mappings under **Default Web Site**
+to avoid duplicate routes.
 
-### Step 3 — Create `web.config`
+### Step 3. Create `web.config`
 
 `web.config` at `C:\inetpub\oneroster\web.config` should contain the
 following. The configuration wires `iisnode` to `server.js`, adds URL
-Rewrite rules that preserve original protocol and host, blocks `.env`
-from being served, and sets basic security headers.
+Rewrite rules that preserve the original protocol and host, blocks
+`.env` from being served, and sets basic security headers.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -219,16 +223,16 @@ from being served, and sets basic security headers.
 </configuration>
 ```
 
-### Step 4 — Register forwarded-header server variables
+### Step 4. Register forwarded-header server variables
 
 For the URL Rewrite rules above to set `HTTP_X_FORWARDED_PROTO` and
 `HTTP_X_FORWARDED_HOST`, register them as allowed server variables:
 
-1. **IIS Manager** → your site → **URL Rewrite**
-2. **View Server Variables** (right panel)
-3. Add `HTTP_X_FORWARDED_PROTO` and `HTTP_X_FORWARDED_HOST`
+1. **IIS Manager** > your site > **URL Rewrite**.
+2. Click **View Server Variables** in the right panel.
+3. Add `HTTP_X_FORWARDED_PROTO` and `HTTP_X_FORWARDED_HOST`.
 
-### Step 5 — Grant directory permissions
+### Step 5. Grant directory permissions
 
 ```powershell
 $appPath = "C:\inetpub\oneroster"
@@ -236,7 +240,7 @@ $appPool = "OneRosterPool"
 icacls $appPath /grant "IIS AppPool\${appPool}:(OI)(CI)F" /T /C
 ```
 
-### Step 6 — Warm up and verify
+### Step 6. Warm up and verify
 
 With `iisnode`, the application starts on the first request.
 
@@ -247,38 +251,38 @@ Get-Content C:\inetpub\oneroster\logs\*.log -Tail 50
 
 ## Architecture B: reverse proxy to a Node Windows service
 
-This architecture runs Node independently (e.g., as a Windows service on
-port 3000) and uses IIS with ARR + URL Rewrite to terminate TLS and
-forward traffic to it.
+This architecture runs Node independently (for example, as a Windows
+service on port 3000) and uses IIS with ARR and URL Rewrite to
+terminate TLS and forward traffic to it.
 
 ```text
-Client → IIS (80/443) → ARR + URL Rewrite → Node (localhost:3000)
+Client -> IIS (80/443) -> ARR + URL Rewrite -> Node (localhost:3000)
 ```
 
-### Step 1 — Install Required IIS Modules
+### Step 1. Install required IIS modules
 
-Install the URL Rewrite module and Application Request Routing (ARR) from
-Microsoft (see _Required IIS components_ above). After install, both
-features should appear in IIS Manager at the server level.
+Install the URL Rewrite module and Application Request Routing (ARR)
+from Microsoft (see _Required IIS components_ above). After installing,
+both features should appear in IIS Manager at the server level.
 
-### Step 2 — Enable the proxy in ARR
+### Step 2. Enable the proxy in ARR
 
-1. In IIS Manager, click the server node
-2. Open **Application Request Routing Cache**
-3. Click **Server Proxy Settings** (right panel)
-4. Check **Enable proxy**, then **Apply**
+1. In IIS Manager, click the server node.
+2. Open **Application Request Routing Cache**.
+3. Click **Server Proxy Settings** in the right panel.
+4. Check **Enable proxy**, then click **Apply**.
 
-### Step 3 — Create the IIS site
+### Step 3. Create the IIS site
 
-1. **Sites** → **Add Website**
+1. **Sites** > **Add Website**.
 2. Configure:
    - **Site name**: `NodeProxy` (or similar)
-   - **Physical path**: `C:\inetpub\node-proxy` (just a placeholder for
-     `web.config`)
-   - **Binding**: HTTP on port `8082` (or 80), HTTPS on port 443 if you
-     want TLS termination
+   - **Physical path**: `C:\inetpub\node-proxy`. This is a placeholder
+     for `web.config`.
+   - **Binding**: HTTP on port `8082` (or 80). Add HTTPS on port 443 if
+     you want TLS termination.
 
-### Step 4 — Configure the reverse proxy rules
+### Step 4. Configure the reverse proxy rules
 
 At `C:\inetpub\node-proxy\web.config`:
 
@@ -324,20 +328,20 @@ At `C:\inetpub\node-proxy\web.config`:
 ```
 
 Register `HTTP_X_FORWARDED_PROTO` and `HTTP_X_FORWARDED_HOST` under the
-site's URL Rewrite → **View Server Variables** so the rules are allowed to
-set them.
+site's URL Rewrite **View Server Variables** so the rules are allowed
+to set them.
 
-### Step 5 — Run Node as a Windows service with WinSW
+### Step 5. Run Node as a Windows service with WinSW
 
 Running Node as a Windows service makes it start on boot, run in the
-background, and restart on failure. Both `NSSM` and `PM2` are possible
-alternatives; WinSW is recommended because it is actively maintained and
-XML-configured.
+background, and restart on failure. NSSM and PM2 are possible
+alternatives. WinSW is recommended because it is actively maintained
+and XML-configured.
 
 1. Download `WinSW-x64.exe` from the [WinSW
-   releases](https://github.com/winsw/winsw/releases)
+   releases](https://github.com/winsw/winsw/releases).
 2. Create `C:\services\oneroster-api\` and copy the binary there as
-   `OneRosterApi.exe`
+   `OneRosterApi.exe`.
 3. Create `OneRosterApi.xml` next to it:
 
    ```xml
@@ -363,10 +367,10 @@ XML-configured.
    .\OneRosterApi.exe start
    ```
 
-5. Confirm the service is running in `services.msc` and that it restarts
-   on reboot (`Startup type = Automatic`).
+5. Confirm the service is running in `services.msc` and that `Startup
+   type = Automatic` so it restarts on reboot.
 
-### Step 6 — Verify
+### Step 6. Verify
 
 ```text
 Direct Node:       http://localhost:3000/health-check
@@ -384,24 +388,25 @@ Useful WinSW commands:
 
 ## TLS / HTTPS
 
-To serve OneRoster© over HTTPS, install or import a certificate into the
-Windows certificate store and add an HTTPS binding (port 443) to the IIS
-site through **Bindings…** in IIS Manager. Both architectures benefit;
-with the reverse-proxy architecture, HTTPS is terminated at IIS and the
-back-end Node service continues to listen on plain HTTP loopback.
+To serve OneRoster© over HTTPS, install or import a certificate into
+the Windows certificate store and add an HTTPS binding (port 443) to
+the IIS site through **Bindings** in IIS Manager. Both architectures
+benefit. With the reverse-proxy architecture, HTTPS is terminated at
+IIS and the back-end Node service continues to listen on plain HTTP
+loopback.
 
 ## Troubleshooting
 
 | Symptom | First thing to check |
 | --- | --- |
 | HTTP 500 on any request | `C:\inetpub\oneroster\logs\*.log` (iisnode stdout) |
-| HTTP 404 on all routes | URL Rewrite module installed; `web.config` rewrite rules present; application pool's .NET CLR version is **No Managed Code** |
-| Self-referencing URLs (Swagger discovery) use `http` instead of `https` | `HTTP_X_FORWARDED_PROTO` is registered under **View Server Variables**; `TRUST_PROXY=true` in `.env` |
-| Database connection failures | `Test-NetConnection` to the DB host on 5432 / 1433; verify credentials in `.env` |
-| App seems to "sleep" after idle | Application pool `Idle Time-out = 0`; `Start Mode = AlwaysRunning`; site-level `Preload Enabled = true`; iisnode `idlePageOutTimePeriod="0"` |
+| HTTP 404 on all routes | URL Rewrite module installed, `web.config` rewrite rules present, application pool's .NET CLR version is **No Managed Code** |
+| Self-referencing URLs (Swagger discovery) use `http` instead of `https` | `HTTP_X_FORWARDED_PROTO` is registered under **View Server Variables**, `TRUST_PROXY=true` in `.env` |
+| Database connection failures | `Test-NetConnection` to the DB host on 5432 or 1433, credentials in `.env` |
+| App seems to "sleep" after idle | Application pool `Idle Time-out = 0`, `Start Mode = AlwaysRunning`, site-level `Preload Enabled = true`, iisnode `idlePageOutTimePeriod="0"` |
 
 To enable detailed iisnode error pages for a short debugging window
-(development only — revert before production):
+(development only, revert before production):
 
 ```xml
 <iisnode

--- a/docs/reference/11-oneroster/getting-started/deploy-iis.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-iis.md
@@ -1,6 +1,6 @@
 # Deploy on IIS (Windows)
 
-This page walks through hosting the Ed-Fi OneRoster© Node service on
+This page walks through hosting the Ed-Fi OneRoster® Node service on
 Internet Information Services (IIS). Two architectures are supported:
 
 - **`iisnode`**. IIS owns the Node worker process lifecycle. Simplest
@@ -23,7 +23,7 @@ database deployment, see [Deploy on PostgreSQL](./deploy-postgres.md) or
 - Administrator access to the server
 - Connectivity from the server to the Ed-Fi ODS (PostgreSQL or SQL
   Server)
-- A free TCP port for the OneRoster© API (default 3000)
+- A free TCP port for the OneRoster API (default 3000)
 
 ### Required IIS components
 
@@ -78,7 +78,7 @@ OAUTH2_PUBLIC_KEY_PEM=
 
 :::note
 
-If IIS serves OneRoster© under a virtual directory such as
+If IIS serves OneRoster under a virtual directory such as
 `/oneroster`, set `API_BASE_PATH=/oneroster` in `.env` so
 self-referencing URLs (such as Swagger discovery) are generated
 correctly.
@@ -388,7 +388,7 @@ Useful WinSW commands:
 
 ## TLS / HTTPS
 
-To serve OneRoster© over HTTPS, install or import a certificate into
+To serve OneRoster over HTTPS, install or import a certificate into
 the Windows certificate store and add an HTTPS binding (port 443) to
 the IIS site through **Bindings** in IIS Manager. Both architectures
 benefit. With the reverse-proxy architecture, HTTPS is terminated at

--- a/docs/reference/11-oneroster/getting-started/deploy-mssql.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-mssql.md
@@ -1,35 +1,36 @@
 # Deploy on Microsoft SQL Server
 
-This page walks through installing the Ed-Fi OneRoster© service against an
-Ed-Fi ODS that runs on Microsoft SQL Server. The MSSQL variant uses tables
-and stored procedures in the `oneroster12` schema (rather than materialized
-views) and relies on SQL Server Agent to drive scheduled refreshes.
+This page walks through installing the Ed-Fi OneRoster© service against
+an Ed-Fi ODS that runs on Microsoft SQL Server. The SQL Server variant
+uses tables and stored procedures in the `oneroster12` schema (rather
+than materialized views) and relies on SQL Server Agent to drive
+scheduled refreshes.
 
 ## Prerequisites
 
-- **SQL Server 2016 or later** — required for native JSON support used by
-  the refresh procedures
-- An Ed-Fi ODS database on SQL Server, reachable from where the OneRoster©
-  Node service will run
+- SQL Server 2016 or later. This is required for the JSON functions used
+  by the refresh procedures.
+- An Ed-Fi ODS database on SQL Server, reachable from where the
+  OneRoster© Node service will run.
 - A database account with permissions to create schemas, tables, stored
-  procedures, and SQL Server Agent jobs (typically `db_owner` on the ODS)
-- **SQL Server Agent must be running.** For SQL Server in Docker, enable
-  the Agent by adding `MSSQL_AGENT_ENABLED=True` to the SQL Server
-  container's environment
-- Node.js 18 LTS or later (for running both the deployment script and the
-  service)
+  procedures, and SQL Server Agent jobs. `db_owner` on the target
+  database is typical.
+- SQL Server Agent must be running. For SQL Server in Docker, add
+  `MSSQL_AGENT_ENABLED=True` to the SQL Server container environment.
+- Node.js 18 LTS or later, for running both the deployment script and
+  the service.
 
-## Step 1 — Deploy the SQL artifacts
+## Step 1. Deploy the SQL artifacts
 
-The deployment is scripted in `standard/deploy-mssql.js`, a Node.js program
-that connects to the target SQL Server, checks prerequisites, and applies
-the SQL artifacts in phases:
+The deployment is scripted in `standard/deploy-mssql.js`, a Node.js
+program that connects to the target SQL Server, checks prerequisites,
+and applies the SQL artifacts in phases:
 
-1. **Foundation** — schema, OneRoster© descriptors, descriptor mappings
-2. **Core** — tables, indexes, and refresh stored procedures for each
+1. Foundation: schema, OneRoster© descriptors, and descriptor mappings
+2. Core: tables, indexes, and refresh stored procedures for each
    OneRoster© entity
-3. **Orchestration** — the master refresh procedure and the SQL Server
-   Agent job that drives scheduled refreshes
+3. Orchestration: the master refresh procedure and the SQL Server Agent
+   job that drives scheduled refreshes
 
 From a clone of the OneRoster© service repository:
 
@@ -38,17 +39,17 @@ git clone https://github.com/Ed-Fi-Alliance-OSS/edfi-oneroster.git
 cd edfi-oneroster
 npm install
 
-# Default (Data Standard 5.0 – 5.2)
+# Default (Data Standard 5.0 through 5.2)
 node standard/deploy-mssql.js
 
 # Data Standard 4.0
 node standard/deploy-mssql.js ds4
 ```
 
-The script reads connection settings from `.env`; see [Environment
+The script reads connection settings from `.env`. See [Environment
 variables](../configuration/environment-variables.md).
 
-If you prefer manual execution, apply the SQL files in this order:
+To run the SQL manually instead, apply the files in this order:
 
 ```text
 00_setup.sql
@@ -69,11 +70,11 @@ They live under `standard/{dataStandardVersion}/artifacts/mssql/core/`
 (core scripts) and `mssql/orchestration/` (master refresh and the Agent
 job).
 
-## Step 2 — Populate the OneRoster© tables
+## Step 2. Populate the OneRoster© tables
 
-The deployment script creates the tables and procedures but does not run
-the initial population. Execute the refresh procedures once, in order, to
-seed data:
+The deployment script creates the tables and procedures but does not
+run the initial population. Execute the refresh procedures once, in
+order, to seed data:
 
 ```sql
 EXEC oneroster12.sp_refresh_orgs;
@@ -90,29 +91,30 @@ UNION ALL SELECT 'users', COUNT(*) FROM oneroster12.users
 UNION ALL SELECT 'classes', COUNT(*) FROM oneroster12.classes;
 ```
 
-After the initial run, the SQL Server Agent job takes over and refreshes
-every 15 minutes.
+After the initial run, the SQL Server Agent job takes over and
+refreshes every 15 minutes.
 
-## Step 3 — Configure the Node service
+## Step 3. Configure the Node service
 
 Copy `.env.example` to `.env` and set at least:
 
 - `DB_TYPE=mssql`
-- `MSSQL_SERVER`, `MSSQL_DATABASE`, `MSSQL_USER`, `MSSQL_PASSWORD`,
+- `MSSQL_SERVER`, `MSSQL_DATABASE`, `MSSQL_USER`, `MSSQL_PASSWORD`, and
   `MSSQL_PORT`
-- `MSSQL_ENCRYPT` and `MSSQL_TRUST_SERVER_CERTIFICATE` per your server's
-  TLS setup
-- `OAUTH2_AUDIENCE`, `OAUTH2_ISSUERBASEURL`, `OAUTH2_TOKENSIGNINGALG`
-  (the server fails fast on startup if the first two are missing)
-- `OAUTH2_PUBLIC_KEY_PEM` if you want PEM-based JWT verification;
-  otherwise leave blank to use JWKS discovery
-- `PORT`, `CORS_ORIGINS`, `TRUST_PROXY` as appropriate for your
+- `MSSQL_ENCRYPT` and `MSSQL_TRUST_SERVER_CERTIFICATE` per your
+  server's TLS setup
+- `OAUTH2_AUDIENCE`, `OAUTH2_ISSUERBASEURL`, `OAUTH2_TOKENSIGNINGALG`.
+  The server fails fast on startup if the first two are missing.
+- `OAUTH2_PUBLIC_KEY_PEM` if you want PEM-based JWT verification.
+  Otherwise leave it blank to use JWKS discovery.
+- `PORT`, `CORS_ORIGINS`, and `TRUST_PROXY` as appropriate for your
   environment
 
 See [OAuth and JWT](../configuration/oauth-and-jwt.md) and [Environment
-variables](../configuration/environment-variables.md) for the full list.
+variables](../configuration/environment-variables.md) for the full
+list.
 
-## Step 4 — Install and run
+## Step 4. Install and run
 
 ```bash
 cd edfi-oneroster
@@ -179,7 +181,8 @@ ORDER BY error_date DESC;
 
 ## Changing the refresh cadence
 
-To change from 15-minute intervals, adjust the SQL Server Agent schedule:
+To change from 15-minute intervals, adjust the SQL Server Agent
+schedule:
 
 ```sql
 -- Every 30 minutes
@@ -198,12 +201,13 @@ EXEC msdb.dbo.sp_update_schedule
 
 | Symptom | First thing to check |
 | --- | --- |
-| Data not refreshing on schedule | SQL Server Agent is running; `enabled = 1` on the `OneRoster Data Refresh` job |
-| `CREATE SCHEMA` or `CREATE PROCEDURE` fails during deployment | The deployment user has `db_owner` (or equivalent) on the target database |
-| JSON-related errors during refresh | SQL Server is 2016 or later; run `SELECT @@VERSION` |
-| Slow refresh | Review `sys.dm_db_index_usage_stats` for the `oneroster12` schema; consider updating statistics |
+| Data not refreshing on schedule | SQL Server Agent is running. Confirm `enabled = 1` on the `OneRoster Data Refresh` job. |
+| `CREATE SCHEMA` or `CREATE PROCEDURE` fails during deployment | The deployment user has `db_owner` (or equivalent) on the target database. |
+| JSON-related errors during refresh | SQL Server is 2016 or later. Run `SELECT @@VERSION`. |
+| Slow refresh | Review `sys.dm_db_index_usage_stats` for the `oneroster12` schema and consider updating statistics. |
 
-The MSSQL variant matches the PostgreSQL variant's output record-for-record
-(verified by `tests/compare-api.js` and `tests/compare-database.js` in the
-service repository), so differences in OneRoster© response content between
-engines point at an environmental issue rather than a mapping difference.
+The SQL Server variant matches the PostgreSQL variant's output
+record-for-record (verified by `tests/compare-api.js` and
+`tests/compare-database.js` in the service repository). Differences in
+OneRoster© response content between engines usually point to an
+environmental issue rather than a mapping difference.

--- a/docs/reference/11-oneroster/getting-started/deploy-mssql.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-mssql.md
@@ -197,7 +197,7 @@ EXEC msdb.dbo.sp_update_schedule
 ## Troubleshooting
 
 | Symptom | First thing to check |
-|---|---|
+| --- | --- |
 | Data not refreshing on schedule | SQL Server Agent is running; `enabled = 1` on the `OneRoster Data Refresh` job |
 | `CREATE SCHEMA` or `CREATE PROCEDURE` fails during deployment | The deployment user has `db_owner` (or equivalent) on the target database |
 | JSON-related errors during refresh | SQL Server is 2016 or later; run `SELECT @@VERSION` |

--- a/docs/reference/11-oneroster/getting-started/deploy-mssql.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-mssql.md
@@ -1,6 +1,6 @@
 # Deploy on Microsoft SQL Server
 
-This page walks through installing the Ed-Fi OneRoster© service against
+This page walks through installing the Ed-Fi OneRoster® service against
 an Ed-Fi ODS that runs on Microsoft SQL Server. The SQL Server variant
 uses tables and stored procedures in the `oneroster12` schema (rather
 than materialized views) and relies on SQL Server Agent to drive
@@ -11,7 +11,7 @@ scheduled refreshes.
 - SQL Server 2016 or later. This is required for the JSON functions used
   by the refresh procedures.
 - An Ed-Fi ODS database on SQL Server, reachable from where the
-  OneRoster© Node service will run.
+  OneRoster Node service will run.
 - A database account with permissions to create schemas, tables, stored
   procedures, and SQL Server Agent jobs. `db_owner` on the target
   database is typical.
@@ -26,13 +26,13 @@ The deployment is scripted in `standard/deploy-mssql.js`, a Node.js
 program that connects to the target SQL Server, checks prerequisites,
 and applies the SQL artifacts in phases:
 
-1. Foundation: schema, OneRoster© descriptors, and descriptor mappings
+1. Foundation: schema, OneRoster descriptors, and descriptor mappings
 2. Core: tables, indexes, and refresh stored procedures for each
-   OneRoster© entity
+   OneRoster entity
 3. Orchestration: the master refresh procedure and the SQL Server Agent
    job that drives scheduled refreshes
 
-From a clone of the OneRoster© service repository:
+From a clone of the OneRoster service repository:
 
 ```bash
 git clone https://github.com/Ed-Fi-Alliance-OSS/edfi-oneroster.git
@@ -70,7 +70,7 @@ They live under `standard/{dataStandardVersion}/artifacts/mssql/core/`
 (core scripts) and `mssql/orchestration/` (master refresh and the Agent
 job).
 
-## Step 2. Populate the OneRoster© tables
+## Step 2. Populate the OneRoster tables
 
 The deployment script creates the tables and procedures but does not
 run the initial population. Execute the refresh procedures once, in
@@ -209,5 +209,5 @@ EXEC msdb.dbo.sp_update_schedule
 The SQL Server variant matches the PostgreSQL variant's output
 record-for-record (verified by `tests/compare-api.js` and
 `tests/compare-database.js` in the service repository). Differences in
-OneRoster© response content between engines usually point to an
+OneRoster response content between engines usually point to an
 environmental issue rather than a mapping difference.

--- a/docs/reference/11-oneroster/getting-started/deploy-mssql.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-mssql.md
@@ -1,6 +1,6 @@
 # Deploy on Microsoft SQL Server
 
-This page walks through installing the Ed-Fi OneRoster service against an
+This page walks through installing the Ed-Fi OneRoster© service against an
 Ed-Fi ODS that runs on Microsoft SQL Server. The MSSQL variant uses tables
 and stored procedures in the `oneroster12` schema (rather than materialized
 views) and relies on SQL Server Agent to drive scheduled refreshes.
@@ -9,7 +9,7 @@ views) and relies on SQL Server Agent to drive scheduled refreshes.
 
 - **SQL Server 2016 or later** — required for native JSON support used by
   the refresh procedures
-- An Ed-Fi ODS database on SQL Server, reachable from where the OneRoster
+- An Ed-Fi ODS database on SQL Server, reachable from where the OneRoster©
   Node service will run
 - A database account with permissions to create schemas, tables, stored
   procedures, and SQL Server Agent jobs (typically `db_owner` on the ODS)
@@ -25,13 +25,13 @@ The deployment is scripted in `standard/deploy-mssql.js`, a Node.js program
 that connects to the target SQL Server, checks prerequisites, and applies
 the SQL artifacts in phases:
 
-1. **Foundation** — schema, OneRoster descriptors, descriptor mappings
+1. **Foundation** — schema, OneRoster© descriptors, descriptor mappings
 2. **Core** — tables, indexes, and refresh stored procedures for each
-   OneRoster entity
+   OneRoster© entity
 3. **Orchestration** — the master refresh procedure and the SQL Server
    Agent job that drives scheduled refreshes
 
-From a clone of the OneRoster service repository:
+From a clone of the OneRoster© service repository:
 
 ```bash
 git clone https://github.com/Ed-Fi-Alliance-OSS/edfi-oneroster.git
@@ -69,7 +69,7 @@ They live under `standard/{dataStandardVersion}/artifacts/mssql/core/`
 (core scripts) and `mssql/orchestration/` (master refresh and the Agent
 job).
 
-## Step 2 — Populate the OneRoster tables
+## Step 2 — Populate the OneRoster© tables
 
 The deployment script creates the tables and procedures but does not run
 the initial population. Execute the refresh procedures once, in order, to
@@ -205,5 +205,5 @@ EXEC msdb.dbo.sp_update_schedule
 
 The MSSQL variant matches the PostgreSQL variant's output record-for-record
 (verified by `tests/compare-api.js` and `tests/compare-database.js` in the
-service repository), so differences in OneRoster response content between
+service repository), so differences in OneRoster© response content between
 engines point at an environmental issue rather than a mapping difference.

--- a/docs/reference/11-oneroster/getting-started/deploy-mssql.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-mssql.md
@@ -1,0 +1,209 @@
+# Deploy on Microsoft SQL Server
+
+This page walks through installing the Ed-Fi OneRoster service against an
+Ed-Fi ODS that runs on Microsoft SQL Server. The MSSQL variant uses tables
+and stored procedures in the `oneroster12` schema (rather than materialized
+views) and relies on SQL Server Agent to drive scheduled refreshes.
+
+## Prerequisites
+
+- **SQL Server 2016 or later** — required for native JSON support used by
+  the refresh procedures
+- An Ed-Fi ODS database on SQL Server, reachable from where the OneRoster
+  Node service will run
+- A database account with permissions to create schemas, tables, stored
+  procedures, and SQL Server Agent jobs (typically `db_owner` on the ODS)
+- **SQL Server Agent must be running.** For SQL Server in Docker, enable
+  the Agent by adding `MSSQL_AGENT_ENABLED=True` to the SQL Server
+  container's environment
+- Node.js 18 LTS or later (for running both the deployment script and the
+  service)
+
+## Step 1 — Deploy the SQL artifacts
+
+The deployment is scripted in `standard/deploy-mssql.js`, a Node.js program
+that connects to the target SQL Server, checks prerequisites, and applies
+the SQL artifacts in phases:
+
+1. **Foundation** — schema, OneRoster descriptors, descriptor mappings
+2. **Core** — tables, indexes, and refresh stored procedures for each
+   OneRoster entity
+3. **Orchestration** — the master refresh procedure and the SQL Server
+   Agent job that drives scheduled refreshes
+
+From a clone of the OneRoster service repository:
+
+```bash
+git clone https://github.com/Ed-Fi-Alliance-OSS/edfi-oneroster.git
+cd edfi-oneroster
+npm install
+
+# Default (Data Standard 5.0 – 5.2)
+node standard/deploy-mssql.js
+
+# Data Standard 4.0
+node standard/deploy-mssql.js ds4
+```
+
+The script reads connection settings from `.env`; see [Environment
+variables](../configuration/environment-variables.md).
+
+If you prefer manual execution, apply the SQL files in this order:
+
+```text
+00_setup.sql
+01_descriptors.sql
+02_descriptorMappings.sql
+academic_sessions.sql
+orgs.sql
+courses.sql
+classes.sql
+demographics.sql
+users.sql
+enrollments.sql
+master_refresh.sql
+sql_agent_job.sql
+```
+
+They live under `standard/{dataStandardVersion}/artifacts/mssql/core/`
+(core scripts) and `mssql/orchestration/` (master refresh and the Agent
+job).
+
+## Step 2 — Populate the OneRoster tables
+
+The deployment script creates the tables and procedures but does not run
+the initial population. Execute the refresh procedures once, in order, to
+seed data:
+
+```sql
+EXEC oneroster12.sp_refresh_orgs;
+EXEC oneroster12.sp_refresh_academicsessions;
+EXEC oneroster12.sp_refresh_courses;
+EXEC oneroster12.sp_refresh_classes;
+EXEC oneroster12.sp_refresh_demographics;
+EXEC oneroster12.sp_refresh_users;
+EXEC oneroster12.sp_refresh_enrollments;
+
+-- Verify row counts
+SELECT 'orgs' AS [Table], COUNT(*) FROM oneroster12.orgs
+UNION ALL SELECT 'users', COUNT(*) FROM oneroster12.users
+UNION ALL SELECT 'classes', COUNT(*) FROM oneroster12.classes;
+```
+
+After the initial run, the SQL Server Agent job takes over and refreshes
+every 15 minutes.
+
+## Step 3 — Configure the Node service
+
+Copy `.env.example` to `.env` and set at least:
+
+- `DB_TYPE=mssql`
+- `MSSQL_SERVER`, `MSSQL_DATABASE`, `MSSQL_USER`, `MSSQL_PASSWORD`,
+  `MSSQL_PORT`
+- `MSSQL_ENCRYPT` and `MSSQL_TRUST_SERVER_CERTIFICATE` per your server's
+  TLS setup
+- `OAUTH2_AUDIENCE`, `OAUTH2_ISSUERBASEURL`, `OAUTH2_TOKENSIGNINGALG`
+  (the server fails fast on startup if the first two are missing)
+- `OAUTH2_PUBLIC_KEY_PEM` if you want PEM-based JWT verification;
+  otherwise leave blank to use JWKS discovery
+- `PORT`, `CORS_ORIGINS`, `TRUST_PROXY` as appropriate for your
+  environment
+
+See [OAuth and JWT](../configuration/oauth-and-jwt.md) and [Environment
+variables](../configuration/environment-variables.md) for the full list.
+
+## Step 4 — Install and run
+
+```bash
+cd edfi-oneroster
+npm install
+node server.js
+```
+
+Verify:
+
+```bash
+curl -i http://localhost:3000/health-check
+curl -i http://localhost:3000/ims/oneroster/rostering/v1p2/orgs \
+  -H "Authorization: Bearer <token>"
+```
+
+## Refresh behavior
+
+A SQL Server Agent job named `OneRoster Data Refresh` runs the master
+refresh procedure every 15 minutes. Common operations:
+
+```sql
+-- Refresh all tables immediately
+EXEC oneroster12.sp_refresh_all;
+
+-- Refresh a single table
+EXEC oneroster12.sp_refresh_users;
+
+-- Continue past errors
+EXEC oneroster12.sp_refresh_all @SkipOnError = 1;
+
+-- Ignore "recently completed" check
+EXEC oneroster12.sp_refresh_all @ForceRefresh = 1;
+```
+
+Job management:
+
+```sql
+-- Start the refresh job manually
+EXEC msdb.dbo.sp_start_job @job_name = 'OneRoster Data Refresh';
+
+-- Temporarily disable scheduled refreshes
+EXEC msdb.dbo.sp_update_job
+  @job_name = 'OneRoster Data Refresh',
+  @enabled  = 0;
+
+-- Re-enable
+EXEC msdb.dbo.sp_update_job
+  @job_name = 'OneRoster Data Refresh',
+  @enabled  = 1;
+```
+
+Status and history live in `oneroster12.refresh_history` and
+`oneroster12.refresh_errors`:
+
+```sql
+-- Recent refreshes
+SELECT * FROM oneroster12.refresh_history
+ORDER BY refresh_start DESC;
+
+-- Recent errors
+SELECT * FROM oneroster12.refresh_errors
+ORDER BY error_date DESC;
+```
+
+## Changing the refresh cadence
+
+To change from 15-minute intervals, adjust the SQL Server Agent schedule:
+
+```sql
+-- Every 30 minutes
+EXEC msdb.dbo.sp_update_schedule
+  @name = 'OneRoster Refresh Schedule',
+  @freq_subday_interval = 30;
+
+-- Hourly
+EXEC msdb.dbo.sp_update_schedule
+  @name = 'OneRoster Refresh Schedule',
+  @freq_subday_type     = 8,  -- 8 = Hours
+  @freq_subday_interval = 1;
+```
+
+## Troubleshooting
+
+| Symptom | First thing to check |
+|---|---|
+| Data not refreshing on schedule | SQL Server Agent is running; `enabled = 1` on the `OneRoster Data Refresh` job |
+| `CREATE SCHEMA` or `CREATE PROCEDURE` fails during deployment | The deployment user has `db_owner` (or equivalent) on the target database |
+| JSON-related errors during refresh | SQL Server is 2016 or later; run `SELECT @@VERSION` |
+| Slow refresh | Review `sys.dm_db_index_usage_stats` for the `oneroster12` schema; consider updating statistics |
+
+The MSSQL variant matches the PostgreSQL variant's output record-for-record
+(verified by `tests/compare-api.js` and `tests/compare-database.js` in the
+service repository), so differences in OneRoster response content between
+engines point at an environmental issue rather than a mapping difference.

--- a/docs/reference/11-oneroster/getting-started/deploy-postgres.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-postgres.md
@@ -1,13 +1,13 @@
 # Deploy on PostgreSQL
 
-This page walks through installing the Ed-Fi OneRoster© service against
+This page walks through installing the Ed-Fi OneRoster® service against
 an Ed-Fi ODS that runs on PostgreSQL. The service ships SQL artifacts
 for Ed-Fi Data Standard 4.0 and 5.0 through 5.2. The deployment script
 picks the right set based on the argument you pass.
 
 ## Prerequisites
 
-- An Ed-Fi ODS PostgreSQL database reachable from where the OneRoster©
+- An Ed-Fi ODS PostgreSQL database reachable from where the OneRoster
   Node service will run
 - A database user that can create schemas, tables, indexes, and
   materialized views in the ODS database
@@ -17,10 +17,10 @@ picks the right set based on the argument you pass.
 ## Step 1. Deploy the SQL artifacts
 
 The SQL artifacts create a separate `oneroster12` schema in the ODS
-database, seed the OneRoster©-namespaced descriptors and mappings, and
+database, seed the OneRoster-namespaced descriptors and mappings, and
 create the materialized views that back each endpoint.
 
-Clone the OneRoster© service repository, then run the PostgreSQL
+Clone the OneRoster service repository, then run the PostgreSQL
 deployment script from the repo root:
 
 ```bash
@@ -95,7 +95,7 @@ curl -i http://localhost:3000/ims/oneroster/rostering/v1p2/orgs \
 ```
 
 The bearer token must be issued by `OAUTH2_ISSUERBASEURL`, have
-audience `OAUTH2_AUDIENCE`, and contain at least one OneRoster© v1.2
+audience `OAUTH2_AUDIENCE`, and contain at least one OneRoster v1.2
 scope (`roster.readonly`, `roster-core.readonly`, or
 `roster-demographics.readonly`).
 
@@ -116,7 +116,7 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY oneroster12.orgs;
 
 The Ed-Fi Alliance publishes sandbox container images with a
 pre-populated template database. They are useful for local testing of
-OneRoster© queries.
+OneRoster queries.
 
 ```bash
 # Data Standard 5.0

--- a/docs/reference/11-oneroster/getting-started/deploy-postgres.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-postgres.md
@@ -1,0 +1,166 @@
+# Deploy on PostgreSQL
+
+This page walks through installing the Ed-Fi OneRoster service against an
+Ed-Fi ODS that runs on PostgreSQL. The service ships SQL artifacts for Ed-Fi
+Data Standard 4.0 and 5.0–5.2; the deployment script picks the right set
+based on the argument you pass.
+
+## Prerequisites
+
+- An Ed-Fi ODS PostgreSQL database (PostgreSQL 13 or later) reachable from
+  where the OneRoster Node service will run
+- A database user that can create schemas, tables, indexes, and materialized
+  views in the ODS database
+- Node.js 18 LTS or later (for running the service)
+- Bash (for the deployment script) — Windows users can run it under WSL2
+
+## Step 1 — Deploy the SQL artifacts
+
+The SQL artifacts create a separate `oneroster12` schema in the ODS
+database, seed the OneRoster-namespaced descriptors and mappings, and
+create the materialized views that back each endpoint.
+
+Clone the OneRoster service repository, then run the PostgreSQL deployment
+script from the repo root:
+
+```bash
+git clone https://github.com/Ed-Fi-Alliance-OSS/edfi-oneroster.git
+cd edfi-oneroster
+
+# Default (Data Standard 5.0 – 5.2)
+./standard/deploy-postgres.sh
+
+# Data Standard 4.0
+./standard/deploy-postgres.sh ds4
+```
+
+The script reads connection settings from `.env`; see [Environment
+variables](../configuration/environment-variables.md) for the exact keys.
+
+If you prefer to run the SQL manually, concatenate the artifact files and
+apply them with `psql`:
+
+```bash
+cd standard/5.2.0/artifacts/pgsql/core
+cat 00_setup.sql 01_descriptors.sql 02_descriptorMappings.sql \
+    academic_sessions.sql orgs.sql courses.sql classes.sql \
+    demographics.sql users.sql enrollments.sql > oneroster12.sql
+
+psql -U <username> -d <ods-db-name> -f oneroster12.sql
+```
+
+:::tip
+
+Adjust the file list for Data Standard 4.0 by pointing at
+`standard/4.0.0/artifacts/pgsql/core/` instead.
+
+:::
+
+## Step 2 — Configure the Node service
+
+Copy `.env.example` to `.env` and set at least:
+
+- `DB_TYPE=postgres`
+- `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS`, `DB_NAME` for the ODS
+- `DB_SSL` (and `DB_SSL_CA` if the server uses a private CA)
+- `OAUTH2_AUDIENCE`, `OAUTH2_ISSUERBASEURL` (the server fails fast on
+  startup if these are missing)
+- `OAUTH2_TOKENSIGNINGALG` (typically `RS256`)
+- Either `OAUTH2_PUBLIC_KEY_PEM` (PEM-encoded public key, single line with
+  `\n` separators) _or_ leave it blank to use JWKS discovery from
+  `OAUTH2_ISSUERBASEURL`
+- `PORT` (defaults to 3000)
+- `PGBOSS_CRON` (cron expression for the refresh job; default
+  `*/15 * * * *`)
+
+See [OAuth and JWT](../configuration/oauth-and-jwt.md) and [CORS, rate
+limiting, and proxy](../configuration/cors-rate-limit-proxy.md) for the
+remaining configuration groups.
+
+## Step 3 — Install and run
+
+```bash
+cd edfi-oneroster
+npm install
+node server.js
+```
+
+Verify the service responds:
+
+```bash
+curl -i http://localhost:3000/health-check
+curl -i http://localhost:3000/ims/oneroster/rostering/v1p2/orgs \
+  -H "Authorization: Bearer <token>"
+```
+
+The bearer token must be issued by `OAUTH2_ISSUERBASEURL`, have audience
+`OAUTH2_AUDIENCE`, and contain at least one OneRoster 1.2 scope
+(`roster.readonly`, `roster-core.readonly`, or `roster-demographics.readonly`).
+
+## Refresh behavior
+
+Materialized views are refreshed concurrently by a [pg-boss](https://timgit.github.io/pg-boss/)
+cron job running inside the Node service, on the schedule given by
+`PGBOSS_CRON`. Refreshes run one-at-a-time to avoid contention.
+
+Manually refreshing a view:
+
+```sql
+REFRESH MATERIALIZED VIEW CONCURRENTLY oneroster12.orgs;
+```
+
+## Standing up a local Ed-Fi ODS for testing
+
+The Ed-Fi Alliance publishes sandbox container images with a pre-populated
+template database. They are useful for local testing of OneRoster queries:
+
+```bash
+# Data Standard 5.0
+docker run -d -e POSTGRES_PASSWORD=P@ssw0rd -p 5432:5432 \
+  edfialliance/ods-api-db-ods-sandbox:7.1
+
+# Data Standard 5.1
+docker run -d -e POSTGRES_PASSWORD=P@ssw0rd -p 5432:5432 \
+  edfialliance/ods-api-db-ods-sandbox:7.2
+
+# Data Standard 5.2
+docker run -d -e POSTGRES_PASSWORD=P@ssw0rd -p 5432:5432 \
+  edfialliance/ods-api-db-ods-sandbox:7.3
+```
+
+The populated template ships with `datallowconn = false`. Enable
+connections before pointing the deployment script at it:
+
+```bash
+psql -U postgres -c \
+  "ALTER DATABASE \"EdFi_Ods_Populated_Template\" ALLOW_CONNECTIONS true;"
+```
+
+### Windows / WSL notes
+
+On Windows, run the deployment script and `psql` under WSL2 for a smoother
+experience with Docker and shell tooling:
+
+1. Install WSL (Ubuntu recommended):
+
+   ```powershell
+   # From an elevated PowerShell prompt
+   wsl --install
+   ```
+
+2. Install Docker Desktop for Windows and enable the Ubuntu distro under
+   _Settings → Resources → WSL Integration_.
+
+3. Start the sandbox container and enable connections, from WSL:
+
+   ```bash
+   docker run -d -e POSTGRES_PASSWORD=P@ssw0rd -p 5432:5432 \
+     --name edfi-ods-ds5 edfialliance/ods-api-db-ods-sandbox:7.1
+
+   docker exec -it edfi-ods-ds5 psql -U postgres -c \
+     "UPDATE pg_database SET datistemplate=false, datallowconn=true \
+      WHERE datname='EdFi_Ods_Populated_Template';"
+   ```
+
+This is only needed because the container initialization marks the populated
+template as a template database (which blocks connections).

--- a/docs/reference/11-oneroster/getting-started/deploy-postgres.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-postgres.md
@@ -1,43 +1,44 @@
 # Deploy on PostgreSQL
 
-This page walks through installing the Ed-Fi OneRoster© service against an
-Ed-Fi ODS that runs on PostgreSQL. The service ships SQL artifacts for Ed-Fi
-Data Standard 4.0 and 5.0–5.2; the deployment script picks the right set
-based on the argument you pass.
+This page walks through installing the Ed-Fi OneRoster© service against
+an Ed-Fi ODS that runs on PostgreSQL. The service ships SQL artifacts
+for Ed-Fi Data Standard 4.0 and 5.0 through 5.2. The deployment script
+picks the right set based on the argument you pass.
 
 ## Prerequisites
 
-- An Ed-Fi ODS PostgreSQL database (PostgreSQL 13 or later) reachable from
-  where the OneRoster© Node service will run
-- A database user that can create schemas, tables, indexes, and materialized
-  views in the ODS database
-- Node.js 18 LTS or later (for running the service)
-- Bash (for the deployment script) — Windows users can run it under WSL2
+- An Ed-Fi ODS PostgreSQL database reachable from where the OneRoster©
+  Node service will run
+- A database user that can create schemas, tables, indexes, and
+  materialized views in the ODS database
+- Node.js 18 LTS or later, for running the service
+- Bash, for the deployment script. Windows users can run it under WSL2.
 
-## Step 1 — Deploy the SQL artifacts
+## Step 1. Deploy the SQL artifacts
 
 The SQL artifacts create a separate `oneroster12` schema in the ODS
 database, seed the OneRoster©-namespaced descriptors and mappings, and
 create the materialized views that back each endpoint.
 
-Clone the OneRoster© service repository, then run the PostgreSQL deployment
-script from the repo root:
+Clone the OneRoster© service repository, then run the PostgreSQL
+deployment script from the repo root:
 
 ```bash
 git clone https://github.com/Ed-Fi-Alliance-OSS/edfi-oneroster.git
 cd edfi-oneroster
 
-# Default (Data Standard 5.0 – 5.2)
+# Default (Data Standard 5.0 through 5.2)
 ./standard/deploy-postgres.sh
 
 # Data Standard 4.0
 ./standard/deploy-postgres.sh ds4
 ```
 
-The script reads connection settings from `.env`; see [Environment
-variables](../configuration/environment-variables.md) for the exact keys.
+The script reads connection settings from `.env`. See [Environment
+variables](../configuration/environment-variables.md) for the exact
+keys.
 
-If you prefer to run the SQL manually, concatenate the artifact files and
+To run the SQL manually instead, concatenate the artifact files and
 apply them with `psql`:
 
 ```bash
@@ -51,33 +52,33 @@ psql -U <username> -d <ods-db-name> -f oneroster12.sql
 
 :::tip
 
-Adjust the file list for Data Standard 4.0 by pointing at
-`standard/4.0.0/artifacts/pgsql/core/` instead.
+For Data Standard 4.0, point at `standard/4.0.0/artifacts/pgsql/core/`
+instead.
 
 :::
 
-## Step 2 — Configure the Node service
+## Step 2. Configure the Node service
 
 Copy `.env.example` to `.env` and set at least:
 
 - `DB_TYPE=postgres`
 - `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS`, `DB_NAME` for the ODS
-- `DB_SSL` (and `DB_SSL_CA` if the server uses a private CA)
-- `OAUTH2_AUDIENCE`, `OAUTH2_ISSUERBASEURL` (the server fails fast on
-  startup if these are missing)
+- `DB_SSL`, and `DB_SSL_CA` if the server uses a private CA
+- `OAUTH2_AUDIENCE` and `OAUTH2_ISSUERBASEURL`. The server fails fast on
+  startup if either is missing.
 - `OAUTH2_TOKENSIGNINGALG` (typically `RS256`)
-- Either `OAUTH2_PUBLIC_KEY_PEM` (PEM-encoded public key, single line with
-  `\n` separators) _or_ leave it blank to use JWKS discovery from
-  `OAUTH2_ISSUERBASEURL`
-- `PORT` (defaults to 3000)
-- `PGBOSS_CRON` (cron expression for the refresh job; default
+- `OAUTH2_PUBLIC_KEY_PEM` if you want PEM-based JWT verification.
+  Otherwise leave it blank to use JWKS discovery from
+  `OAUTH2_ISSUERBASEURL`.
+- `PORT` (defaults to `3000`)
+- `PGBOSS_CRON`, the cron expression for the refresh job (default
   `*/15 * * * *`)
 
 See [OAuth and JWT](../configuration/oauth-and-jwt.md) and [CORS, rate
 limiting, and proxy](../configuration/cors-rate-limit-proxy.md) for the
 remaining configuration groups.
 
-## Step 3 — Install and run
+## Step 3. Install and run
 
 ```bash
 cd edfi-oneroster
@@ -93,17 +94,19 @@ curl -i http://localhost:3000/ims/oneroster/rostering/v1p2/orgs \
   -H "Authorization: Bearer <token>"
 ```
 
-The bearer token must be issued by `OAUTH2_ISSUERBASEURL`, have audience
-`OAUTH2_AUDIENCE`, and contain at least one OneRoster© 1.2 scope
-(`roster.readonly`, `roster-core.readonly`, or `roster-demographics.readonly`).
+The bearer token must be issued by `OAUTH2_ISSUERBASEURL`, have
+audience `OAUTH2_AUDIENCE`, and contain at least one OneRoster© v1.2
+scope (`roster.readonly`, `roster-core.readonly`, or
+`roster-demographics.readonly`).
 
 ## Refresh behavior
 
-Materialized views are refreshed concurrently by a [pg-boss](https://timgit.github.io/pg-boss/)
-cron job running inside the Node service, on the schedule given by
-`PGBOSS_CRON`. Refreshes run one-at-a-time to avoid contention.
+Materialized views are refreshed concurrently by a
+[pg-boss](https://timgit.github.io/pg-boss/) cron job running inside the
+Node service, on the schedule given by `PGBOSS_CRON`. Refreshes run one
+at a time to avoid contention.
 
-Manually refreshing a view:
+To refresh a view manually:
 
 ```sql
 REFRESH MATERIALIZED VIEW CONCURRENTLY oneroster12.orgs;
@@ -111,8 +114,9 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY oneroster12.orgs;
 
 ## Standing up a local Ed-Fi ODS for testing
 
-The Ed-Fi Alliance publishes sandbox container images with a pre-populated
-template database. They are useful for local testing of OneRoster© queries:
+The Ed-Fi Alliance publishes sandbox container images with a
+pre-populated template database. They are useful for local testing of
+OneRoster© queries.
 
 ```bash
 # Data Standard 5.0
@@ -138,8 +142,9 @@ psql -U postgres -c \
 
 ### Windows / WSL notes
 
-On Windows, run the deployment script and `psql` under WSL2 for a smoother
-experience with Docker and shell tooling:
+On Windows, run the deployment script and `psql` under WSL2. This gives
+smoother Docker and shell behavior than running them directly in
+Windows.
 
 1. Install WSL (Ubuntu recommended):
 
@@ -148,8 +153,8 @@ experience with Docker and shell tooling:
    wsl --install
    ```
 
-2. Install Docker Desktop for Windows and enable the Ubuntu distro under
-   _Settings → Resources → WSL Integration_.
+2. Install Docker Desktop for Windows and enable the Ubuntu distro
+   under _Settings → Resources → WSL Integration_.
 
 3. Start the sandbox container and enable connections, from WSL:
 
@@ -162,5 +167,5 @@ experience with Docker and shell tooling:
       WHERE datname='EdFi_Ods_Populated_Template';"
    ```
 
-This is only needed because the container initialization marks the populated
-template as a template database (which blocks connections).
+This step is only needed because the container initialization marks the
+populated template as a template database, which blocks connections.

--- a/docs/reference/11-oneroster/getting-started/deploy-postgres.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-postgres.md
@@ -1,6 +1,6 @@
 # Deploy on PostgreSQL
 
-This page walks through installing the Ed-Fi OneRoster service against an
+This page walks through installing the Ed-Fi OneRoster© service against an
 Ed-Fi ODS that runs on PostgreSQL. The service ships SQL artifacts for Ed-Fi
 Data Standard 4.0 and 5.0–5.2; the deployment script picks the right set
 based on the argument you pass.
@@ -8,7 +8,7 @@ based on the argument you pass.
 ## Prerequisites
 
 - An Ed-Fi ODS PostgreSQL database (PostgreSQL 13 or later) reachable from
-  where the OneRoster Node service will run
+  where the OneRoster© Node service will run
 - A database user that can create schemas, tables, indexes, and materialized
   views in the ODS database
 - Node.js 18 LTS or later (for running the service)
@@ -17,10 +17,10 @@ based on the argument you pass.
 ## Step 1 — Deploy the SQL artifacts
 
 The SQL artifacts create a separate `oneroster12` schema in the ODS
-database, seed the OneRoster-namespaced descriptors and mappings, and
+database, seed the OneRoster©-namespaced descriptors and mappings, and
 create the materialized views that back each endpoint.
 
-Clone the OneRoster service repository, then run the PostgreSQL deployment
+Clone the OneRoster© service repository, then run the PostgreSQL deployment
 script from the repo root:
 
 ```bash
@@ -94,7 +94,7 @@ curl -i http://localhost:3000/ims/oneroster/rostering/v1p2/orgs \
 ```
 
 The bearer token must be issued by `OAUTH2_ISSUERBASEURL`, have audience
-`OAUTH2_AUDIENCE`, and contain at least one OneRoster 1.2 scope
+`OAUTH2_AUDIENCE`, and contain at least one OneRoster© 1.2 scope
 (`roster.readonly`, `roster-core.readonly`, or `roster-demographics.readonly`).
 
 ## Refresh behavior
@@ -112,7 +112,7 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY oneroster12.orgs;
 ## Standing up a local Ed-Fi ODS for testing
 
 The Ed-Fi Alliance publishes sandbox container images with a pre-populated
-template database. They are useful for local testing of OneRoster queries:
+template database. They are useful for local testing of OneRoster© queries:
 
 ```bash
 # Data Standard 5.0

--- a/docs/reference/11-oneroster/getting-started/docker-compose.md
+++ b/docs/reference/11-oneroster/getting-started/docker-compose.md
@@ -4,7 +4,7 @@
 
 **The bundled Docker Compose stack is for demo and evaluation only.** It
 runs a small, self-contained environment for development, testing against
-a known data set, or trying OneRoster© end-to-end with a bundled Ed-Fi
+a known data set, or trying OneRoster® end-to-end with a bundled Ed-Fi
 ODS / API and OAuth token issuer. Do not use it for production.
 
 For production-supported deployments, use one of the native paths:
@@ -13,10 +13,10 @@ Server](./deploy-mssql.md), or [IIS](./deploy-iis.md).
 
 :::
 
-The Docker Compose configuration lives in the OneRoster© service
+The Docker Compose configuration lives in the OneRoster service
 repository under `compose/`. It starts the Ed-Fi ODS / API v7 stack, an
 OAuth issuer, a Swagger UI, an NGINX TLS reverse proxy, and the
-OneRoster© Node service, wired together on a shared Docker network.
+OneRoster Node service, wired together on a shared Docker network.
 
 ## What gets deployed
 
@@ -27,7 +27,7 @@ OneRoster© Node service, wired together on a shared Docker network.
 | `swagger` | Bundled Swagger UI for the Ed-Fi v7 API |
 | `pgadmin4` | Optional database browser at `http://localhost:5050` |
 | `nginx` | Terminates TLS on `https://localhost:443` and routes to the APIs |
-| `oneroster-api` | The OneRoster© Node service, built from the repository root |
+| `oneroster-api` | The OneRoster Node service, built from the repository root |
 
 ## Prerequisites
 
@@ -64,8 +64,8 @@ Key flags:
 - `-InitializeAdminClients` seeds test vendors and clients (using
   `LEA_KEY`, `LEA_SECRET`, `SCHOOL_KEY`, and `SCHOOL_SECRET` from the env
   file) via the bootstrap script.
-- `-Rebuild` rebuilds the OneRoster© image before starting. Use this
-  after changing OneRoster© source.
+- `-Rebuild` rebuilds the OneRoster image before starting. Use this
+  after changing OneRoster source.
 
 The script validates that JWT signing keys exist (in the environment,
 env file, or via `-GenerateSigningKeys`) before starting containers.
@@ -77,7 +77,7 @@ Once the containers are healthy:
 | Service | URL |
 | --- | --- |
 | Ed-Fi API | `https://localhost/<V7_SINGLE_API_VIRTUAL_NAME>` |
-| OneRoster© API | `https://localhost/<ONEROSTER_API_VIRTUAL_NAME>` |
+| OneRoster API | `https://localhost/<ONEROSTER_API_VIRTUAL_NAME>` |
 | Swagger UI | `https://localhost/<DOCS_VIRTUAL_NAME>` |
 | pgAdmin | `http://localhost:5050` |
 
@@ -124,7 +124,7 @@ other Docker workload:
 - Do _not_ use `privileged: true`, host namespaces, or broad device
   mounts
 
-Example service hardening for the OneRoster© Node container:
+Example service hardening for the OneRoster Node container:
 
 ```yaml
 services:

--- a/docs/reference/11-oneroster/getting-started/docker-compose.md
+++ b/docs/reference/11-oneroster/getting-started/docker-compose.md
@@ -21,7 +21,7 @@ wired together on a shared Docker network.
 ## What gets deployed
 
 | Service | Role |
-|---|---|
+| --- | --- |
 | `db-ods`, `db-admin` | PostgreSQL containers seeded from the Ed-Fi populated template |
 | `v7-single-api` | Ed-Fi ODS/API v7 (used as the OAuth issuer and Ed-Fi resource API) |
 | `swagger` | Bundled Swagger UI for the Ed-Fi v7 API |
@@ -75,7 +75,7 @@ file, or via `-GenerateSigningKeys`) before starting containers.
 Once the containers are healthy:
 
 | Service | URL |
-|---|---|
+| --- | --- |
 | Ed-Fi API | `https://localhost/<V7_SINGLE_API_VIRTUAL_NAME>` |
 | OneRoster API | `https://localhost/<ONEROSTER_API_VIRTUAL_NAME>` |
 | Swagger UI | `https://localhost/<DOCS_VIRTUAL_NAME>` |
@@ -87,7 +87,7 @@ template under `compose/ssl/` so TLS certificates resolve correctly.
 ## Picking an env file
 
 | File | Target Data Standard |
-|---|---|
+| --- | --- |
 | `compose/.env.5.2.0.example` | Ed-Fi Data Standard 5.2.0 (default) |
 | `compose/.env.4.0.0.example` | Ed-Fi Data Standard 4.0.0 |
 

--- a/docs/reference/11-oneroster/getting-started/docker-compose.md
+++ b/docs/reference/11-oneroster/getting-started/docker-compose.md
@@ -1,0 +1,138 @@
+# Docker Compose (Demo)
+
+:::warning
+
+**The bundled Docker Compose stack is for demo and evaluation only.** It
+enables a small, self-contained environment for development, testing against
+a known data set, or trying OneRoster end-to-end with a bundled Ed-Fi ODS/API
+and OAuth token issuer. Do not use it for production.
+
+For production-supported deployments, use one of the native paths:
+[PostgreSQL](./deploy-postgres.md), [Microsoft SQL
+Server](./deploy-mssql.md), or [IIS](./deploy-iis.md).
+
+:::
+
+The Docker Compose configuration lives in the OneRoster service repository
+under `compose/`. It starts the Ed-Fi ODS/API v7 stack, an OAuth issuer /
+Swagger UI, an NGINX TLS reverse proxy, and the OneRoster Node service, all
+wired together on a shared Docker network.
+
+## What gets deployed
+
+| Service | Role |
+|---|---|
+| `db-ods`, `db-admin` | PostgreSQL containers seeded from the Ed-Fi populated template |
+| `v7-single-api` | Ed-Fi ODS/API v7 (used as the OAuth issuer and Ed-Fi resource API) |
+| `swagger` | Bundled Swagger UI for the Ed-Fi v7 API |
+| `pgadmin4` | Optional database browser at `http://localhost:5050` |
+| `nginx` | Terminates TLS on `https://localhost:443` and routes to the APIs |
+| `oneroster-api` | The OneRoster Node service, built from the repo root |
+
+## Prerequisites
+
+- Docker Desktop (or Docker Engine) with Compose v2
+- PowerShell 7+ (`pwsh`) — the helper scripts are written in PowerShell and
+  run cross-platform
+- Git (to clone the repository)
+
+## Quick start
+
+From a clone of `Ed-Fi-Alliance-OSS/edfi-oneroster`:
+
+```bash
+cd compose
+cp .env.5.2.0.example .env.5.2.0
+# edit .env.5.2.0 to set credentials, image tags, and JWT keys as needed
+```
+
+Then start the stack. The helper script launches all compose files together
+and can generate JWT signing keys for a quick trial:
+
+```bash
+pwsh ./start-services.ps1 -EnvFile ./.env.5.2.0 -GenerateSigningKeys -InitializeAdminClients
+```
+
+Key flags:
+
+- `-EnvFile` — points at the `.env` variant for the Data Standard version
+  you want (`.env.5.2.0` or `.env.4.0.0`). Relative paths resolve from
+  `compose/`.
+- `-GenerateSigningKeys` — creates an ephemeral RSA key pair and injects it
+  as `SECURITY__JWT__PRIVATEKEY` / `SECURITY__JWT__PUBLICKEY`. Use when you
+  don't already have keys set.
+- `-InitializeAdminClients` — seeds test vendors / clients (using
+  `LEA_KEY`, `LEA_SECRET`, `SCHOOL_KEY`, `SCHOOL_SECRET` from the env file)
+  via the bootstrap script.
+- `-Rebuild` — rebuilds the OneRoster image before starting; use after
+  changing OneRoster source.
+
+The script validates that JWT signing keys exist (in the environment, env
+file, or via `-GenerateSigningKeys`) before starting containers.
+
+## Accessing the stack
+
+Once the containers are healthy:
+
+| Service | URL |
+|---|---|
+| Ed-Fi API | `https://localhost/<V7_SINGLE_API_VIRTUAL_NAME>` |
+| OneRoster API | `https://localhost/<ONEROSTER_API_VIRTUAL_NAME>` |
+| Swagger UI | `https://localhost/<DOCS_VIRTUAL_NAME>` |
+| pgAdmin | `http://localhost:5050` |
+
+The virtual-name values come from the env file and must match the NGINX
+template under `compose/ssl/` so TLS certificates resolve correctly.
+
+## Picking an env file
+
+| File | Target Data Standard |
+|---|---|
+| `compose/.env.5.2.0.example` | Ed-Fi Data Standard 5.2.0 (default) |
+| `compose/.env.4.0.0.example` | Ed-Fi Data Standard 4.0.0 |
+
+Rename a copy to `.env.5.2.0` / `.env.4.0.0` (the version-numbered files are
+git-ignored working copies), or pass the file path directly to the helper
+scripts with `-EnvFile`.
+
+See [Environment variables](../configuration/environment-variables.md) for
+the full list of configuration keys.
+
+## Stopping the stack
+
+```bash
+pwsh ./stop-services.ps1 -EnvFile ./.env.5.2.0
+```
+
+- `-Purge` adds `--volumes --rmi all` to tear down the database volumes and
+  images as well — useful when switching Data Standards or templates.
+- `-EnvFile` should match the file used when starting so the correct compose
+  project is torn down.
+
+## Security hardening for custom compose files
+
+If you adapt the sample compose files into your own stack (even for staging),
+apply the same least-privilege controls the Ed-Fi Alliance applies elsewhere:
+
+- `cap_drop: [ALL]` by default; add back only capabilities a container needs
+- Run workload containers as a non-root user (`USER` in the Dockerfile,
+  `user:` in Compose)
+- `security_opt: ["no-new-privileges:true"]`
+- Apply seccomp / AppArmor / SELinux profiles per host platform
+- Do _not_ use `privileged: true`, host namespaces, or broad device mounts
+
+Example service hardening for the OneRoster Node container:
+
+```yaml
+services:
+  oneroster-api:
+    build: ../
+    user: appuser
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+```
+
+For third-party images (database, reverse proxy, admin tools), follow vendor
+guidance before dropping capabilities — some need them to initialize.

--- a/docs/reference/11-oneroster/getting-started/docker-compose.md
+++ b/docs/reference/11-oneroster/getting-started/docker-compose.md
@@ -3,9 +3,9 @@
 :::warning
 
 **The bundled Docker Compose stack is for demo and evaluation only.** It
-enables a small, self-contained environment for development, testing against
-a known data set, or trying OneRoster© end-to-end with a bundled Ed-Fi ODS/API
-and OAuth token issuer. Do not use it for production.
+runs a small, self-contained environment for development, testing against
+a known data set, or trying OneRoster© end-to-end with a bundled Ed-Fi
+ODS / API and OAuth token issuer. Do not use it for production.
 
 For production-supported deployments, use one of the native paths:
 [PostgreSQL](./deploy-postgres.md), [Microsoft SQL
@@ -13,28 +13,28 @@ Server](./deploy-mssql.md), or [IIS](./deploy-iis.md).
 
 :::
 
-The Docker Compose configuration lives in the OneRoster© service repository
-under `compose/`. It starts the Ed-Fi ODS/API v7 stack, an OAuth issuer /
-Swagger UI, an NGINX TLS reverse proxy, and the OneRoster© Node service, all
-wired together on a shared Docker network.
+The Docker Compose configuration lives in the OneRoster© service
+repository under `compose/`. It starts the Ed-Fi ODS / API v7 stack, an
+OAuth issuer, a Swagger UI, an NGINX TLS reverse proxy, and the
+OneRoster© Node service, wired together on a shared Docker network.
 
 ## What gets deployed
 
 | Service | Role |
 | --- | --- |
 | `db-ods`, `db-admin` | PostgreSQL containers seeded from the Ed-Fi populated template |
-| `v7-single-api` | Ed-Fi ODS/API v7 (used as the OAuth issuer and Ed-Fi resource API) |
+| `v7-single-api` | Ed-Fi ODS / API v7, used as both OAuth issuer and Ed-Fi resource API |
 | `swagger` | Bundled Swagger UI for the Ed-Fi v7 API |
 | `pgadmin4` | Optional database browser at `http://localhost:5050` |
 | `nginx` | Terminates TLS on `https://localhost:443` and routes to the APIs |
-| `oneroster-api` | The OneRoster© Node service, built from the repo root |
+| `oneroster-api` | The OneRoster© Node service, built from the repository root |
 
 ## Prerequisites
 
-- Docker Desktop (or Docker Engine) with Compose v2
-- PowerShell 7+ (`pwsh`) — the helper scripts are written in PowerShell and
-  run cross-platform
-- Git (to clone the repository)
+- Docker Desktop or Docker Engine with Compose v2
+- PowerShell 7 or later (`pwsh`). The helper scripts are PowerShell and
+  run on macOS, Linux, and Windows.
+- Git, to clone the repository
 
 ## Quick start
 
@@ -46,8 +46,8 @@ cp .env.5.2.0.example .env.5.2.0
 # edit .env.5.2.0 to set credentials, image tags, and JWT keys as needed
 ```
 
-Then start the stack. The helper script launches all compose files together
-and can generate JWT signing keys for a quick trial:
+Then start the stack. The helper script launches all compose files
+together and can generate JWT signing keys for a quick trial:
 
 ```bash
 pwsh ./start-services.ps1 -EnvFile ./.env.5.2.0 -GenerateSigningKeys -InitializeAdminClients
@@ -55,20 +55,20 @@ pwsh ./start-services.ps1 -EnvFile ./.env.5.2.0 -GenerateSigningKeys -Initialize
 
 Key flags:
 
-- `-EnvFile` — points at the `.env` variant for the Data Standard version
-  you want (`.env.5.2.0` or `.env.4.0.0`). Relative paths resolve from
+- `-EnvFile` selects the `.env` variant for the Data Standard version you
+  want (`.env.5.2.0` or `.env.4.0.0`). Relative paths resolve from
   `compose/`.
-- `-GenerateSigningKeys` — creates an ephemeral RSA key pair and injects it
-  as `SECURITY__JWT__PRIVATEKEY` / `SECURITY__JWT__PUBLICKEY`. Use when you
-  don't already have keys set.
-- `-InitializeAdminClients` — seeds test vendors / clients (using
-  `LEA_KEY`, `LEA_SECRET`, `SCHOOL_KEY`, `SCHOOL_SECRET` from the env file)
-  via the bootstrap script.
-- `-Rebuild` — rebuilds the OneRoster© image before starting; use after
-  changing OneRoster© source.
+- `-GenerateSigningKeys` creates an ephemeral RSA key pair and injects it
+  as `SECURITY__JWT__PRIVATEKEY` and `SECURITY__JWT__PUBLICKEY`. Use this
+  when you do not already have keys set.
+- `-InitializeAdminClients` seeds test vendors and clients (using
+  `LEA_KEY`, `LEA_SECRET`, `SCHOOL_KEY`, and `SCHOOL_SECRET` from the env
+  file) via the bootstrap script.
+- `-Rebuild` rebuilds the OneRoster© image before starting. Use this
+  after changing OneRoster© source.
 
-The script validates that JWT signing keys exist (in the environment, env
-file, or via `-GenerateSigningKeys`) before starting containers.
+The script validates that JWT signing keys exist (in the environment,
+env file, or via `-GenerateSigningKeys`) before starting containers.
 
 ## Accessing the stack
 
@@ -91,12 +91,12 @@ template under `compose/ssl/` so TLS certificates resolve correctly.
 | `compose/.env.5.2.0.example` | Ed-Fi Data Standard 5.2.0 (default) |
 | `compose/.env.4.0.0.example` | Ed-Fi Data Standard 4.0.0 |
 
-Rename a copy to `.env.5.2.0` / `.env.4.0.0` (the version-numbered files are
-git-ignored working copies), or pass the file path directly to the helper
-scripts with `-EnvFile`.
+Rename a copy to `.env.5.2.0` or `.env.4.0.0` (the version-numbered files
+are git-ignored working copies), or pass the file path directly to the
+helper scripts with `-EnvFile`.
 
-See [Environment variables](../configuration/environment-variables.md) for
-the full list of configuration keys.
+See [Environment variables](../configuration/environment-variables.md)
+for the full list of configuration keys.
 
 ## Stopping the stack
 
@@ -104,22 +104,25 @@ the full list of configuration keys.
 pwsh ./stop-services.ps1 -EnvFile ./.env.5.2.0
 ```
 
-- `-Purge` adds `--volumes --rmi all` to tear down the database volumes and
-  images as well — useful when switching Data Standards or templates.
-- `-EnvFile` should match the file used when starting so the correct compose
-  project is torn down.
+- `-Purge` adds `--volumes --rmi all` to tear down the database volumes
+  and images as well. Useful when switching Data Standards or templates.
+- `-EnvFile` should match the file used when starting so the correct
+  compose project is torn down.
 
 ## Security hardening for custom compose files
 
-If you adapt the sample compose files into your own stack (even for staging),
-apply the same least-privilege controls the Ed-Fi Alliance applies elsewhere:
+If you adapt the sample compose files into your own stack (even for
+staging), apply the same least-privilege controls you would apply to any
+other Docker workload:
 
-- `cap_drop: [ALL]` by default; add back only capabilities a container needs
+- `cap_drop: [ALL]` by default, adding back only capabilities a container
+  actually needs
 - Run workload containers as a non-root user (`USER` in the Dockerfile,
   `user:` in Compose)
 - `security_opt: ["no-new-privileges:true"]`
-- Apply seccomp / AppArmor / SELinux profiles per host platform
-- Do _not_ use `privileged: true`, host namespaces, or broad device mounts
+- Apply seccomp, AppArmor, or SELinux profiles per host platform
+- Do _not_ use `privileged: true`, host namespaces, or broad device
+  mounts
 
 Example service hardening for the OneRoster© Node container:
 
@@ -134,5 +137,6 @@ services:
       - no-new-privileges:true
 ```
 
-For third-party images (database, reverse proxy, admin tools), follow vendor
-guidance before dropping capabilities — some need them to initialize.
+For third-party images (database, reverse proxy, admin tools), follow
+vendor guidance before dropping capabilities. Some images need specific
+capabilities to initialize.

--- a/docs/reference/11-oneroster/getting-started/docker-compose.md
+++ b/docs/reference/11-oneroster/getting-started/docker-compose.md
@@ -4,7 +4,7 @@
 
 **The bundled Docker Compose stack is for demo and evaluation only.** It
 enables a small, self-contained environment for development, testing against
-a known data set, or trying OneRoster end-to-end with a bundled Ed-Fi ODS/API
+a known data set, or trying OneRoster© end-to-end with a bundled Ed-Fi ODS/API
 and OAuth token issuer. Do not use it for production.
 
 For production-supported deployments, use one of the native paths:
@@ -13,9 +13,9 @@ Server](./deploy-mssql.md), or [IIS](./deploy-iis.md).
 
 :::
 
-The Docker Compose configuration lives in the OneRoster service repository
+The Docker Compose configuration lives in the OneRoster© service repository
 under `compose/`. It starts the Ed-Fi ODS/API v7 stack, an OAuth issuer /
-Swagger UI, an NGINX TLS reverse proxy, and the OneRoster Node service, all
+Swagger UI, an NGINX TLS reverse proxy, and the OneRoster© Node service, all
 wired together on a shared Docker network.
 
 ## What gets deployed
@@ -27,7 +27,7 @@ wired together on a shared Docker network.
 | `swagger` | Bundled Swagger UI for the Ed-Fi v7 API |
 | `pgadmin4` | Optional database browser at `http://localhost:5050` |
 | `nginx` | Terminates TLS on `https://localhost:443` and routes to the APIs |
-| `oneroster-api` | The OneRoster Node service, built from the repo root |
+| `oneroster-api` | The OneRoster© Node service, built from the repo root |
 
 ## Prerequisites
 
@@ -64,8 +64,8 @@ Key flags:
 - `-InitializeAdminClients` — seeds test vendors / clients (using
   `LEA_KEY`, `LEA_SECRET`, `SCHOOL_KEY`, `SCHOOL_SECRET` from the env file)
   via the bootstrap script.
-- `-Rebuild` — rebuilds the OneRoster image before starting; use after
-  changing OneRoster source.
+- `-Rebuild` — rebuilds the OneRoster© image before starting; use after
+  changing OneRoster© source.
 
 The script validates that JWT signing keys exist (in the environment, env
 file, or via `-GenerateSigningKeys`) before starting containers.
@@ -77,7 +77,7 @@ Once the containers are healthy:
 | Service | URL |
 | --- | --- |
 | Ed-Fi API | `https://localhost/<V7_SINGLE_API_VIRTUAL_NAME>` |
-| OneRoster API | `https://localhost/<ONEROSTER_API_VIRTUAL_NAME>` |
+| OneRoster© API | `https://localhost/<ONEROSTER_API_VIRTUAL_NAME>` |
 | Swagger UI | `https://localhost/<DOCS_VIRTUAL_NAME>` |
 | pgAdmin | `http://localhost:5050` |
 
@@ -121,7 +121,7 @@ apply the same least-privilege controls the Ed-Fi Alliance applies elsewhere:
 - Apply seccomp / AppArmor / SELinux profiles per host platform
 - Do _not_ use `privileged: true`, host namespaces, or broad device mounts
 
-Example service hardening for the OneRoster Node container:
+Example service hardening for the OneRoster© Node container:
 
 ```yaml
 services:

--- a/docs/reference/11-oneroster/getting-started/readme.mdx
+++ b/docs/reference/11-oneroster/getting-started/readme.mdx
@@ -2,14 +2,14 @@ import DocCardList from '@theme/DocCardList';
 
 # Getting Started
 
-The Ed-Fi OneRoster© service is deployed on top of an existing Ed-Fi ODS
+The Ed-Fi OneRoster® service is deployed on top of an existing Ed-Fi ODS
 database. Pick the deployment path that matches your environment.
 
 | Path | When to use | Status |
 | --- | --- | --- |
-| [Docker Compose (demo)](./docker-compose.md) | Spin up a local end-to-end stack (ODS / API, OneRoster©, NGINX, OAuth issuer) to try the service. | Demo only, not production |
-| [Deploy on PostgreSQL](./deploy-postgres.md) | You operate an Ed-Fi ODS on PostgreSQL and want to run the OneRoster© Node service natively against it. | Production-supported |
-| [Deploy on Microsoft SQL Server](./deploy-mssql.md) | You operate an Ed-Fi ODS on SQL Server and want to run the OneRoster© Node service natively against it. | Production-supported |
+| [Docker Compose (demo)](./docker-compose.md) | Spin up a local end-to-end stack (ODS / API, OneRoster, NGINX, OAuth issuer) to try the service. | Demo only, not production |
+| [Deploy on PostgreSQL](./deploy-postgres.md) | You operate an Ed-Fi ODS on PostgreSQL and want to run the OneRoster Node service natively against it. | Production-supported |
+| [Deploy on Microsoft SQL Server](./deploy-mssql.md) | You operate an Ed-Fi ODS on SQL Server and want to run the OneRoster Node service natively against it. | Production-supported |
 | [Deploy on IIS (Windows)](./deploy-iis.md) | You run the Node service on Windows Server and want IIS to host it (via `iisnode`) or front it (via a reverse proxy). | Production-supported |
 
 All paths end with the service listening on an OAuth-protected

--- a/docs/reference/11-oneroster/getting-started/readme.mdx
+++ b/docs/reference/11-oneroster/getting-started/readme.mdx
@@ -6,7 +6,7 @@ The Ed-Fi OneRoster service is deployed on top of an existing Ed-Fi ODS
 database. Pick the deployment path that matches your environment:
 
 | Path | When to use | Status |
-|---|---|---|
+| --- | --- | --- |
 | [Docker Compose (demo)](./docker-compose.md) | Fastest way to spin up a local end-to-end stack (ODS/API + OneRoster + NGINX + OAuth) to try the service. | Demo only — not production |
 | [Deploy on PostgreSQL](./deploy-postgres.md) | You operate an Ed-Fi ODS on PostgreSQL and want to run the OneRoster Node service natively against it. | Production-supported |
 | [Deploy on Microsoft SQL Server](./deploy-mssql.md) | You operate an Ed-Fi ODS on MSSQL and want to run the OneRoster Node service natively against it. | Production-supported |

--- a/docs/reference/11-oneroster/getting-started/readme.mdx
+++ b/docs/reference/11-oneroster/getting-started/readme.mdx
@@ -3,22 +3,22 @@ import DocCardList from '@theme/DocCardList';
 # Getting Started
 
 The Ed-Fi OneRoster© service is deployed on top of an existing Ed-Fi ODS
-database. Pick the deployment path that matches your environment:
+database. Pick the deployment path that matches your environment.
 
 | Path | When to use | Status |
 | --- | --- | --- |
-| [Docker Compose (demo)](./docker-compose.md) | Fastest way to spin up a local end-to-end stack (ODS/API + OneRoster© + NGINX + OAuth) to try the service. | Demo only — not production |
+| [Docker Compose (demo)](./docker-compose.md) | Spin up a local end-to-end stack (ODS / API, OneRoster©, NGINX, OAuth issuer) to try the service. | Demo only, not production |
 | [Deploy on PostgreSQL](./deploy-postgres.md) | You operate an Ed-Fi ODS on PostgreSQL and want to run the OneRoster© Node service natively against it. | Production-supported |
-| [Deploy on Microsoft SQL Server](./deploy-mssql.md) | You operate an Ed-Fi ODS on MSSQL and want to run the OneRoster© Node service natively against it. | Production-supported |
-| [Deploy on IIS (Windows)](./deploy-iis.md) | You run the Node service on a Windows Server and want IIS to host it (via `iisnode`) or front it (via a reverse proxy). | Production-supported |
+| [Deploy on Microsoft SQL Server](./deploy-mssql.md) | You operate an Ed-Fi ODS on SQL Server and want to run the OneRoster© Node service natively against it. | Production-supported |
+| [Deploy on IIS (Windows)](./deploy-iis.md) | You run the Node service on Windows Server and want IIS to host it (via `iisnode`) or front it (via a reverse proxy). | Production-supported |
 
 All paths end with the service listening on an OAuth-protected
 `/ims/oneroster/rostering/v1p2/` URL backed by the same Ed-Fi ODS schema.
-Only the hosting / database specifics differ.
+Only the hosting and database specifics differ.
 
 :::tip
 
-Before deploying, confirm your ODS/API version against the [Supported
+Before deploying, confirm your ODS / API version against the [Supported
 Versions](../supported-versions.mdx) matrix.
 
 :::

--- a/docs/reference/11-oneroster/getting-started/readme.mdx
+++ b/docs/reference/11-oneroster/getting-started/readme.mdx
@@ -1,0 +1,26 @@
+import DocCardList from '@theme/DocCardList';
+
+# Getting Started
+
+The Ed-Fi OneRoster service is deployed on top of an existing Ed-Fi ODS
+database. Pick the deployment path that matches your environment:
+
+| Path | When to use | Status |
+|---|---|---|
+| [Docker Compose (demo)](./docker-compose.md) | Fastest way to spin up a local end-to-end stack (ODS/API + OneRoster + NGINX + OAuth) to try the service. | Demo only — not production |
+| [Deploy on PostgreSQL](./deploy-postgres.md) | You operate an Ed-Fi ODS on PostgreSQL and want to run the OneRoster Node service natively against it. | Production-supported |
+| [Deploy on Microsoft SQL Server](./deploy-mssql.md) | You operate an Ed-Fi ODS on MSSQL and want to run the OneRoster Node service natively against it. | Production-supported |
+| [Deploy on IIS (Windows)](./deploy-iis.md) | You run the Node service on a Windows Server and want IIS to host it (via `iisnode`) or front it (via a reverse proxy). | Production-supported |
+
+All paths end with the service listening on an OAuth-protected
+`/ims/oneroster/rostering/v1p2/` URL backed by the same Ed-Fi ODS schema.
+Only the hosting / database specifics differ.
+
+:::tip
+
+Before deploying, confirm your ODS/API version against the [Supported
+Versions](../supported-versions.mdx) matrix.
+
+:::
+
+<DocCardList />

--- a/docs/reference/11-oneroster/getting-started/readme.mdx
+++ b/docs/reference/11-oneroster/getting-started/readme.mdx
@@ -2,14 +2,14 @@ import DocCardList from '@theme/DocCardList';
 
 # Getting Started
 
-The Ed-Fi OneRoster service is deployed on top of an existing Ed-Fi ODS
+The Ed-Fi OneRoster© service is deployed on top of an existing Ed-Fi ODS
 database. Pick the deployment path that matches your environment:
 
 | Path | When to use | Status |
 | --- | --- | --- |
-| [Docker Compose (demo)](./docker-compose.md) | Fastest way to spin up a local end-to-end stack (ODS/API + OneRoster + NGINX + OAuth) to try the service. | Demo only — not production |
-| [Deploy on PostgreSQL](./deploy-postgres.md) | You operate an Ed-Fi ODS on PostgreSQL and want to run the OneRoster Node service natively against it. | Production-supported |
-| [Deploy on Microsoft SQL Server](./deploy-mssql.md) | You operate an Ed-Fi ODS on MSSQL and want to run the OneRoster Node service natively against it. | Production-supported |
+| [Docker Compose (demo)](./docker-compose.md) | Fastest way to spin up a local end-to-end stack (ODS/API + OneRoster© + NGINX + OAuth) to try the service. | Demo only — not production |
+| [Deploy on PostgreSQL](./deploy-postgres.md) | You operate an Ed-Fi ODS on PostgreSQL and want to run the OneRoster© Node service natively against it. | Production-supported |
+| [Deploy on Microsoft SQL Server](./deploy-mssql.md) | You operate an Ed-Fi ODS on MSSQL and want to run the OneRoster© Node service natively against it. | Production-supported |
 | [Deploy on IIS (Windows)](./deploy-iis.md) | You run the Node service on a Windows Server and want IIS to host it (via `iisnode`) or front it (via a reverse proxy). | Production-supported |
 
 All paths end with the service listening on an OAuth-protected

--- a/docs/reference/11-oneroster/readme.mdx
+++ b/docs/reference/11-oneroster/readme.mdx
@@ -1,25 +1,25 @@
 import DocCardList from '@theme/DocCardList';
 
-# Ed-Fi OneRoster
+# Ed-Fi OneRoster©
 
 ## Welcome
 
 ---
 
-The Ed-Fi OneRoster service serves a [1EdTech OneRoster 1.2
+The Ed-Fi OneRoster© service serves a [1EdTech OneRoster© v1.2
 Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) API from data in an
 existing Ed-Fi ODS. It is implemented as a Node.js/Express application that
 reads from the ODS via materialized views (PostgreSQL) or stored-procedure-fed
-tables (Microsoft SQL Server) and exposes the standard OneRoster rostering
+tables (Microsoft SQL Server) and exposes the standard OneRoster© rostering
 endpoints over OAuth 2.0.
 
-It is released and versioned independently from the Ed-Fi ODS/API and supports
+It is released and versioned independently from the Ed-Fi ODS/API and currently supports
 Ed-Fi Data Standard 4.0 and 5.0 – 5.2 from the same code base.
 
 :::tip
 
-Already running an Ed-Fi ODS/API and want to expose OneRoster to a vendor
-application? Start with _What is the Ed-Fi OneRoster service_ to confirm it
+Already running an Ed-Fi ODS/API and want to expose OneRoster© to a vendor
+application? Start with _What is the Ed-Fi OneRoster© service_ to confirm it
 fits your use case, then pick a deployment path under _Getting Started_.
 
 :::

--- a/docs/reference/11-oneroster/readme.mdx
+++ b/docs/reference/11-oneroster/readme.mdx
@@ -1,17 +1,17 @@
 import DocCardList from '@theme/DocCardList';
 
-# Ed-Fi OneRoster©
+# Ed-Fi OneRoster®
 
 ## Welcome
 
 ---
 
-The Ed-Fi OneRoster© service serves a [1EdTech OneRoster© v1.2
+The Ed-Fi OneRoster service serves a [1EdTech® OneRoster v1.2
 Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) API from data in an
 existing Ed-Fi ODS. It is a Node.js / Express application that reads the ODS
 through a separate `oneroster12` schema (materialized views on PostgreSQL,
 tables fed by stored procedures on Microsoft SQL Server) and exposes the
-standard OneRoster© rostering endpoints over OAuth 2.0.
+standard OneRoster rostering endpoints over OAuth 2.0.
 
 The service is released independently of the Ed-Fi ODS / API and currently
 supports Ed-Fi Data Standard 4.0 and 5.0 through 5.2 from a single code base.
@@ -21,3 +21,8 @@ supports Ed-Fi Data Standard 4.0 and 5.0 through 5.2 from a single code base.
 ---
 
 <DocCardList />
+
+---
+
+_OneRoster® and 1EdTech® are trademarks of 1EdTech® Consortium, Inc.
+([1edtech.org](https://1edtech.org))._

--- a/docs/reference/11-oneroster/readme.mdx
+++ b/docs/reference/11-oneroster/readme.mdx
@@ -8,21 +8,13 @@ import DocCardList from '@theme/DocCardList';
 
 The Ed-Fi OneRoster© service serves a [1EdTech OneRoster© v1.2
 Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) API from data in an
-existing Ed-Fi ODS. It is implemented as a Node.js/Express application that
-reads from the ODS via materialized views (PostgreSQL) or stored-procedure-fed
-tables (Microsoft SQL Server) and exposes the standard OneRoster© rostering
-endpoints over OAuth 2.0.
+existing Ed-Fi ODS. It is a Node.js / Express application that reads the ODS
+through a separate `oneroster12` schema (materialized views on PostgreSQL,
+tables fed by stored procedures on Microsoft SQL Server) and exposes the
+standard OneRoster© rostering endpoints over OAuth 2.0.
 
-It is released and versioned independently from the Ed-Fi ODS/API and currently supports
-Ed-Fi Data Standard 4.0 and 5.0 – 5.2 from the same code base.
-
-:::tip
-
-Already running an Ed-Fi ODS/API and want to expose OneRoster© to a vendor
-application? Start with _What is the Ed-Fi OneRoster© service_ to confirm it
-fits your use case, then pick a deployment path under _Getting Started_.
-
-:::
+The service is released independently of the Ed-Fi ODS / API and currently
+supports Ed-Fi Data Standard 4.0 and 5.0 through 5.2 from a single code base.
 
 ## Contents
 

--- a/docs/reference/11-oneroster/readme.mdx
+++ b/docs/reference/11-oneroster/readme.mdx
@@ -1,0 +1,31 @@
+import DocCardList from '@theme/DocCardList';
+
+# Ed-Fi OneRoster
+
+## Welcome
+
+---
+
+The Ed-Fi OneRoster service serves a [1EdTech OneRoster 1.2
+Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) API from data in an
+existing Ed-Fi ODS. It is implemented as a Node.js/Express application that
+reads from the ODS via materialized views (PostgreSQL) or stored-procedure-fed
+tables (Microsoft SQL Server) and exposes the standard OneRoster rostering
+endpoints over OAuth 2.0.
+
+It is released and versioned independently from the Ed-Fi ODS/API and supports
+Ed-Fi Data Standard 4.0 and 5.0 – 5.2 from the same code base.
+
+:::tip
+
+Already running an Ed-Fi ODS/API and want to expose OneRoster to a vendor
+application? Start with _What is the Ed-Fi OneRoster service_ to confirm it
+fits your use case, then pick a deployment path under _Getting Started_.
+
+:::
+
+## Contents
+
+---
+
+<DocCardList />

--- a/docs/reference/11-oneroster/supported-versions.mdx
+++ b/docs/reference/11-oneroster/supported-versions.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/docs/reference/11-oneroster/supported-versions.mdx
+++ b/docs/reference/11-oneroster/supported-versions.mdx
@@ -3,14 +3,14 @@ import TabItem from '@theme/TabItem';
 
 # Supported Versions
 
-The Ed-Fi OneRoster service supports two Ed-Fi Data Standard lines and two
+The Ed-Fi OneRoster© service supports two Ed-Fi Data Standard lines and two
 database engines from a single code base. The SQL artifacts for each Data
 Standard version live in the service repository under
 `standard/{dataStandardVersion}/artifacts/{pgsql|mssql}/core/`.
 
-## OneRoster specification
+## OneRoster© specification
 
-All releases implement the 1EdTech [OneRoster 1.2
+All releases implement the 1EdTech [OneRoster© 1.2
 Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) REST binding.
 
 ## Ed-Fi Data Standard support
@@ -18,7 +18,7 @@ Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) REST binding.
 | Data Standard | Supported | Notes |
 | --- | --- | --- |
 | 5.2 | Yes | Default artifact set; used with ODS/API 7.3 |
-| 5.1 | Yes | Same SQL artifacts as 5.2 (no breaking changes consumed by OneRoster) |
+| 5.1 | Yes | Same SQL artifacts as 5.2 (no breaking changes consumed by OneRoster©) |
 | 5.0 | Yes | Same SQL artifacts as 5.2 |
 | 4.0 | Yes | Separate artifact set under `standard/4.0.0/` |
 
@@ -37,7 +37,7 @@ schema, refreshed on a schedule by [pg-boss](https://timgit.github.io/pg-boss/).
 </TabItem>
 <TabItem value="mssql" label="SQL Server">
 
-The Microsoft SQL Server implementation stores OneRoster output in tables that
+The Microsoft SQL Server implementation stores OneRoster© output in tables that
 are repopulated by stored procedures on a schedule driven by SQL Server Agent.
 
 - SQL Server 2016 or later (required for JSON support)
@@ -50,7 +50,7 @@ are repopulated by stored procedures on a schedule driven by SQL Server Agent.
 
 ## Ed-Fi ODS/API image tags
 
-The OneRoster service reads directly from an Ed-Fi ODS database, so it works
+The OneRoster© service reads directly from an Ed-Fi ODS database, so it works
 with any ODS/API deployment on a supported Data Standard. The ODS/API image
 tags below can be used to stand up a compatible ODS for local testing:
 
@@ -62,9 +62,9 @@ tags below can be used to stand up a compatible ODS for local testing:
 
 For Data Standard 4.0, use the matching 6.x ODS/API image line.
 
-## OneRoster service versioning
+## OneRoster© service versioning
 
-The OneRoster service follows an independent release cadence from the Ed-Fi
+The OneRoster© service follows an independent release cadence from the Ed-Fi
 ODS/API. This documentation is not versioned at launch; if the service
 accumulates breaking changes in the future, per-version documentation will be
 introduced at that time.

--- a/docs/reference/11-oneroster/supported-versions.mdx
+++ b/docs/reference/11-oneroster/supported-versions.mdx
@@ -16,7 +16,7 @@ Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) REST binding.
 ## Ed-Fi Data Standard support
 
 | Data Standard | Supported | Notes |
-|---|---|---|
+| --- | --- | --- |
 | 5.2 | Yes | Default artifact set; used with ODS/API 7.3 |
 | 5.1 | Yes | Same SQL artifacts as 5.2 (no breaking changes consumed by OneRoster) |
 | 5.0 | Yes | Same SQL artifacts as 5.2 |
@@ -25,7 +25,7 @@ Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) REST binding.
 ## Database engine support
 
 <Tabs>
-  <TabItem value="pg" label="PostgreSQL" default>
+<TabItem value="pg" label="PostgreSQL" default>
 
 The PostgreSQL implementation uses materialized views in the `oneroster12`
 schema, refreshed on a schedule by [pg-boss](https://timgit.github.io/pg-boss/).
@@ -34,8 +34,8 @@ schema, refreshed on a schedule by [pg-boss](https://timgit.github.io/pg-boss/).
 - Refresh cadence is configured via `PGBOSS_CRON` (default `*/15 * * * *`)
 - See [Deploy on PostgreSQL](./getting-started/deploy-postgres.md)
 
-  </TabItem>
-  <TabItem value="mssql" label="SQL Server">
+</TabItem>
+<TabItem value="mssql" label="SQL Server">
 
 The Microsoft SQL Server implementation stores OneRoster output in tables that
 are repopulated by stored procedures on a schedule driven by SQL Server Agent.
@@ -45,7 +45,7 @@ are repopulated by stored procedures on a schedule driven by SQL Server Agent.
 - Default refresh cadence is every 15 minutes
 - See [Deploy on Microsoft SQL Server](./getting-started/deploy-mssql.md)
 
-  </TabItem>
+</TabItem>
 </Tabs>
 
 ## Ed-Fi ODS/API image tags
@@ -55,7 +55,7 @@ with any ODS/API deployment on a supported Data Standard. The ODS/API image
 tags below can be used to stand up a compatible ODS for local testing:
 
 | Data Standard | ODS/API image tag | Image |
-|---|---|---|
+| --- | --- | --- |
 | 5.2 | `7.3` | `edfialliance/ods-api-db-ods-sandbox:7.3` |
 | 5.1 | `7.2` | `edfialliance/ods-api-db-ods-sandbox:7.2` |
 | 5.0 | `7.1` | `edfialliance/ods-api-db-ods-sandbox:7.1` |

--- a/docs/reference/11-oneroster/supported-versions.mdx
+++ b/docs/reference/11-oneroster/supported-versions.mdx
@@ -14,17 +14,17 @@ Standard version live in the service repository under
 
 ## OneRoster© specification
 
-All releases implement the 1EdTech [OneRoster© 1.2
+All releases implement the 1EdTech [OneRoster© v1.2
 Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) REST binding.
 
 ## Ed-Fi Data Standard support
 
 | Data Standard | Supported | Notes |
 | --- | --- | --- |
-| 5.2 | Yes | Default artifact set; used with ODS/API 7.3 |
-| 5.1 | Yes | Same SQL artifacts as 5.2 (no breaking changes consumed by OneRoster©) |
-| 5.0 | Yes | Same SQL artifacts as 5.2 |
-| 4.0 | Yes | Separate artifact set under `standard/4.0.0/` |
+| 5.2 | Yes | Default artifact set. Compatible with ODS / API 7.3. |
+| 5.1 | Yes | Uses the 5.2 SQL artifacts. |
+| 5.0 | Yes | Uses the 5.2 SQL artifacts. |
+| 4.0 | Yes | Separate artifact set under `standard/4.0.0/`. |
 
 ## Database engine support
 
@@ -34,41 +34,45 @@ Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) REST binding.
 The PostgreSQL implementation uses materialized views in the `oneroster12`
 schema, refreshed on a schedule by [pg-boss](https://timgit.github.io/pg-boss/).
 
-- PostgreSQL 13 or later (same minimum as the supported Ed-Fi ODS/API releases)
+- Any PostgreSQL version supported by the corresponding Ed-Fi ODS / API line
 - Refresh cadence is configured via `PGBOSS_CRON` (default `*/15 * * * *`)
 - See [Deploy on PostgreSQL](./getting-started/deploy-postgres.md)
 
 </TabItem>
 <TabItem value="mssql" label="SQL Server">
 
-The Microsoft SQL Server implementation stores OneRoster© output in tables that
-are repopulated by stored procedures on a schedule driven by SQL Server Agent.
+The Microsoft SQL Server implementation stores OneRoster© output in tables
+that are repopulated by stored procedures on a schedule driven by SQL Server
+Agent.
 
-- SQL Server 2016 or later (required for JSON support)
-- SQL Server Agent must be enabled (in Docker, set `MSSQL_AGENT_ENABLED=True`)
+- SQL Server 2016 or later (required for the JSON functions used by the
+  refresh procedures)
+- SQL Server Agent must be running. For SQL Server in Docker, add
+  `MSSQL_AGENT_ENABLED=True` to the container environment.
 - Default refresh cadence is every 15 minutes
 - See [Deploy on Microsoft SQL Server](./getting-started/deploy-mssql.md)
 
 </TabItem>
 </Tabs>
 
-## Ed-Fi ODS/API image tags
+## Ed-Fi ODS / API image tags
 
-The OneRoster© service reads directly from an Ed-Fi ODS database, so it works
-with any ODS/API deployment on a supported Data Standard. The ODS/API image
-tags below can be used to stand up a compatible ODS for local testing:
+The OneRoster© service reads directly from an Ed-Fi ODS database and works
+with any ODS / API deployment on a supported Data Standard. The ODS / API
+sandbox image tags below can be used to stand up a compatible ODS for local
+testing:
 
-| Data Standard | ODS/API image tag | Image |
+| Data Standard | ODS / API image tag | Image |
 | --- | --- | --- |
 | 5.2 | `7.3` | `edfialliance/ods-api-db-ods-sandbox:7.3` |
 | 5.1 | `7.2` | `edfialliance/ods-api-db-ods-sandbox:7.2` |
 | 5.0 | `7.1` | `edfialliance/ods-api-db-ods-sandbox:7.1` |
 
-For Data Standard 4.0, use the matching 6.x ODS/API image line.
+For Data Standard 4.0, use the matching 6.x ODS / API image line.
 
 ## OneRoster© service versioning
 
-The OneRoster© service follows an independent release cadence from the Ed-Fi
-ODS/API. This documentation is not versioned at launch; if the service
-accumulates breaking changes in the future, per-version documentation will be
-introduced at that time.
+The OneRoster© service follows a release cadence independent of the Ed-Fi
+ODS / API. This documentation is not versioned at launch. If the service
+accumulates breaking changes in the future, per-version documentation will
+be introduced at that time.

--- a/docs/reference/11-oneroster/supported-versions.mdx
+++ b/docs/reference/11-oneroster/supported-versions.mdx
@@ -1,0 +1,70 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Supported Versions
+
+The Ed-Fi OneRoster service supports two Ed-Fi Data Standard lines and two
+database engines from a single code base. The SQL artifacts for each Data
+Standard version live in the service repository under
+`standard/{dataStandardVersion}/artifacts/{pgsql|mssql}/core/`.
+
+## OneRoster specification
+
+All releases implement the 1EdTech [OneRoster 1.2
+Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) REST binding.
+
+## Ed-Fi Data Standard support
+
+| Data Standard | Supported | Notes |
+|---|---|---|
+| 5.2 | Yes | Default artifact set; used with ODS/API 7.3 |
+| 5.1 | Yes | Same SQL artifacts as 5.2 (no breaking changes consumed by OneRoster) |
+| 5.0 | Yes | Same SQL artifacts as 5.2 |
+| 4.0 | Yes | Separate artifact set under `standard/4.0.0/` |
+
+## Database engine support
+
+<Tabs>
+  <TabItem value="pg" label="PostgreSQL" default>
+
+The PostgreSQL implementation uses materialized views in the `oneroster12`
+schema, refreshed on a schedule by [pg-boss](https://timgit.github.io/pg-boss/).
+
+- PostgreSQL 13 or later (same minimum as the supported Ed-Fi ODS/API releases)
+- Refresh cadence is configured via `PGBOSS_CRON` (default `*/15 * * * *`)
+- See [Deploy on PostgreSQL](./getting-started/deploy-postgres.md)
+
+  </TabItem>
+  <TabItem value="mssql" label="SQL Server">
+
+The Microsoft SQL Server implementation stores OneRoster output in tables that
+are repopulated by stored procedures on a schedule driven by SQL Server Agent.
+
+- SQL Server 2016 or later (required for JSON support)
+- SQL Server Agent must be enabled (in Docker, set `MSSQL_AGENT_ENABLED=True`)
+- Default refresh cadence is every 15 minutes
+- See [Deploy on Microsoft SQL Server](./getting-started/deploy-mssql.md)
+
+  </TabItem>
+</Tabs>
+
+## Ed-Fi ODS/API image tags
+
+The OneRoster service reads directly from an Ed-Fi ODS database, so it works
+with any ODS/API deployment on a supported Data Standard. The ODS/API image
+tags below can be used to stand up a compatible ODS for local testing:
+
+| Data Standard | ODS/API image tag | Image |
+|---|---|---|
+| 5.2 | `7.3` | `edfialliance/ods-api-db-ods-sandbox:7.3` |
+| 5.1 | `7.2` | `edfialliance/ods-api-db-ods-sandbox:7.2` |
+| 5.0 | `7.1` | `edfialliance/ods-api-db-ods-sandbox:7.1` |
+
+For Data Standard 4.0, use the matching 6.x ODS/API image line.
+
+## OneRoster service versioning
+
+The OneRoster service follows an independent release cadence from the Ed-Fi
+ODS/API. This documentation is not versioned at launch; if the service
+accumulates breaking changes in the future, per-version documentation will be
+introduced at that time.

--- a/docs/reference/11-oneroster/supported-versions.mdx
+++ b/docs/reference/11-oneroster/supported-versions.mdx
@@ -7,14 +7,14 @@ import TabItem from '@theme/TabItem';
 
 # Supported Versions
 
-The Ed-Fi OneRoster© service supports two Ed-Fi Data Standard lines and two
+The Ed-Fi OneRoster® service supports two Ed-Fi Data Standard lines and two
 database engines from a single code base. The SQL artifacts for each Data
 Standard version live in the service repository under
 `standard/{dataStandardVersion}/artifacts/{pgsql|mssql}/core/`.
 
-## OneRoster© specification
+## OneRoster specification
 
-All releases implement the 1EdTech [OneRoster© v1.2
+All releases implement the 1EdTech® [OneRoster v1.2
 Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) REST binding.
 
 ## Ed-Fi Data Standard support
@@ -41,7 +41,7 @@ schema, refreshed on a schedule by [pg-boss](https://timgit.github.io/pg-boss/).
 </TabItem>
 <TabItem value="mssql" label="SQL Server">
 
-The Microsoft SQL Server implementation stores OneRoster© output in tables
+The Microsoft SQL Server implementation stores OneRoster output in tables
 that are repopulated by stored procedures on a schedule driven by SQL Server
 Agent.
 
@@ -57,7 +57,7 @@ Agent.
 
 ## Ed-Fi ODS / API image tags
 
-The OneRoster© service reads directly from an Ed-Fi ODS database and works
+The OneRoster service reads directly from an Ed-Fi ODS database and works
 with any ODS / API deployment on a supported Data Standard. The ODS / API
 sandbox image tags below can be used to stand up a compatible ODS for local
 testing:
@@ -70,9 +70,9 @@ testing:
 
 For Data Standard 4.0, use the matching 6.x ODS / API image line.
 
-## OneRoster© service versioning
+## OneRoster service versioning
 
-The OneRoster© service follows a release cadence independent of the Ed-Fi
+The OneRoster service follows a release cadence independent of the Ed-Fi
 ODS / API. This documentation is not versioned at launch. If the service
 accumulates breaking changes in the future, per-version documentation will
 be introduced at that time.

--- a/docs/reference/11-oneroster/what-it-is.md
+++ b/docs/reference/11-oneroster/what-it-is.md
@@ -1,12 +1,12 @@
-# What is the Ed-Fi OneRoster Service
+# What is the Ed-Fi OneRoster© Service
 
-The Ed-Fi OneRoster service is an independently deployed Node.js application
-that serves a [1EdTech OneRoster 1.2
+The Ed-Fi OneRoster© service is an independently deployed Node.js application
+that serves a [1EdTech OneRoster© v1.2
 Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) API from data in an
 Ed-Fi ODS. It complements the Ed-Fi ODS/API, which remains the system of record
 and continues to serve the full Ed-Fi Data Standard resource set.
 
-Adopt the OneRoster service when a vendor application expects a OneRoster 1.2
+Adopt the OneRoster© service when a vendor application expects a OneRoster© 1.2
 feed, and the source of truth for rostering data lives in an Ed-Fi ODS.
 
 ## How it fits with the ODS/API
@@ -15,22 +15,22 @@ The service does not replace the Ed-Fi ODS/API. It sits alongside it:
 
 - The ODS/API continues to write and read Ed-Fi resources to/from the ODS
   database.
-- The OneRoster service reads from the same ODS database through a separate
+- The OneRoster© service reads from the same ODS database through a separate
   `oneroster12` schema (materialized views on PostgreSQL, tables populated by
   stored procedures on Microsoft SQL Server).
-- OAuth 2.0 tokens for OneRoster clients are issued by the Ed-Fi ODS/API (or an
+- OAuth 2.0 tokens for OneRoster© clients are issued by the Ed-Fi ODS/API (or an
   external identity provider configured to match); see
   [OAuth and JWT](./configuration/oauth-and-jwt.md) for the specifics.
 
-Refresh of the derived OneRoster views is scheduled and runs independently of
-the ODS/API — every 15 minutes by default — so OneRoster clients see
+Refresh of the derived OneRoster© views is scheduled and runs independently of
+the ODS/API — every 15 minutes by default — so OneRoster© clients see
 near-real-time rostering data without additional write load on the ODS/API.
 
-## Supported OneRoster 1.2 endpoints
+## Supported OneRoster© 1.2 endpoints
 
-The service implements the OneRoster 1.2 rostering endpoints listed below. All
+The service implements the OneRoster© 1.2 rostering endpoints listed below. All
 endpoints are versioned under `/ims/oneroster/rostering/v1p2/` and require an
-OAuth 2.0 bearer token with a OneRoster scope (see
+OAuth 2.0 bearer token with a OneRoster© scope (see
 [OAuth and JWT](./configuration/oauth-and-jwt.md)).
 
 | Endpoint | Ed-Fi source entities |
@@ -51,16 +51,16 @@ OAuth 2.0 bearer token with a OneRoster scope (see
 See [Endpoint to Ed-Fi source mapping](./data-model/endpoint-source-mapping.md)
 for field-level detail.
 
-All endpoints accept the OneRoster 1.2 query parameters `limit` (default 100),
+All endpoints accept the OneRoster© 1.2 query parameters `limit` (default 100),
 `offset` (default 0), `sort`, `orderBy`, `filter`, and `fields`.
 
 :::info
 
-The following OneRoster 1.2 features are _not_ implemented in the current
+The following OneRoster© 1.2 features are _not_ implemented in the current
 release:
 
 - Nested convenience endpoints such as `/classes/{id}/students` (not required
-  for OneRoster certification).
+  for OneRoster© certification).
 - `X-Total-Count` response header and pagination `Link` header.
 - Multi-tenant deployments.
 
@@ -68,27 +68,27 @@ release:
 
 ## How the service relates to the Ed-Fi Data Standard
 
-OneRoster 1.2 defines a smaller, rostering-focused set of entities than the
+OneRoster© 1.2 defines a smaller, rostering-focused set of entities than the
 Ed-Fi Data Standard. The service bridges the two by:
 
-- Deriving OneRoster org `type` from Ed-Fi entity tables (school / LEA / SEA),
+- Deriving OneRoster© org `type` from Ed-Fi entity tables (school / LEA / SEA),
   not from `EducationOrganizationCategoryDescriptor`. See [Org and agency
   mapping](./data-model/org-and-agency-mapping.md).
-- Mapping a small set of Ed-Fi descriptors to OneRoster enumerations via
+- Mapping a small set of Ed-Fi descriptors to OneRoster© enumerations via
   `edfi.descriptormapping` rows seeded during deployment. See [Descriptor
   mappings](./data-model/descriptor-mappings.md).
-- Synthesizing OneRoster school-year academic sessions from Ed-Fi calendar
+- Synthesizing OneRoster© school-year academic sessions from Ed-Fi calendar
   events.
 
-Clients receive OneRoster-spec-compliant JSON; the Ed-Fi natural keys are
+Clients receive OneRoster©-spec-compliant JSON; the Ed-Fi natural keys are
 preserved in each record's `metadata` field for traceability back to the ODS.
 
 ## Integration with the Ed-Fi ODS/API
 
 The Ed-Fi ODS/API (version 7.3 and later) exposes feature-management settings
-and claim-set entries that govern how OneRoster clients are issued tokens and
+and claim-set entries that govern how OneRoster© clients are issued tokens and
 which scopes they may request. For the ODS/API-side configuration, see the
 [ODS/API platform developer guide's Features
-reference](/reference/ods-api/platform-dev-guide/features/); the OneRoster
+reference](/reference/ods-api/platform-dev-guide/features/); the OneRoster©
 entry on that page documents the `FeatureManagement:OneRoster` setting and
 related claim-set wiring.

--- a/docs/reference/11-oneroster/what-it-is.md
+++ b/docs/reference/11-oneroster/what-it-is.md
@@ -2,15 +2,15 @@
 sidebar_position: 1
 ---
 
-# What is the Ed-Fi OneRoster© Service
+# What is the Ed-Fi OneRoster® Service
 
-The Ed-Fi OneRoster© service is a Node.js application that serves a
-[1EdTech OneRoster© v1.2
+The Ed-Fi OneRoster service is a Node.js application that serves a
+[1EdTech® OneRoster v1.2
 Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) API from data in an
 Ed-Fi ODS. It complements the Ed-Fi ODS / API, which remains the system of
 record and continues to serve the full Ed-Fi Data Standard resource set.
 
-Use the OneRoster© service when a vendor application expects a OneRoster©
+Use the OneRoster service when a vendor application expects a OneRoster
 v1.2 feed and the source of truth for rostering data lives in an Ed-Fi ODS.
 
 ## How it fits with the ODS / API
@@ -19,20 +19,20 @@ The service does not replace the Ed-Fi ODS / API. It sits alongside it:
 
 - The ODS / API continues to write and read Ed-Fi resources against the ODS
   database.
-- The OneRoster© service reads from the same ODS database through a separate
+- The OneRoster service reads from the same ODS database through a separate
   `oneroster12` schema. On PostgreSQL this schema holds materialized views;
   on Microsoft SQL Server it holds tables populated by stored procedures.
-- OAuth 2.0 tokens for OneRoster© clients are issued by the Ed-Fi ODS / API
+- OAuth 2.0 tokens for OneRoster clients are issued by the Ed-Fi ODS / API
   or by an external identity provider configured to match. See
   [OAuth and JWT](./configuration/oauth-and-jwt.md) for the specifics.
 
-Refresh of the derived OneRoster© views runs on a schedule, independent of
+Refresh of the derived OneRoster views runs on a schedule, independent of
 ODS / API traffic. The default cadence is every 15 minutes.
 
-## Supported OneRoster© v1.2 endpoints
+## Supported OneRoster v1.2 endpoints
 
 All endpoints are versioned under `/ims/oneroster/rostering/v1p2/` and
-require an OAuth 2.0 bearer token with a OneRoster© scope. See [OAuth and
+require an OAuth 2.0 bearer token with a OneRoster scope. See [OAuth and
 JWT](./configuration/oauth-and-jwt.md) for the scope model.
 
 | Endpoint | Ed-Fi source entities |
@@ -53,16 +53,16 @@ JWT](./configuration/oauth-and-jwt.md) for the scope model.
 See [Endpoint to Ed-Fi source mapping](./data-model/endpoint-source-mapping.md)
 for field-level detail.
 
-All endpoints accept the OneRoster© v1.2 query parameters `limit` (default
+All endpoints accept the OneRoster v1.2 query parameters `limit` (default
 100), `offset` (default 0), `sort`, `orderBy`, `filter`, and `fields`.
 
 :::info
 
-The following OneRoster© v1.2 features are _not_ implemented in the current
+The following OneRoster v1.2 features are _not_ implemented in the current
 release:
 
 - Nested convenience endpoints such as `/classes/{id}/students`. These are
-  not required for OneRoster© certification.
+  not required for OneRoster certification.
 - The `X-Total-Count` response header and pagination `Link` header.
 - Multi-tenant deployments.
 
@@ -70,28 +70,28 @@ release:
 
 ## How the service relates to the Ed-Fi Data Standard
 
-OneRoster© v1.2 defines a smaller, rostering-focused set of entities than the
+OneRoster v1.2 defines a smaller, rostering-focused set of entities than the
 Ed-Fi Data Standard. The service bridges the two in three ways:
 
-- OneRoster© `org.type` is derived from Ed-Fi entity tables (school, LEA,
+- OneRoster `org.type` is derived from Ed-Fi entity tables (school, LEA,
   SEA), not from `EducationOrganizationCategoryDescriptor`. See [Org and
   agency mapping](./data-model/org-and-agency-mapping.md).
-- A small set of Ed-Fi descriptors is mapped to OneRoster© enumerations
+- A small set of Ed-Fi descriptors is mapped to OneRoster enumerations
   through rows in `edfi.descriptormapping` that are seeded during
   deployment. See [Descriptor mappings](./data-model/descriptor-mappings.md).
-- OneRoster© school-year academic sessions are synthesized from Ed-Fi
+- OneRoster school-year academic sessions are synthesized from Ed-Fi
   calendar events.
 
-Clients receive OneRoster©-spec-compliant JSON. The Ed-Fi natural keys are
+Clients receive OneRoster-spec-compliant JSON. The Ed-Fi natural keys are
 preserved in each record's `metadata` field so that records can be traced
 back to the ODS without joining on the hashed `sourcedId`.
 
 ## Integration with the Ed-Fi ODS / API
 
 The Ed-Fi ODS / API (version 7.3 and later) exposes feature-management
-settings and claim-set entries that govern how OneRoster© clients are issued
+settings and claim-set entries that govern how OneRoster clients are issued
 tokens and which scopes they may request. For the ODS / API-side
 configuration, see the [Features
 reference](/reference/ods-api/platform-dev-guide/features/) in the ODS / API
-v7.3 platform developer guide. The OneRoster© entry on that page documents
+v7.3 platform developer guide. The OneRoster entry on that page documents
 the `FeatureManagement:OneRoster` setting and the related claim-set wiring.

--- a/docs/reference/11-oneroster/what-it-is.md
+++ b/docs/reference/11-oneroster/what-it-is.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # What is the Ed-Fi OneRoster© Service
 
 The Ed-Fi OneRoster© service is an independently deployed Node.js application

--- a/docs/reference/11-oneroster/what-it-is.md
+++ b/docs/reference/11-oneroster/what-it-is.md
@@ -4,38 +4,36 @@ sidebar_position: 1
 
 # What is the Ed-Fi OneRoster© Service
 
-The Ed-Fi OneRoster© service is an independently deployed Node.js application
-that serves a [1EdTech OneRoster© v1.2
+The Ed-Fi OneRoster© service is a Node.js application that serves a
+[1EdTech OneRoster© v1.2
 Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) API from data in an
-Ed-Fi ODS. It complements the Ed-Fi ODS/API, which remains the system of record
-and continues to serve the full Ed-Fi Data Standard resource set.
+Ed-Fi ODS. It complements the Ed-Fi ODS / API, which remains the system of
+record and continues to serve the full Ed-Fi Data Standard resource set.
 
-Adopt the OneRoster© service when a vendor application expects a OneRoster© 1.2
-feed, and the source of truth for rostering data lives in an Ed-Fi ODS.
+Use the OneRoster© service when a vendor application expects a OneRoster©
+v1.2 feed and the source of truth for rostering data lives in an Ed-Fi ODS.
 
-## How it fits with the ODS/API
+## How it fits with the ODS / API
 
-The service does not replace the Ed-Fi ODS/API. It sits alongside it:
+The service does not replace the Ed-Fi ODS / API. It sits alongside it:
 
-- The ODS/API continues to write and read Ed-Fi resources to/from the ODS
+- The ODS / API continues to write and read Ed-Fi resources against the ODS
   database.
 - The OneRoster© service reads from the same ODS database through a separate
-  `oneroster12` schema (materialized views on PostgreSQL, tables populated by
-  stored procedures on Microsoft SQL Server).
-- OAuth 2.0 tokens for OneRoster© clients are issued by the Ed-Fi ODS/API (or an
-  external identity provider configured to match); see
+  `oneroster12` schema. On PostgreSQL this schema holds materialized views;
+  on Microsoft SQL Server it holds tables populated by stored procedures.
+- OAuth 2.0 tokens for OneRoster© clients are issued by the Ed-Fi ODS / API
+  or by an external identity provider configured to match. See
   [OAuth and JWT](./configuration/oauth-and-jwt.md) for the specifics.
 
-Refresh of the derived OneRoster© views is scheduled and runs independently of
-the ODS/API — every 15 minutes by default — so OneRoster© clients see
-near-real-time rostering data without additional write load on the ODS/API.
+Refresh of the derived OneRoster© views runs on a schedule, independent of
+ODS / API traffic. The default cadence is every 15 minutes.
 
-## Supported OneRoster© 1.2 endpoints
+## Supported OneRoster© v1.2 endpoints
 
-The service implements the OneRoster© 1.2 rostering endpoints listed below. All
-endpoints are versioned under `/ims/oneroster/rostering/v1p2/` and require an
-OAuth 2.0 bearer token with a OneRoster© scope (see
-[OAuth and JWT](./configuration/oauth-and-jwt.md)).
+All endpoints are versioned under `/ims/oneroster/rostering/v1p2/` and
+require an OAuth 2.0 bearer token with a OneRoster© scope. See [OAuth and
+JWT](./configuration/oauth-and-jwt.md) for the scope model.
 
 | Endpoint | Ed-Fi source entities |
 | --- | --- |
@@ -45,7 +43,7 @@ OAuth 2.0 bearer token with a OneRoster© scope (see
 | `GET /demographics`, `GET /demographics/{id}` | `students`, `studentEducationOrganizationAssociations` |
 | `GET /enrollments`, `GET /enrollments/{id}` | `staffSectionAssociations`, `studentSectionAssociations`, `sections` |
 | `GET /orgs`, `GET /orgs/{id}` | `schools`, `localEducationAgencies`, `stateEducationAgencies` |
-| `GET /users`, `GET /users/{id}` | `staffs`, `students`, `contacts` and their school/EdOrg associations |
+| `GET /users`, `GET /users/{id}` | `staffs`, `students`, `contacts` and their school / EdOrg associations |
 | `GET /schools`, `GET /schools/{id}` | subset of `orgs` |
 | `GET /students`, `GET /students/{id}` | subset of `users` |
 | `GET /teachers`, `GET /teachers/{id}` | subset of `users` |
@@ -55,44 +53,45 @@ OAuth 2.0 bearer token with a OneRoster© scope (see
 See [Endpoint to Ed-Fi source mapping](./data-model/endpoint-source-mapping.md)
 for field-level detail.
 
-All endpoints accept the OneRoster© 1.2 query parameters `limit` (default 100),
-`offset` (default 0), `sort`, `orderBy`, `filter`, and `fields`.
+All endpoints accept the OneRoster© v1.2 query parameters `limit` (default
+100), `offset` (default 0), `sort`, `orderBy`, `filter`, and `fields`.
 
 :::info
 
-The following OneRoster© 1.2 features are _not_ implemented in the current
+The following OneRoster© v1.2 features are _not_ implemented in the current
 release:
 
-- Nested convenience endpoints such as `/classes/{id}/students` (not required
-  for OneRoster© certification).
-- `X-Total-Count` response header and pagination `Link` header.
+- Nested convenience endpoints such as `/classes/{id}/students`. These are
+  not required for OneRoster© certification.
+- The `X-Total-Count` response header and pagination `Link` header.
 - Multi-tenant deployments.
 
 :::
 
 ## How the service relates to the Ed-Fi Data Standard
 
-OneRoster© 1.2 defines a smaller, rostering-focused set of entities than the
-Ed-Fi Data Standard. The service bridges the two by:
+OneRoster© v1.2 defines a smaller, rostering-focused set of entities than the
+Ed-Fi Data Standard. The service bridges the two in three ways:
 
-- Deriving OneRoster© org `type` from Ed-Fi entity tables (school / LEA / SEA),
-  not from `EducationOrganizationCategoryDescriptor`. See [Org and agency
-  mapping](./data-model/org-and-agency-mapping.md).
-- Mapping a small set of Ed-Fi descriptors to OneRoster© enumerations via
-  `edfi.descriptormapping` rows seeded during deployment. See [Descriptor
-  mappings](./data-model/descriptor-mappings.md).
-- Synthesizing OneRoster© school-year academic sessions from Ed-Fi calendar
-  events.
+- OneRoster© `org.type` is derived from Ed-Fi entity tables (school, LEA,
+  SEA), not from `EducationOrganizationCategoryDescriptor`. See [Org and
+  agency mapping](./data-model/org-and-agency-mapping.md).
+- A small set of Ed-Fi descriptors is mapped to OneRoster© enumerations
+  through rows in `edfi.descriptormapping` that are seeded during
+  deployment. See [Descriptor mappings](./data-model/descriptor-mappings.md).
+- OneRoster© school-year academic sessions are synthesized from Ed-Fi
+  calendar events.
 
-Clients receive OneRoster©-spec-compliant JSON; the Ed-Fi natural keys are
-preserved in each record's `metadata` field for traceability back to the ODS.
+Clients receive OneRoster©-spec-compliant JSON. The Ed-Fi natural keys are
+preserved in each record's `metadata` field so that records can be traced
+back to the ODS without joining on the hashed `sourcedId`.
 
-## Integration with the Ed-Fi ODS/API
+## Integration with the Ed-Fi ODS / API
 
-The Ed-Fi ODS/API (version 7.3 and later) exposes feature-management settings
-and claim-set entries that govern how OneRoster© clients are issued tokens and
-which scopes they may request. For the ODS/API-side configuration, see the
-[ODS/API platform developer guide's Features
-reference](/reference/ods-api/platform-dev-guide/features/); the OneRoster©
-entry on that page documents the `FeatureManagement:OneRoster` setting and
-related claim-set wiring.
+The Ed-Fi ODS / API (version 7.3 and later) exposes feature-management
+settings and claim-set entries that govern how OneRoster© clients are issued
+tokens and which scopes they may request. For the ODS / API-side
+configuration, see the [Features
+reference](/reference/ods-api/platform-dev-guide/features/) in the ODS / API
+v7.3 platform developer guide. The OneRoster© entry on that page documents
+the `FeatureManagement:OneRoster` setting and the related claim-set wiring.

--- a/docs/reference/11-oneroster/what-it-is.md
+++ b/docs/reference/11-oneroster/what-it-is.md
@@ -1,0 +1,94 @@
+# What is the Ed-Fi OneRoster Service
+
+The Ed-Fi OneRoster service is an independently deployed Node.js application
+that serves a [1EdTech OneRoster 1.2
+Rostering](https://www.imsglobal.org/spec/oneroster/v1p2) API from data in an
+Ed-Fi ODS. It complements the Ed-Fi ODS/API, which remains the system of record
+and continues to serve the full Ed-Fi Data Standard resource set.
+
+Adopt the OneRoster service when a vendor application expects a OneRoster 1.2
+feed, and the source of truth for rostering data lives in an Ed-Fi ODS.
+
+## How it fits with the ODS/API
+
+The service does not replace the Ed-Fi ODS/API. It sits alongside it:
+
+- The ODS/API continues to write and read Ed-Fi resources to/from the ODS
+  database.
+- The OneRoster service reads from the same ODS database through a separate
+  `oneroster12` schema (materialized views on PostgreSQL, tables populated by
+  stored procedures on Microsoft SQL Server).
+- OAuth 2.0 tokens for OneRoster clients are issued by the Ed-Fi ODS/API (or an
+  external identity provider configured to match); see
+  [OAuth and JWT](./configuration/oauth-and-jwt.md) for the specifics.
+
+Refresh of the derived OneRoster views is scheduled and runs independently of
+the ODS/API — every 15 minutes by default — so OneRoster clients see
+near-real-time rostering data without additional write load on the ODS/API.
+
+## Supported OneRoster 1.2 endpoints
+
+The service implements the OneRoster 1.2 rostering endpoints listed below. All
+endpoints are versioned under `/ims/oneroster/rostering/v1p2/` and require an
+OAuth 2.0 bearer token with a OneRoster scope (see
+[OAuth and JWT](./configuration/oauth-and-jwt.md)).
+
+| Endpoint | Ed-Fi source entities |
+|---|---|
+| `GET /academicSessions`, `GET /academicSessions/{id}` | `sessions`, `schools`, `schoolCalendars` |
+| `GET /classes`, `GET /classes/{id}` | `sections`, `courseOfferings`, `schools` |
+| `GET /courses`, `GET /courses/{id}` | `courses`, `courseOfferings`, `schools` |
+| `GET /demographics`, `GET /demographics/{id}` | `students`, `studentEducationOrganizationAssociations` |
+| `GET /enrollments`, `GET /enrollments/{id}` | `staffSectionAssociations`, `studentSectionAssociations`, `sections` |
+| `GET /orgs`, `GET /orgs/{id}` | `schools`, `localEducationAgencies`, `stateEducationAgencies` |
+| `GET /users`, `GET /users/{id}` | `staffs`, `students`, `contacts` and their school/EdOrg associations |
+| `GET /schools`, `GET /schools/{id}` | subset of `orgs` |
+| `GET /students`, `GET /students/{id}` | subset of `users` |
+| `GET /teachers`, `GET /teachers/{id}` | subset of `users` |
+| `GET /gradingPeriods`, `GET /gradingPeriods/{id}` | subset of `academicSessions` |
+| `GET /terms`, `GET /terms/{id}` | subset of `academicSessions` |
+
+See [Endpoint to Ed-Fi source mapping](./data-model/endpoint-source-mapping.md)
+for field-level detail.
+
+All endpoints accept the OneRoster 1.2 query parameters `limit` (default 100),
+`offset` (default 0), `sort`, `orderBy`, `filter`, and `fields`.
+
+:::info
+
+The following OneRoster 1.2 features are _not_ implemented in the current
+release:
+
+- Nested convenience endpoints such as `/classes/{id}/students` (not required
+  for OneRoster certification).
+- `X-Total-Count` response header and pagination `Link` header.
+- Multi-tenant deployments.
+
+:::
+
+## How the service relates to the Ed-Fi Data Standard
+
+OneRoster 1.2 defines a smaller, rostering-focused set of entities than the
+Ed-Fi Data Standard. The service bridges the two by:
+
+- Deriving OneRoster org `type` from Ed-Fi entity tables (school / LEA / SEA),
+  not from `EducationOrganizationCategoryDescriptor`. See [Org and agency
+  mapping](./data-model/org-and-agency-mapping.md).
+- Mapping a small set of Ed-Fi descriptors to OneRoster enumerations via
+  `edfi.descriptormapping` rows seeded during deployment. See [Descriptor
+  mappings](./data-model/descriptor-mappings.md).
+- Synthesizing OneRoster school-year academic sessions from Ed-Fi calendar
+  events.
+
+Clients receive OneRoster-spec-compliant JSON; the Ed-Fi natural keys are
+preserved in each record's `metadata` field for traceability back to the ODS.
+
+## Integration with the Ed-Fi ODS/API
+
+The Ed-Fi ODS/API (version 7.3 and later) exposes feature-management settings
+and claim-set entries that govern how OneRoster clients are issued tokens and
+which scopes they may request. For the ODS/API-side configuration, see the
+[ODS/API platform developer guide's Features
+reference](/reference/ods-api/platform-dev-guide/features/); the OneRoster
+entry on that page documents the `FeatureManagement:OneRoster` setting and
+related claim-set wiring.

--- a/docs/reference/11-oneroster/what-it-is.md
+++ b/docs/reference/11-oneroster/what-it-is.md
@@ -34,7 +34,7 @@ OAuth 2.0 bearer token with a OneRoster scope (see
 [OAuth and JWT](./configuration/oauth-and-jwt.md)).
 
 | Endpoint | Ed-Fi source entities |
-|---|---|
+| --- | --- |
 | `GET /academicSessions`, `GET /academicSessions/{id}` | `sessions`, `schools`, `schoolCalendars` |
 | `GET /classes`, `GET /classes/{id}` | `sections`, `courseOfferings`, `schools` |
 | `GET /courses`, `GET /courses/{id}` | `courses`, `courseOfferings`, `schools` |


### PR DESCRIPTION
## Summary

Launch documentation for the Ed-Fi OneRoster® service under
`docs/reference/11-oneroster/`, covering the P0 (foundation plus data
model) and P1 (deployment plus configuration) slices of the release
plan.

Structured in four subsections:

- Section foundation (landing, positioning, DS x DB support matrix)
- `data-model/` — endpoint-to-source mapping, org / agency derivation,
  all six shipped descriptor mappings with per-descriptor unmapped-value
  behavior
- `getting-started/` — Docker Compose (demo-only banner), native
  PostgreSQL, native SQL Server, IIS (both `iisnode` and ARR plus WinSW
  paths)
- `configuration/` — env-var reference, OAuth / JWT (JWKS vs PEM), CORS
  / rate-limit / trust-proxy

Also adds a OneRoster cross-link from the data-exchange reference
landing page.

## Reviewer focus

Vinaya — the two net-new pages that close the data-model gap you
flagged:

- `data-model/org-and-agency-mapping.md` (commit ace4a0f)
- `data-model/descriptor-mappings.md` (commit 09d2990)

The rest of the PR is distillation from the edfi-oneroster repo
(`README.md`, `compose/README.md`, `docs/IIS_Installation_Guide.md`,
`.env.example`, the core SQL artifacts under `standard/5.2.0/`).

## Test plan

- [x] `npm run lint:folder docs/reference/11-oneroster` clean
- [x] `npm run build` green with no broken internal links
- [x] Descriptor tables verified against
  `edfi-oneroster/standard/5.2.0/artifacts/pgsql/core/02_descriptorMappings.sql`
  (Calendar 10, Term 16, Sex 4, Race 5, StaffClassification 25,
  ClassroomPosition 4; 12 unmapped staff classifications)
- [x] Unmapped-behavior table per descriptor verified against the join
  style in `users.sql`, `demographics.sql`, `academic_sessions.sql`
- [x] `orgs.sql` type-derivation claim (purely table-source, no
  `EducationOrganizationCategoryDescriptor` involvement) verified
- [x] Trademark usage aligned with
  https://www.1edtech.org/about/legal/trademarks (first-occurrence ®,
  attribution footer on section landing)
- [ ] Dev-server click-through of the new section and the
  data-exchange cross-link (reviewer)

## Open questions

- **Claim-set wiring (R4).** Whether `FeatureManagement:OneRoster =
  true` on the ODS / API side grants the three OneRoster scopes
  (`roster.readonly`, `roster-core.readonly`,
  `roster-demographics.readonly`) to claim sets automatically, or
  whether an operator must edit `ClaimSet` / `ResourceClaim` rows, is
  resolved on the ODS / API side. Flagged with a `:::note` in
  `configuration/oauth-and-jwt.md`. Pointer to be added once the
  ODS / API-side OneRoster docs (PR #429 on `ODSAPI_7.3.2`) are live on
  `main`.
- **Cross-link to versioned ODS / API OneRoster page (item 6.1).**
  Deferred: the target file
  `odsApi_versioned_docs/version-7.3/platform-dev-guide/features/oneroster.md`
  is introduced by PR #429 and is not yet on `main`. Needs a follow-up
  commit after #429 merges (or a direct commit on `ODSAPI_7.3.2`).

## Linked Jira

ONEROSTER-46