### PR TITLE
Add config to load raw mmd into mdx files.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,6 +162,23 @@ const config = {
         },
       },
     ],
+    function rawLoaderPlugin() {
+      return {
+        name: 'raw-loader-plugin',
+        configureWebpack() {
+          return {
+            module: {
+              rules: [
+                {
+                  resourceQuery: /raw/,
+                  type: 'asset/source',
+                },
+              ],
+            },
+          };
+        },
+      };
+    },
   ],
 
   themeConfig:


### PR DESCRIPTION
Adds a webpack v5 configuration to allow raw content to be imported into mdx files just like js modules. This enables `.mmd` files to be imported and rendered directly into markdown compatible `.mdx` files, without embedding as an inline mermaid diagram.

Example of use below (the PerformanceEvaluaton.mmd is an example and does not exist).

```
import Mermaid from '@theme/Mermaid';
import diagram from './PerformanceEvaluation.mmd?raw';

## Simplified
<Mermaid value={diagram} />

[Link to Large Diagram](./PerformanceEvaluation.mmd)
```