### PR TITLE
[ONEROSTER-40] Update OneRoster reference docs to reflect recent changes

### DIFF
--- a/docs/reference/11-oneroster/configuration/environment-variables.md
+++ b/docs/reference/11-oneroster/configuration/environment-variables.md
@@ -21,16 +21,19 @@ single-tenant `EdFi_Admin`:
 DB_TYPE=postgres
 CONNECTION_CONFIG={"adminConnection":"host=localhost;port=5432;database=EdFi_Admin;username=<your-username>;password=<your-password>"}
 ODS_CONNECTION_STRING_ENCRYPTION_KEY=<base64 key matching the ODS API's ApiSettings:OdsConnectionStringEncryptionKey>
+PG_BOSS_CONNECTION_CONFIG={"adminConnection":"host=localhost;port=5432;database=EdFi_Admin;username=<your-username>;password=<your-password>"}
 
 OAUTH2_ISSUERBASEURL=https://your-issuer/
 OAUTH2_AUDIENCE=http://localhost:3000
 OAUTH2_TOKENSIGNINGALG=RS256
 ```
 
-The server fails to start if `OAUTH2_ISSUERBASEURL` or
-`OAUTH2_AUDIENCE` is missing, if `CONNECTION_CONFIG` is unset (or,
-in multi-tenant mode, if `TENANTS_CONNECTION_CONFIG` is unset), or if
-`DB_SSL_CA` is set but unreadable.
+The server fails to start if any required variable is missing or invalid. Required
+variables validated at startup include `OAUTH2_ISSUERBASEURL`, `OAUTH2_AUDIENCE`,
+`ODS_CONNECTION_STRING_ENCRYPTION_KEY`, `CONNECTION_CONFIG` (or `TENANTS_CONNECTION_CONFIG`
+in multi-tenant mode), and `PG_BOSS_CONNECTION_CONFIG` (PostgreSQL only). The process
+also exits immediately if `ENABLE_HTTPS=true` but `TLS_KEY_PATH` or `TLS_CERT_PATH`
+is missing.
 
 ## Application
 
@@ -123,10 +126,25 @@ These settings apply when `DB_TYPE=postgres`.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `DB_SSL` | `false` | When `true`, enables TLS with certificate validation (`rejectUnauthorized: true`). |
-| `DB_SSL_CA` | _(empty)_ | Optional path to a CA PEM file. Only used when `DB_SSL=true`. Startup fails fast if set but unreadable. |
-| `PG_BOSS_CONNECTION_CONFIG` | _(empty)_ | PostgreSQL connection used by [pg-boss](https://timgit.github.io/pg-boss/) as its job-metadata store. Same JSON shape as `CONNECTION_CONFIG`. Point at one tenant's admin DB (multi-tenant), the same DB as `CONNECTION_CONFIG` (single-tenant), or a dedicated database reserved for pg-boss. |
+| `PG_BOSS_CONNECTION_CONFIG` | _(none)_ | Required when `DB_TYPE=postgres`. PostgreSQL connection used by [pg-boss](https://timgit.github.io/pg-boss/) as its job-metadata store. Same JSON shape as `CONNECTION_CONFIG`. Point at one tenant's admin DB (multi-tenant), the same DB as `CONNECTION_CONFIG` (single-tenant), or a dedicated database reserved for pg-boss. |
 | `PGBOSS_CRON` | `*/15 * * * *` | Cron expression for the pg-boss job that refreshes materialized views. Accepts standard 5-field cron syntax. |
+
+### PostgreSQL SSL
+
+SSL for the admin database connection is configured through parameters embedded directly in the `adminConnection` connection string (inside `CONNECTION_CONFIG`, `TENANTS_CONNECTION_CONFIG`, or `PG_BOSS_CONNECTION_CONFIG`).
+
+| Parameter | Description |
+| --- | --- |
+| `sslmode` | `disable` turns SSL off. `require`, `verify-ca`, and `verify-full` enable SSL with certificate validation (`rejectUnauthorized: true`). Omitting `sslmode` leaves SSL inactive unless a certificate file parameter is also set. |
+| `sslrootcert` | File-system path to a CA certificate (PEM). Used to verify the server certificate. |
+| `sslcert` | File-system path to a client certificate (PEM). Required for mutual TLS. |
+| `sslkey` | File-system path to a client private key (PEM). Required for mutual TLS. |
+
+Example with CA verification:
+
+```env
+CONNECTION_CONFIG={"adminConnection":"host=localhost;port=5432;database=EdFi_Admin;username=<user>;password=<pass>;sslmode=verify-ca;sslrootcert=/etc/ssl/certs/ca.pem"}
+```
 
 ## Microsoft SQL Server
 
@@ -137,6 +155,23 @@ the `mssql` connection string embedded in `CONNECTION_CONFIG` (or
 `TENANTS_CONNECTION_CONFIG`). See [Deploy on Microsoft SQL
 Server](../getting-started/deploy-mssql.md) for commands to change the
 cadence.
+
+### Microsoft SQL Server SSL
+
+SSL/TLS for the admin database connection is configured through parameters
+embedded directly in the `adminConnection` connection string. The Tedious
+driver (used by Knex for SQL Server) exposes two relevant options:
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `encrypt` | `false` | Set to `true` to enable TLS encryption between the service and SQL Server. Required for Azure SQL and recommended for any remote SQL Server. |
+| `TrustServerCertificate` | `true` | Set to `false` to enforce certificate validation (recommended in production). When `false`, the server's TLS certificate must be trusted by the system certificate store. |
+
+Example with encryption enabled and certificate validation enforced:
+
+```env
+CONNECTION_CONFIG={"adminConnection":"server=sql.example.com;database=EdFi_Admin;user id=<user>;password=<pass>;encrypt=true;TrustServerCertificate=false"}
+```
 
 ## OAuth 2.0 and JWT
 
@@ -157,10 +192,23 @@ the behavior details.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed origins. Leave empty to allow all (not recommended in production). |
+| `CORS_ORIGINS` | _(empty — allow all)_ | Comma-separated allowed origins. When unset or empty, all origins are allowed. Restrict to specific origins in production. |
 | `RATE_LIMIT_WINDOW_MS` | `60000` | Rate-limit window in milliseconds (`express-rate-limit`). |
 | `RATE_LIMIT_MAX_REQUESTS` | `100` | Maximum requests per window per IP. |
 | `TRUST_PROXY` | `false` | When `true`, the service trusts `X-Forwarded-*` headers. Required when running behind IIS, NGINX, or ARR. |
+
+## HTTPS / TLS
+
+By default the service listens over plain HTTP. Set `ENABLE_HTTPS=true` to
+switch to HTTPS.
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `ENABLE_HTTPS` | `false` | When `true`, the service starts an HTTPS server instead of HTTP. `TLS_KEY_PATH` and `TLS_CERT_PATH` become required. Minimum TLS version enforced: TLSv1.2. |
+| `TLS_KEY_PATH` | _(empty)_ | Required when `ENABLE_HTTPS=true`. File-system path to the PEM-encoded TLS private key. |
+| `TLS_CERT_PATH` | _(empty)_ | Required when `ENABLE_HTTPS=true`. File-system path to the PEM-encoded TLS certificate. |
+| `TLS_CA_PATH` | _(empty)_ | Optional. Path to a CA bundle for client certificate chain validation. Only used when `ENABLE_HTTPS=true`. |
+| `ONEROSTER_API_HEALTHCHECK_TEST` | `["CMD","curl","-f","http://localhost:3000/health-check"]` | Docker Compose health-check command array. When `ENABLE_HTTPS=true`, change the scheme to `https://` and add `"--insecure"` (e.g., `["CMD","curl","-f","https://localhost:3000/health-check","--insecure"]`). |
 
 ## Deployment-script variables
 
@@ -199,9 +247,12 @@ After populating `.env`, confirm the service can start:
 
 ```bash
 node server.js
-# The process exits immediately with an error if OAUTH2_AUDIENCE or
-# OAUTH2_ISSUERBASEURL is missing, if CONNECTION_CONFIG / TENANTS_CONNECTION_CONFIG
-# cannot be parsed, or if DB_SSL_CA is set but unreadable.
+# The process exits immediately with an error if any required variable is
+# missing or invalid (OAUTH2_AUDIENCE, OAUTH2_ISSUERBASEURL, DB_TYPE,
+# ODS_CONNECTION_STRING_ENCRYPTION_KEY, CONNECTION_CONFIG /
+# TENANTS_CONNECTION_CONFIG, PG_BOSS_CONNECTION_CONFIG on PostgreSQL,
+# or TLS_KEY_PATH / TLS_CERT_PATH when ENABLE_HTTPS=true).
 
-curl -i http://localhost:3000/health-check
+curl -i http://localhost:3000/health-check   # HTTP (default)
+# curl -ik https://localhost:3000/health-check  # HTTPS (when ENABLE_HTTPS=true)
 ```

--- a/docs/reference/11-oneroster/conformance.md
+++ b/docs/reference/11-oneroster/conformance.md
@@ -11,7 +11,7 @@ rostering endpoints that make up the Core service; the
 scope.
 
 <!--
-Review (Vinaya): confirm and paste the 1EdTech certified-products
+TODO: confirm and paste the 1EdTech certified-products
 directory URL for the Ed-Fi OneRoster service here, along with the
 formal certification date and certification identifier if one is
 issued by 1EdTech. The page currently says "certified" without

--- a/docs/reference/11-oneroster/getting-started/deploy-mssql.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-mssql.md
@@ -58,6 +58,9 @@ Copy `.env.example` to `.env` at the repository root and set at least:
   CONNECTION_CONFIG={"adminConnection":"server=localhost;database=EdFi_Admin;user id=<your-username>;password=<your-password>;encrypt=false;TrustServerCertificate=true"}
   ```
 
+  To enable TLS, set `encrypt=true` and `TrustServerCertificate=false` in the
+  connection string. See [Microsoft SQL Server SSL](../configuration/environment-variables.md#microsoft-sql-server-ssl).
+
 - `ODS_CONNECTION_STRING_ENCRYPTION_KEY` — the base64 AES key that
   matches the ODS API's `ApiSettings:OdsConnectionStringEncryptionKey`
 - `OAUTH2_AUDIENCE`, `OAUTH2_ISSUERBASEURL`, `OAUTH2_TOKENSIGNINGALG`.
@@ -79,6 +82,22 @@ variables](../configuration/environment-variables.md) for the full
 list.
 
 ## Step 3. Install and run
+
+### Option A: Official Docker image (recommended for production)
+
+Pull and run the official image from Docker Hub, passing the `.env`
+file from Step 2:
+
+```bash
+docker run --env-file .env -p 3000:3000 edfialliance/one-roster-api
+```
+
+Pin a specific version by appending a tag (for example,
+`edfialliance/one-roster-api:1.0.0`). See
+[Docker Hub](https://hub.docker.com/r/edfialliance/one-roster-api/tags)
+for available tags.
+
+### Option B: Run from source
 
 ```bash
 cd edfi-oneroster

--- a/docs/reference/11-oneroster/getting-started/deploy-postgres.md
+++ b/docs/reference/11-oneroster/getting-started/deploy-postgres.md
@@ -46,8 +46,9 @@ Copy `.env.example` to `.env` at the repository root and set at least:
 
 - `ODS_CONNECTION_STRING_ENCRYPTION_KEY` — the base64 AES key that
   matches the ODS API's `ApiSettings:OdsConnectionStringEncryptionKey`
-- `DB_SSL`, and `DB_SSL_CA` if `EdFi_Admin` requires TLS with a
-  private CA
+- `sslmode` (and optionally `sslrootcert`, `sslcert`, `sslkey`) embedded in the
+  `adminConnection` value if `EdFi_Admin` requires TLS. See
+  [PostgreSQL SSL](../configuration/environment-variables.md#postgresql-ssl).
 - `PG_BOSS_CONNECTION_CONFIG` — same JSON shape as
   `CONNECTION_CONFIG`. Points at the PostgreSQL database pg-boss uses
   to store its job metadata. Reusing `EdFi_Admin` is the simplest
@@ -74,6 +75,22 @@ limiting, and proxy](../configuration/cors-rate-limit-proxy.md) for the
 remaining configuration groups.
 
 ## Step 3. Install and run
+
+### Option A: Official Docker image (recommended for production)
+
+Pull and run the official image from Docker Hub, passing the `.env`
+file from Step 2:
+
+```bash
+docker run --env-file .env -p 3000:3000 edfialliance/one-roster-api
+```
+
+Pin a specific version by appending a tag (for example,
+`edfialliance/one-roster-api:1.0.0`). See
+[Docker Hub](https://hub.docker.com/r/edfialliance/one-roster-api/tags)
+for available tags.
+
+### Option B: Run from source
 
 ```bash
 cd edfi-oneroster
@@ -114,7 +131,4 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY oneroster12.orgs;
 
 For end-to-end local testing that stands up an ODS, `EdFi_Admin`, and
 an Ed-Fi ODS / API configured as the OAuth issuer, use the [Docker
-Compose demo stack](./docker-compose.md). For a standalone ODS
-container (without the API or admin DB), see the Ed-Fi ODS / API
-sandbox images in the [Ed-Fi ODS / API
-documentation](/reference/ods-api/).
+Compose demo stack](./docker-compose.md).

--- a/docs/reference/11-oneroster/getting-started/readme.mdx
+++ b/docs/reference/11-oneroster/getting-started/readme.mdx
@@ -22,10 +22,10 @@ image — the in-repo Docker Compose stack is for demo only.
 
 The OneRoster service runs against an existing Ed-Fi ODS / API, not a standalone
 ODS database. Before deploying via any path above (except the Docker Compose
-demo, which stands up its own preconfigured stack), configure feature
-management, claim sets, and the OneRoster vendor application in your ODS / API.
-See
-[How to use OneRoster with the Ed-Fi ODS / API](/reference/ods-api/how-to-guides/how-to-oneroster-with-the-ed-fi-ods-api).
+demo, which stands up its own preconfigured stack), enable the OneRoster feature
+and configure JWT-based token signing in your ODS / API. See [How to use
+OneRoster with the Ed-Fi ODS /
+API](/reference/ods-api/how-to-guides/how-to-oneroster-with-the-ed-fi-ods-api).
 
 :::
 
@@ -60,14 +60,5 @@ are repopulated by stored procedures on a schedule driven by SQL Server Agent.
 
 </TabItem>
 </Tabs>
-
-:::tip
-
-Before deploying, confirm your ODS / API version against the
-[Supported Data Standard versions](../readme.mdx#supported-data-standard-versions)
-matrix. For the current Ed-Fi ODS / API sandbox images and tags, see the
-[Ed-Fi ODS / API reference](/reference/ods-api/).
-
-:::
 
 <DocCardList />

--- a/drafts/oneroster-troubleshooting-deferred.md
+++ b/drafts/oneroster-troubleshooting-deferred.md
@@ -221,15 +221,21 @@ connection error or a permissions error on the first query.
 _Fix:_ confirm the service's database credentials match the
 credentials used to deploy the `oneroster12` schema, and that the
 role has `USAGE` on the schema and `SELECT` on each view or table.
-See [Environment variables, Database section](../docs/reference/11-oneroster/configuration/environment-variables.md#database).
+See [Environment variables](../docs/reference/11-oneroster/configuration/environment-variables.md#connection-and-tenancy).
 
-### Symptom: service fails to start with TLS error
+### Symptom: SSL connection to the database fails
 
-With `DB_SSL=true` and `DB_SSL_CA` pointing to a missing or empty
-file, the service fails fast at startup.
+PostgreSQL SSL is configured through connection string parameters
+(`sslmode`, `sslrootcert`, `sslcert`, `sslkey`) embedded in
+`CONNECTION_CONFIG`, `TENANTS_CONNECTION_CONFIG`, or
+`PG_BOSS_CONNECTION_CONFIG`. If a certificate file path is set but
+the file cannot be read, the service logs an error to stderr, skips
+that certificate option, and attempts the connection without it —
+which may result in a failed connection or unintentionally weaker TLS.
 
-_Fix:_ confirm the CA PEM path is correct and readable by the
-service process.
+_Fix:_ confirm the certificate file paths in the `adminConnection`
+string are correct and readable by the service process. See
+[PostgreSQL SSL](../docs/reference/11-oneroster/configuration/environment-variables.md#postgresql-ssl).
 
 ## Getting more help
 


### PR DESCRIPTION
 - Add HTTPS/TLS variables (ENABLE_HTTPS, TLS_KEY_PATH, TLS_CERT_PATH, TLS_CA_PATH, ONEROSTER_API_HEALTHCHECK_TEST)
 - Replace removed DB_SSL/DB_SSL_CA with connection-string-based SSL parameters for both PostgreSQL (sslmode, sslrootcert, sslcert, sslkey) and SQL Server (encrypt, TrustServerCertificate)
 - Mark PG_BOSS_CONNECTION_CONFIG as required for PostgreSQL deployments
 - Add PG_BOSS_CONNECTION_CONFIG to the minimum viable config example
 - Fix CORS_ORIGINS default (allow all when unset, not http://localhost:3000)
 - Add official Docker image (edfialliance/one-roster-api) as Option A in deploy-postgres and deploy-mssql Step 3