### PR TITLE
Unpublish Admin Console RC 1 post

### DIFF
--- a/blog/2025-05-23.md
+++ b/blog/2025-05-23.md
@@ -2,6 +2,8 @@
 title: Announcing Ed-Fi Admin Console 1-RC1
 authors: hoekstra
 tags: [tools, release]
+# unpublish this, since the Admin Console repo is now private and this post is no longer relevant to the public
+draft: true
 ---
 
 We are excited to announce the release of **Ed-Fi Admin Console 1-RC1** (Release Candidate 1)!


### PR DESCRIPTION
The article itself is fine, but we don't want people (or search / AI results) to be confused and think we have a product called Admin Console. Keeping the doc around for historical purposes though.