### PR TITLE
[DMS-1167] Update Project Tanager repo links to Ed-Fi-Exchange-OSS

### DIFF
--- a/blog/2024-05-31.md
+++ b/blog/2024-05-31.md
@@ -26,7 +26,7 @@ answers on that page as they come upk.
 :::note
 
 Project Tanager, as explained in the
-[project's readme](https://github.com/Ed-Fi-Alliance-OSS/Project-Tanager/blob/main),
+[project's readme](https://github.com/Ed-Fi-Exchange-OSS/Project-Tanager/blob/main),
 is a code name for the _project_ to create new _products_, of which the Data
 Management Service will be the key component.
 

--- a/docs/reference/0-roadmap/api-faq.md
+++ b/docs/reference/0-roadmap/api-faq.md
@@ -203,15 +203,13 @@ the 2028-2029 school year.
 
 ### Q: How can I / my team get involved?
 
-The Ed-Fi Alliance is running a technical workgroup that will meet regularly
-to help with prioritization, review, and testing of the software.
+The Ed-Fi Alliance is running a technical workgroup that will meet regularly to
+help with prioritization, review, and testing of the software.
 
 Anyone wishing to contribute at the level of design or application code level is
-invited to review the
-[Project Tanager design repository](https://github.com/Ed-Fi-Alliance-OSS/Project-Tanager)
-to understand current and upcoming work. Please see
-[How to Contribute](https://github.com/Ed-Fi-Alliance-OSS/Project-Tanager/CONTRIBUTING.md)
-for more information.
+invited to review the [Design
+Documents](https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service/tree/main/reference/design)
+to understand current and upcoming work.
 
 ## Technical Design
 


### PR DESCRIPTION
Update blog post link to Project Tanager readme to point to the Exchange OSS org. Also update api-faq.md to replace the removed Project Tanager design repo link with the DMS design documents location