### PR TITLE
feat: asset upload utility — compress, convert to WebP, upload to Azure, replace links

### DIFF
--- a/.claude/skills/upload-assets/SKILL.md
+++ b/.claude/skills/upload-assets/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: upload-assets
+description: Upload static images to Azure Blob Storage — compresses, converts to WebP, uploads, and replaces Markdown links. Run when adding new images to static/img/ that need to go to Azure CDN.
+---
+
+Guide the user through uploading static assets to Azure Blob Storage in three checkpoints.
+
+## Checkpoint 1 — Pre-flight
+
+Run `az account show` to check the Azure login session:
+
+```bash
+az account show
+```
+
+If this fails, tell the user: "You need to log in first. Run `! az login` in the prompt."
+
+Once authenticated, check for new images in static/img/:
+
+```bash
+git status static/img/
+```
+
+Ask the user:
+1. Do you want to process all of `static/img/`, a specific subfolder, or specific files?
+   - All: use default (no --source flag)
+   - Subfolder: use `--source static/img/<subfolder>`
+2. Do any of your images need to stay as PNG/JPG instead of converting to WebP? (e.g., images with transparency that WebP handles differently, or images that must keep a specific filename)
+   - If yes: add the `--no-convert` flag
+
+## Checkpoint 2 — Prepare and review manifest
+
+Run the prepare phase with the chosen flags:
+
+```bash
+npm run assets:prepare
+# or with flags: node eng/upload-assets.js --prepare --source static/img/subfolder --no-convert
+```
+
+After it completes, show the user a summary by reading the manifest:
+
+```bash
+node -e "
+const m = require('./asset-upload-manifest.json');
+console.log('Files to upload:', m.entries.length);
+m.entries.forEach(e => console.log(' ', e.originalPath, '->', e.azureUrl));
+"
+```
+
+Ask: "Does this manifest look correct? Any files you don't want to upload, or wrong paths?"
+
+If anything looks wrong: the user can delete or move files from `static/img/`, then re-run `npm run assets:prepare`.
+
+## Checkpoint 3 — Upload and verify
+
+Before uploading, ask: "Do you want to delete the source files from `static/img/` automatically after upload? (Adds `--delete` flag)"
+
+Run the upload phase:
+
+```bash
+npm run assets:upload --yes
+# or with delete: node eng/upload-assets.js --upload --yes --delete
+```
+
+After completion:
+- Show the upload summary (uploaded count, failed count, links replaced)
+- If there were failures, show which files failed and offer: "Want me to retry? Just run `npm run assets:upload --yes` again — it skips already-uploaded entries."
+- If `--delete` was not used, list the source files remaining in `static/` and remind the user to remove them before committing
+- Remind the user to run `npm run build` to check for broken links:
+
+```bash
+npm run build
+```
+
+If the build passes, the assets are live and links are updated. Commit the changed docs files.

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ chroma_db_test/
 # Claude Code personal instructions
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Asset upload utility
+asset-upload-manifest.json
+.asset-backup/
+eng/upload-assets/.tmp/

--- a/eng/docs/2026-05-26-asset-upload-utility-design.md
+++ b/eng/docs/2026-05-26-asset-upload-utility-design.md
@@ -126,6 +126,9 @@ files.
 
 4. **Replace links** — scans `docs/**/*.md` and `docs/**/*.mdx`, replaces exact
    string matches of `oldLink` → `newLink` for all `"uploaded"` entries only.
+   Note: Docusaurus serves `static/img/foo.png` at `/img/foo.png` — the link
+   replacer searches for both the filesystem path (`static/img/...`) and the
+   served path (`/img/...`) to catch all reference styles.
 
 5. **Cleanup** — if `--delete` is set, removes original files from `static/` for
    all `"uploaded"` entries. Otherwise prints a list of source files that can be
@@ -145,7 +148,7 @@ files.
       "processedPath": "eng/upload-assets/.tmp/sdlc/foo.webp",
       "azureUrl": "https://edfidocs.blob.core.windows.net/$web/img/sdlc/foo.webp",
       "referencedIn": ["docs/reference/sdlc.md"],
-      "oldLink": "static/img/sdlc/foo.png",
+      "oldLinks": ["static/img/sdlc/foo.png", "/img/sdlc/foo.png"],
       "newLink": "https://edfidocs.blob.core.windows.net/$web/img/sdlc/foo.webp",
       "status": "ready"
     }

--- a/eng/docs/2026-05-26-asset-upload-utility-design.md
+++ b/eng/docs/2026-05-26-asset-upload-utility-design.md
@@ -1,0 +1,202 @@
+# Asset Upload Utility — Design Spec
+
+**Date:** 2026-05-26
+**Status:** Approved
+**Author:** Robert Hunter Jr
+
+## Overview
+
+A two-phase Node.js CLI utility (`eng/upload-assets.js`) plus a Claude Code skill
+(`.claude/skills/upload-assets.md`) that automates the manual workflow of
+compressing, optimizing, uploading static assets to Azure Blob Storage, and
+replacing in-repo `static/` references with Azure CDN URLs.
+
+This replaces the current manual process described in DEVELOPER.md where a core
+developer uploads images to Azure and hand-edits Markdown links.
+
+## File Structure
+
+```
+eng/
+  upload-assets.js              ← main CLI entry point (both phases)
+  upload-assets/
+    compress.js                 ← sharp-based image compression/conversion
+    azure.js                    ← Azure Blob Storage upload via @azure/storage-blob
+    link-replacer.js            ← scans docs/ and replaces static/* links
+    manifest.js                 ← read/write asset-upload-manifest.json
+
+.claude/skills/
+  upload-assets.md              ← project-level Claude skill (/upload-assets)
+
+asset-upload-manifest.json      ← generated during prepare phase (gitignored)
+.asset-backup/                  ← timestamped backup folders (gitignored)
+eng/upload-assets/.tmp/         ← processed images staging area (gitignored)
+```
+
+**New npm scripts (package.json):**
+
+```json
+"assets:prepare": "node eng/upload-assets.js --prepare",
+"assets:upload":  "node eng/upload-assets.js --upload",
+"assets":         "node eng/upload-assets.js --prepare && node eng/upload-assets.js --upload"
+```
+
+**New dependencies:**
+
+| Package | Purpose |
+|---|---|
+| `sharp` | Image compression and WebP conversion |
+| `@azure/storage-blob` | Azure Blob Storage upload client |
+| `@azure/identity` | `DefaultAzureCredential` picks up active `az login` session |
+
+## Authentication
+
+Uses `az login` (Azure CLI). `DefaultAzureCredential` from `@azure/identity`
+automatically picks up the active `az` session. If the credential check fails,
+the script prints clear instructions to run `az login` and exits with a non-zero
+code.
+
+No secrets, SAS tokens, or connection strings are stored in the repo or `.env`
+files.
+
+## Phase 1 — Prepare
+
+**Command:** `npm run assets:prepare`
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `--source <path>` | Override source directory (default: `static/img/`) |
+| `--no-convert` | Compress in original format; skip WebP conversion |
+
+**Steps (in order):**
+
+1. **Scan** — finds all `*.png`, `*.jpg`, `*.jpeg`, `*.gif`, `*.svg` files under
+   the source directory. Existing `*.webp` files are included (compressed, not
+   re-converted). Files under 10KB are skipped.
+
+2. **Backup** — copies originals to `.asset-backup/YYYY-MM-DD-HH-mm-ss/`
+   preserving subdirectory structure. Aborts if a backup folder with the same
+   timestamp already exists (prevents double-runs).
+
+3. **Compress/convert** — processes each file using `sharp` into
+   `eng/upload-assets/.tmp/`:
+   - Default: converts PNG/JPG/JPEG → WebP at quality 85
+   - `--no-convert`: compresses PNG → optimized PNG, JPG → optimized JPG at quality 85
+   - SVG and GIF: copied as-is (sharp does not support these formats)
+   - Files under 10KB: skipped (not worth processing)
+
+4. **Write manifest** — saves `asset-upload-manifest.json` at repo root.
+
+5. **Print summary** — files found, files processed, total size before/after,
+   estimated savings %.
+
+## Phase 2 — Upload
+
+**Command:** `npm run assets:upload`
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `--yes` | Skip interactive confirmation prompt |
+| `--delete` | Delete originals from `static/` after successful upload |
+
+**Steps (in order):**
+
+1. **Validate** — reads `asset-upload-manifest.json`. Aborts if:
+   - File not found (prepare has not been run)
+   - `preparedAt` is older than 24 hours (stale manifest warning)
+   - `DefaultAzureCredential` cannot authenticate
+
+2. **Preview** — prints the full before/after URL table. Requires `--yes` or
+   interactive confirmation to proceed.
+
+3. **Upload** — uploads each processed file from `.tmp/` to Azure Blob Storage:
+   - Azure container: `$web` (Static Website container)
+   - Target path mirrors `static/` structure:
+     `static/img/sdlc/foo.png` → `$web/img/sdlc/foo.webp`
+   - Public Azure URL: `https://edfidocs.blob.core.windows.net/$web/img/sdlc/foo.webp`
+   - Sets `Content-Type` per format (`image/webp`, `image/png`, etc.)
+   - Sets `Cache-Control: public, max-age=31536000`
+   - Marks each entry `status: "uploaded"` in manifest as it completes
+   - On failure: marks `status: "failed"`, logs error, continues remaining files
+   - Re-runs skip already-`"uploaded"` entries (resumable)
+
+4. **Replace links** — scans `docs/**/*.md` and `docs/**/*.mdx`, replaces exact
+   string matches of `oldLink` → `newLink` for all `"uploaded"` entries only.
+
+5. **Cleanup** — if `--delete` is set, removes original files from `static/` for
+   all `"uploaded"` entries. Otherwise prints a list of source files that can be
+   manually removed.
+
+6. **Print summary** — uploaded count, failed count, links replaced, files
+   deleted.
+
+## Manifest Format
+
+```json
+{
+  "preparedAt": "2026-05-26T14:30:00.000Z",
+  "entries": [
+    {
+      "originalPath": "static/img/sdlc/foo.png",
+      "processedPath": "eng/upload-assets/.tmp/sdlc/foo.webp",
+      "azureUrl": "https://edfidocs.blob.core.windows.net/$web/img/sdlc/foo.webp",
+      "referencedIn": ["docs/reference/sdlc.md"],
+      "oldLink": "static/img/sdlc/foo.png",
+      "newLink": "https://edfidocs.blob.core.windows.net/$web/img/sdlc/foo.webp",
+      "status": "ready"
+    }
+  ]
+}
+```
+
+**`status` values:** `ready` | `uploaded` | `failed`
+
+## Claude Skill — `/upload-assets`
+
+File: `.claude/skills/upload-assets.md`
+
+The skill guides the user through three checkpoints:
+
+### Checkpoint 1 — Pre-flight
+
+- Runs `az account show` to verify an active `az login` session; if not, instructs
+  the user to run `! az login`
+- Checks for uncommitted changes in `static/img/` (advisory only, does not block)
+- Asks which images to process: all of `static/img/`, a specific subfolder, or
+  individual files (passed via `--source`)
+- Asks whether to use `--no-convert` if SVG/GIF files are present
+
+### Checkpoint 2 — Review manifest
+
+- Runs `npm run assets:prepare` (with flags as needed)
+- Displays the manifest summary: file count, size savings, before/after URL table
+- Asks user to confirm the manifest looks correct before proceeding
+- If anything looks wrong, user aborts, adjusts `static/`, and re-runs prepare
+
+### Checkpoint 3 — Upload and verify
+
+- Runs `npm run assets:upload --yes` (with `--delete` if requested)
+- Reports upload summary (uploaded, failed, links replaced)
+- If any failures, shows failed entries and offers to retry
+- Reminds user to run `npm run build` to verify no broken links
+- If `--delete` was not used, lists source files remaining in `static/` with a
+  reminder to remove them before committing
+
+## Gitignore Additions
+
+```
+asset-upload-manifest.json
+.asset-backup/
+eng/upload-assets/.tmp/
+```
+
+## Out of Scope
+
+- Non-image files (PDFs, fonts, etc.) — `static/files/` is not targeted
+- Automatic resizing or responsive image generation
+- CI/CD integration — this is a developer workflow tool
+- Rollback automation — the `.asset-backup/` folder is the manual restore path

--- a/eng/docs/2026-05-26-asset-upload-utility-plan.md
+++ b/eng/docs/2026-05-26-asset-upload-utility-plan.md
@@ -1,0 +1,1358 @@
+# Asset Upload Utility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a two-phase Node.js CLI + Claude skill that compresses/converts static images to WebP, uploads them to Azure Blob Storage, and replaces Markdown image links automatically.
+
+**Architecture:** Phase 1 (`--prepare`) scans `static/img/`, backs up originals to `.asset-backup/`, converts to WebP via `sharp`, and writes `asset-upload-manifest.json`. Phase 2 (`--upload`) reads the manifest, uploads to Azure Blob Storage (`$web` container) via `@azure/storage-blob` + `DefaultAzureCredential`, then replaces image links in `docs/`. A Claude skill wraps both phases with guided checkpoints.
+
+**Tech Stack:** Node.js 22 (CommonJS), `sharp`, `@azure/storage-blob`, `@azure/identity`, `node:test` + `node:assert` for unit tests (no extra test deps needed).
+
+**Working directory for all commands:** `C:/Dev/local-ed-fi/ed-fi-alliance-oss.github.io/.worktrees/asset-upload-utility`
+
+---
+
+## File Map
+
+| File | Status | Responsibility |
+|---|---|---|
+| `package.json` | Modify | Add npm scripts + 3 new deps |
+| `.gitignore` | Modify | Add manifest, backup, tmp to gitignore |
+| `eng/upload-assets.js` | Create | CLI entry point; parses flags, orchestrates phases |
+| `eng/upload-assets/manifest.js` | Create | Read/write `asset-upload-manifest.json` |
+| `eng/upload-assets/manifest.test.js` | Create | Tests for manifest.js |
+| `eng/upload-assets/compress.js` | Create | Scan images, backup originals, process with sharp |
+| `eng/upload-assets/compress.test.js` | Create | Tests for compress.js |
+| `eng/upload-assets/link-replacer.js` | Create | Compute oldLinks; find references in docs; replace links |
+| `eng/upload-assets/link-replacer.test.js` | Create | Tests for link-replacer.js |
+| `eng/upload-assets/azure.js` | Create | getBlobName, getAzureUrl, getCredential, uploadBlob |
+| `eng/upload-assets/azure.test.js` | Create | Tests for pure functions in azure.js |
+| `.claude/skills/upload-assets/SKILL.md` | Create | Claude skill for `/upload-assets` |
+
+---
+
+### Task 1: Setup — dependencies, npm scripts, gitignore
+
+**Files:**
+- Modify: `package.json`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Install new dependencies**
+
+```bash
+npm install sharp @azure/storage-blob @azure/identity
+```
+
+Expected: packages added to `node_modules/`, `package-lock.json` updated.
+
+- [ ] **Step 2: Add npm scripts to package.json**
+
+Open `package.json`. Add these three lines inside the `"scripts"` block (after `"lint:fix"`):
+
+```json
+"assets:prepare": "node eng/upload-assets.js --prepare",
+"assets:upload": "node eng/upload-assets.js --upload",
+"assets": "node eng/upload-assets.js --prepare && node eng/upload-assets.js --upload"
+```
+
+- [ ] **Step 3: Add gitignore entries**
+
+Add these lines to the end of `.gitignore`:
+
+```
+# Asset upload utility
+asset-upload-manifest.json
+.asset-backup/
+eng/upload-assets/.tmp/
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json .gitignore
+git commit -m "chore: add asset upload utility deps and npm scripts"
+```
+
+---
+
+### Task 2: manifest.js — read and write manifest file
+
+**Files:**
+- Create: `eng/upload-assets/manifest.js`
+- Create: `eng/upload-assets/manifest.test.js`
+
+- [ ] **Step 1: Create the test file**
+
+Create `eng/upload-assets/manifest.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { read, write, MANIFEST_FILENAME } = require('./manifest');
+
+test('read returns null when manifest file does not exist', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manifest-test-'));
+  const result = read(tmpDir);
+  assert.equal(result, null);
+});
+
+test('write creates manifest file with correct content', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manifest-test-'));
+  const manifest = { preparedAt: '2026-05-26T00:00:00.000Z', entries: [] };
+  write(tmpDir, manifest);
+  const filePath = path.join(tmpDir, MANIFEST_FILENAME);
+  assert.ok(fs.existsSync(filePath), 'manifest file should exist');
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  assert.deepEqual(parsed, manifest);
+});
+
+test('read returns written manifest', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manifest-test-'));
+  const manifest = {
+    preparedAt: '2026-05-26T00:00:00.000Z',
+    entries: [{ originalPath: 'static/img/foo.png', status: 'ready' }],
+  };
+  write(tmpDir, manifest);
+  const result = read(tmpDir);
+  assert.deepEqual(result, manifest);
+});
+
+test('MANIFEST_FILENAME is asset-upload-manifest.json', () => {
+  assert.equal(MANIFEST_FILENAME, 'asset-upload-manifest.json');
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+node --test eng/upload-assets/manifest.test.js
+```
+
+Expected: error — `Cannot find module './manifest'`
+
+- [ ] **Step 3: Create manifest.js**
+
+Create `eng/upload-assets/manifest.js`:
+
+```js
+const fs = require('fs');
+const path = require('path');
+
+const MANIFEST_FILENAME = 'asset-upload-manifest.json';
+
+function read(repoRoot) {
+  const filePath = path.join(repoRoot, MANIFEST_FILENAME);
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function write(repoRoot, manifest) {
+  const filePath = path.join(repoRoot, MANIFEST_FILENAME);
+  fs.writeFileSync(filePath, JSON.stringify(manifest, null, 2));
+}
+
+module.exports = { read, write, MANIFEST_FILENAME };
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+node --test eng/upload-assets/manifest.test.js
+```
+
+Expected: `✓ read returns null when manifest file does not exist`, `✓ write creates manifest file with correct content`, `✓ read returns written manifest`, `✓ MANIFEST_FILENAME is asset-upload-manifest.json` — all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add eng/upload-assets/manifest.js eng/upload-assets/manifest.test.js
+git commit -m "feat: add manifest read/write module"
+```
+
+---
+
+### Task 3: compress.js — scan images, backup, process with sharp
+
+**Files:**
+- Create: `eng/upload-assets/compress.js`
+- Create: `eng/upload-assets/compress.test.js`
+
+- [ ] **Step 1: Create the test file**
+
+Create `eng/upload-assets/compress.test.js`:
+
+```js
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const sharp = require('sharp');
+const { scanImages, backup, processImage, SKIP_BELOW_BYTES } = require('./compress');
+
+// Helpers
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'compress-test-'));
+}
+
+function touchFile(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '');
+}
+
+async function makeLargePng(destPath) {
+  // 300x300 noise image ~200KB, well above SKIP_BELOW_BYTES
+  const noise = Buffer.alloc(300 * 300 * 3);
+  for (let i = 0; i < noise.length; i++) noise[i] = (i * 37) % 256;
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  await sharp(noise, { raw: { width: 300, height: 300, channels: 3 } })
+    .png()
+    .toFile(destPath);
+}
+
+// scanImages tests
+test('scanImages finds png, jpg, jpeg, gif, svg, webp files', () => {
+  const dir = makeTmpDir();
+  touchFile(path.join(dir, 'a.png'));
+  touchFile(path.join(dir, 'sub', 'b.jpg'));
+  touchFile(path.join(dir, 'c.jpeg'));
+  touchFile(path.join(dir, 'd.gif'));
+  touchFile(path.join(dir, 'e.svg'));
+  touchFile(path.join(dir, 'f.webp'));
+  touchFile(path.join(dir, 'ignored.txt'));
+  const found = scanImages(dir);
+  assert.equal(found.length, 6);
+  assert.ok(found.some((f) => f.endsWith('a.png')));
+  assert.ok(found.some((f) => f.endsWith('b.jpg')));
+  assert.ok(!found.some((f) => f.endsWith('.txt')));
+});
+
+test('scanImages is case-insensitive for extensions', () => {
+  const dir = makeTmpDir();
+  touchFile(path.join(dir, 'A.PNG'));
+  touchFile(path.join(dir, 'B.JPG'));
+  const found = scanImages(dir);
+  assert.equal(found.length, 2);
+});
+
+// backup tests
+test('backup copies files preserving structure and returns backup dir path', async () => {
+  const srcDir = makeTmpDir();
+  const backupRoot = makeTmpDir();
+  const file1 = path.join(srcDir, 'a.png');
+  const file2 = path.join(srcDir, 'sub', 'b.jpg');
+  fs.writeFileSync(file1, 'img1');
+  fs.mkdirSync(path.dirname(file2), { recursive: true });
+  fs.writeFileSync(file2, 'img2');
+
+  const backupDir = await backup([file1, file2], srcDir, backupRoot);
+
+  assert.ok(fs.existsSync(path.join(backupDir, 'a.png')));
+  assert.ok(fs.existsSync(path.join(backupDir, 'sub', 'b.jpg')));
+  assert.equal(fs.readFileSync(path.join(backupDir, 'a.png'), 'utf8'), 'img1');
+});
+
+test('backup aborts if timestamp folder already exists', async () => {
+  const srcDir = makeTmpDir();
+  const backupRoot = makeTmpDir();
+  const file = path.join(srcDir, 'a.png');
+  fs.writeFileSync(file, 'x');
+
+  // Pre-create the dir backup would create this second (same timestamp format)
+  const ts = new Date().toISOString().replace(/:/g, '-').replace(/\..+$/, '');
+  fs.mkdirSync(path.join(backupRoot, ts));
+
+  await assert.rejects(
+    () => backup([file], srcDir, backupRoot),
+    /already exists/
+  );
+});
+
+// processImage tests
+test('processImage returns null for files under SKIP_BELOW_BYTES', async () => {
+  const dir = makeTmpDir();
+  const src = path.join(dir, 'tiny.png');
+  const dest = path.join(dir, 'tiny.webp');
+  fs.writeFileSync(src, Buffer.alloc(100)); // 100 bytes, well under 10KB
+  const result = await processImage(src, dest, false);
+  assert.equal(result, null);
+});
+
+test('processImage converts PNG to WebP by default', async () => {
+  const dir = makeTmpDir();
+  const src = path.join(dir, 'large.png');
+  const dest = path.join(dir, 'large.webp');
+  await makeLargePng(src);
+  assert.ok(fs.statSync(src).size > SKIP_BELOW_BYTES, 'test image should be > SKIP_BELOW_BYTES');
+
+  const result = await processImage(src, dest, false);
+
+  assert.ok(result !== null);
+  assert.ok(fs.existsSync(dest), 'webp output should exist');
+  assert.ok(result.processedSize > 0);
+  assert.ok(result.originalSize > SKIP_BELOW_BYTES);
+});
+
+test('processImage compresses PNG without converting when noConvert=true', async () => {
+  const dir = makeTmpDir();
+  const src = path.join(dir, 'large.png');
+  const dest = path.join(dir, 'large-compressed.png');
+  await makeLargePng(src);
+
+  const result = await processImage(src, dest, true);
+
+  assert.ok(result !== null);
+  assert.ok(fs.existsSync(dest), 'compressed png should exist');
+  // Verify it's still a valid PNG (sharp can read it back)
+  const meta = await sharp(dest).metadata();
+  assert.equal(meta.format, 'png');
+});
+
+test('processImage copies SVG as-is regardless of size or noConvert flag', async () => {
+  const dir = makeTmpDir();
+  const src = path.join(dir, 'icon.svg');
+  const dest = path.join(dir, 'icon-out.svg');
+  const svgContent = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100"/></svg>';
+  // Pad to exceed SKIP_BELOW_BYTES
+  fs.writeFileSync(src, svgContent.padEnd(SKIP_BELOW_BYTES + 100, ' '));
+
+  const result = await processImage(src, dest, false);
+
+  assert.ok(result !== null);
+  assert.ok(fs.readFileSync(dest, 'utf8').startsWith('<svg'));
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+node --test eng/upload-assets/compress.test.js
+```
+
+Expected: error — `Cannot find module './compress'`
+
+- [ ] **Step 3: Create compress.js**
+
+Create `eng/upload-assets/compress.js`:
+
+```js
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+
+const SKIP_BELOW_BYTES = 10 * 1024;
+const CONVERT_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg']);
+const PASSTHROUGH_EXTENSIONS = new Set(['.svg', '.gif']);
+const ALL_EXTENSIONS = new Set([...CONVERT_EXTENSIONS, ...PASSTHROUGH_EXTENSIONS, '.webp']);
+const WEBP_QUALITY = 85;
+const JPEG_QUALITY = 85;
+const PNG_COMPRESSION = 9;
+
+function scanImages(sourceDir) {
+  const results = [];
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (ALL_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+        results.push(fullPath);
+      }
+    }
+  }
+  walk(sourceDir);
+  return results;
+}
+
+async function backup(files, sourceDir, backupRoot) {
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/:/g, '-')
+    .replace(/\..+$/, '');
+  const backupDir = path.join(backupRoot, timestamp);
+  if (fs.existsSync(backupDir)) {
+    throw new Error(
+      `Backup directory already exists: ${backupDir}. Wait a moment and retry.`
+    );
+  }
+  fs.mkdirSync(backupDir, { recursive: true });
+  for (const file of files) {
+    const rel = path.relative(sourceDir, file);
+    const dest = path.join(backupDir, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(file, dest);
+  }
+  return backupDir;
+}
+
+async function processImage(srcPath, destPath, noConvert) {
+  const stat = fs.statSync(srcPath);
+  if (stat.size < SKIP_BELOW_BYTES) return null;
+
+  const ext = path.extname(srcPath).toLowerCase();
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+
+  if (PASSTHROUGH_EXTENSIONS.has(ext) || ext === '.webp') {
+    fs.copyFileSync(srcPath, destPath);
+    return { originalSize: stat.size, processedSize: fs.statSync(destPath).size };
+  }
+
+  if (noConvert) {
+    if (ext === '.png') {
+      await sharp(srcPath).png({ compressionLevel: PNG_COMPRESSION }).toFile(destPath);
+    } else {
+      await sharp(srcPath).jpeg({ quality: JPEG_QUALITY }).toFile(destPath);
+    }
+  } else {
+    await sharp(srcPath).webp({ quality: WEBP_QUALITY }).toFile(destPath);
+  }
+
+  return { originalSize: stat.size, processedSize: fs.statSync(destPath).size };
+}
+
+module.exports = { scanImages, backup, processImage, SKIP_BELOW_BYTES };
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+node --test eng/upload-assets/compress.test.js
+```
+
+Expected: all tests pass. The large-image tests may take 1-2s due to sharp processing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add eng/upload-assets/compress.js eng/upload-assets/compress.test.js
+git commit -m "feat: add image scan, backup, and compress/convert module"
+```
+
+---
+
+### Task 4: link-replacer.js — find references and replace links in docs
+
+**Files:**
+- Create: `eng/upload-assets/link-replacer.js`
+- Create: `eng/upload-assets/link-replacer.test.js`
+
+- [ ] **Step 1: Create the test file**
+
+Create `eng/upload-assets/link-replacer.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { getOldLinks, findReferences, replaceLinks } = require('./link-replacer');
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'link-test-'));
+}
+
+function writeDoc(dir, filename, content) {
+  const full = path.join(dir, filename);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+  return full;
+}
+
+// getOldLinks tests
+test('getOldLinks returns filesystem and Docusaurus served paths', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/sdlc/foo.png';
+  const links = getOldLinks(filePath, repoRoot);
+  assert.ok(links.includes('static/img/sdlc/foo.png'), 'should include filesystem path');
+  assert.ok(links.includes('/img/sdlc/foo.png'), 'should include Docusaurus served path');
+});
+
+test('getOldLinks handles Windows-style backslashes', () => {
+  const repoRoot = 'C:\\repo';
+  const filePath = 'C:\\repo\\static\\img\\foo.png';
+  const links = getOldLinks(filePath, repoRoot);
+  assert.ok(links.some((l) => l.includes('/')), 'all links should use forward slashes');
+  assert.ok(!links.some((l) => l.includes('\\')), 'no backslashes in output');
+});
+
+// findReferences tests
+test('findReferences returns doc files that contain a matching link', () => {
+  const docsRoot = makeTmpDir();
+  writeDoc(docsRoot, 'page.md', '![foo](/img/sdlc/foo.png)');
+  writeDoc(docsRoot, 'other.md', 'no images here');
+
+  const entries = [
+    { originalPath: '/repo/static/img/sdlc/foo.png', oldLinks: ['static/img/sdlc/foo.png', '/img/sdlc/foo.png'] },
+  ];
+  const result = findReferences(entries, docsRoot);
+  const refs = result.get('/repo/static/img/sdlc/foo.png');
+  assert.ok(refs, 'should have references for this image');
+  assert.equal(refs.length, 1);
+  assert.ok(refs[0].endsWith('page.md'));
+});
+
+test('findReferences matches both static/ and /img/ link styles', () => {
+  const docsRoot = makeTmpDir();
+  writeDoc(docsRoot, 'page-a.md', '![a](static/img/foo.png)');
+  writeDoc(docsRoot, 'page-b.md', '![b](/img/foo.png)');
+
+  const entries = [
+    { originalPath: '/repo/static/img/foo.png', oldLinks: ['static/img/foo.png', '/img/foo.png'] },
+  ];
+  const result = findReferences(entries, docsRoot);
+  const refs = result.get('/repo/static/img/foo.png');
+  assert.equal(refs.length, 2);
+});
+
+test('findReferences returns empty map when no docs reference the image', () => {
+  const docsRoot = makeTmpDir();
+  writeDoc(docsRoot, 'page.md', 'no images');
+
+  const entries = [
+    { originalPath: '/repo/static/img/foo.png', oldLinks: ['static/img/foo.png', '/img/foo.png'] },
+  ];
+  const result = findReferences(entries, docsRoot);
+  assert.ok(!result.has('/repo/static/img/foo.png'));
+});
+
+// replaceLinks tests
+test('replaceLinks replaces old links with new Azure URL in doc files', () => {
+  const docsRoot = makeTmpDir();
+  const docPath = writeDoc(docsRoot, 'page.md', '![foo](/img/foo.png) and ![foo](static/img/foo.png)');
+
+  const entries = [
+    {
+      originalPath: '/repo/static/img/foo.png',
+      oldLinks: ['static/img/foo.png', '/img/foo.png'],
+      newLink: 'https://edfidocs.blob.core.windows.net/$web/img/foo.webp',
+      status: 'uploaded',
+    },
+  ];
+  const count = replaceLinks(entries, docsRoot);
+  const content = fs.readFileSync(docPath, 'utf8');
+  assert.ok(
+    !content.includes('/img/foo.png'),
+    'old /img/ link should be replaced'
+  );
+  assert.ok(
+    !content.includes('static/img/foo.png'),
+    'old static/ link should be replaced'
+  );
+  assert.ok(
+    content.includes('https://edfidocs.blob.core.windows.net/$web/img/foo.webp'),
+    'new Azure URL should appear'
+  );
+  assert.equal(count, 2, 'should count 2 replacements');
+});
+
+test('replaceLinks skips entries that are not status=uploaded', () => {
+  const docsRoot = makeTmpDir();
+  const docPath = writeDoc(docsRoot, 'page.md', '![foo](/img/foo.png)');
+
+  const entries = [
+    {
+      originalPath: '/repo/static/img/foo.png',
+      oldLinks: ['/img/foo.png'],
+      newLink: 'https://azure.example.com/foo.webp',
+      status: 'failed',
+    },
+  ];
+  replaceLinks(entries, docsRoot);
+  const content = fs.readFileSync(docPath, 'utf8');
+  assert.ok(content.includes('/img/foo.png'), 'failed entry should not be replaced');
+});
+
+test('replaceLinks processes .md and .mdx files', () => {
+  const docsRoot = makeTmpDir();
+  writeDoc(docsRoot, 'page.md', '![x](/img/x.png)');
+  writeDoc(docsRoot, 'page.mdx', '<img src="/img/x.png" />');
+  writeDoc(docsRoot, 'other.txt', '/img/x.png');
+
+  const entries = [
+    {
+      originalPath: '/repo/static/img/x.png',
+      oldLinks: ['/img/x.png'],
+      newLink: 'https://azure.example.com/x.webp',
+      status: 'uploaded',
+    },
+  ];
+  replaceLinks(entries, docsRoot);
+  assert.ok(!fs.readFileSync(path.join(docsRoot, 'page.md'), 'utf8').includes('/img/x.png'));
+  assert.ok(!fs.readFileSync(path.join(docsRoot, 'page.mdx'), 'utf8').includes('/img/x.png'));
+  // .txt should NOT be modified
+  assert.ok(fs.readFileSync(path.join(docsRoot, 'other.txt'), 'utf8').includes('/img/x.png'));
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+node --test eng/upload-assets/link-replacer.test.js
+```
+
+Expected: error — `Cannot find module './link-replacer'`
+
+- [ ] **Step 3: Create link-replacer.js**
+
+Create `eng/upload-assets/link-replacer.js`:
+
+```js
+const fs = require('fs');
+const path = require('path');
+
+function getOldLinks(filePath, repoRoot) {
+  const rel = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+  // rel = 'static/img/sdlc/foo.png'
+  const withoutStatic = rel.replace(/^static\//, '');
+  // withoutStatic = 'img/sdlc/foo.png'
+  return [rel, `/${withoutStatic}`];
+}
+
+function findDocFiles(docsRoot) {
+  const results = [];
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.name.endsWith('.md') || entry.name.endsWith('.mdx')) {
+        results.push(fullPath);
+      }
+    }
+  }
+  walk(docsRoot);
+  return results;
+}
+
+function findReferences(entries, docsRoot) {
+  const docFiles = findDocFiles(docsRoot);
+  const result = new Map();
+
+  for (const docFile of docFiles) {
+    const content = fs.readFileSync(docFile, 'utf8');
+    for (const { originalPath, oldLinks } of entries) {
+      for (const link of oldLinks) {
+        if (content.includes(link)) {
+          if (!result.has(originalPath)) result.set(originalPath, new Set());
+          result.get(originalPath).add(docFile);
+          break;
+        }
+      }
+    }
+  }
+
+  return new Map([...result].map(([k, v]) => [k, [...v]]));
+}
+
+function replaceLinks(entries, docsRoot) {
+  const docFiles = findDocFiles(docsRoot);
+  const uploadedEntries = entries.filter((e) => e.status === 'uploaded');
+  let totalReplacements = 0;
+
+  for (const docFile of docFiles) {
+    let content = fs.readFileSync(docFile, 'utf8');
+    let changed = false;
+
+    for (const entry of uploadedEntries) {
+      for (const oldLink of entry.oldLinks) {
+        if (content.includes(oldLink)) {
+          content = content.split(oldLink).join(entry.newLink);
+          totalReplacements++;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) fs.writeFileSync(docFile, content, 'utf8');
+  }
+
+  return totalReplacements;
+}
+
+module.exports = { getOldLinks, findReferences, replaceLinks };
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+node --test eng/upload-assets/link-replacer.test.js
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add eng/upload-assets/link-replacer.js eng/upload-assets/link-replacer.test.js
+git commit -m "feat: add link-replacer module for finding and replacing image links"
+```
+
+---
+
+### Task 5: azure.js — blob name, Azure URL, credential, upload
+
+**Files:**
+- Create: `eng/upload-assets/azure.js`
+- Create: `eng/upload-assets/azure.test.js`
+
+Tests cover the pure functions only (`getBlobName`, `getAzureUrl`). `getCredential` and `uploadBlob` call Azure and are excluded from unit tests.
+
+- [ ] **Step 1: Create the test file**
+
+Create `eng/upload-assets/azure.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { getBlobName, getAzureUrl, STORAGE_ACCOUNT_URL, CONTAINER_NAME } = require('./azure');
+
+test('getBlobName strips static/ prefix and changes extension to .webp by default', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/sdlc/foo.png';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/sdlc/foo.webp');
+});
+
+test('getBlobName preserves original extension when noConvert=true', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/sdlc/foo.png';
+  const result = getBlobName(filePath, repoRoot, true);
+  assert.equal(result, 'img/sdlc/foo.png');
+});
+
+test('getBlobName handles JPG extension change to webp', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/photo.jpg';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/photo.webp');
+});
+
+test('getBlobName does not change extension for SVG', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/icon.svg';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/icon.svg');
+});
+
+test('getBlobName does not change extension for GIF', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/anim.gif';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/anim.gif');
+});
+
+test('getBlobName handles nested subdirectories', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/reference/ods-api/fig1.png';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/reference/ods-api/fig1.webp');
+});
+
+test('getAzureUrl returns correct blob storage URL', () => {
+  const url = getAzureUrl('img/sdlc/foo.webp');
+  assert.equal(url, `${STORAGE_ACCOUNT_URL}/$web/img/sdlc/foo.webp`);
+});
+
+test('STORAGE_ACCOUNT_URL defaults to edfidocs', () => {
+  assert.equal(STORAGE_ACCOUNT_URL, 'https://edfidocs.blob.core.windows.net');
+});
+
+test('CONTAINER_NAME is $web', () => {
+  assert.equal(CONTAINER_NAME, '$web');
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+node --test eng/upload-assets/azure.test.js
+```
+
+Expected: error — `Cannot find module './azure'`
+
+- [ ] **Step 3: Create azure.js**
+
+Create `eng/upload-assets/azure.js`:
+
+```js
+const { BlobServiceClient } = require('@azure/storage-blob');
+const { DefaultAzureCredential } = require('@azure/identity');
+const fs = require('fs');
+const path = require('path');
+
+const STORAGE_ACCOUNT_URL =
+  process.env.AZURE_STORAGE_ACCOUNT_URL || 'https://edfidocs.blob.core.windows.net';
+const CONTAINER_NAME = '$web';
+
+const CONVERT_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg']);
+
+const CONTENT_TYPES = {
+  '.webp': 'image/webp',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+};
+
+function getBlobName(filePath, repoRoot, noConvert) {
+  const rel = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+  // rel = 'static/img/sdlc/foo.png'
+  const withoutStatic = rel.replace(/^static\//, '');
+  // withoutStatic = 'img/sdlc/foo.png'
+
+  if (!noConvert) {
+    const ext = path.extname(withoutStatic).toLowerCase();
+    if (CONVERT_EXTENSIONS.has(ext)) {
+      return withoutStatic.slice(0, -ext.length) + '.webp';
+    }
+  }
+  return withoutStatic;
+}
+
+function getAzureUrl(blobName) {
+  return `${STORAGE_ACCOUNT_URL}/$web/${blobName.replace(/\\/g, '/')}`;
+}
+
+async function getCredential() {
+  const credential = new DefaultAzureCredential();
+  await credential.getToken('https://storage.azure.com/.default');
+  return credential;
+}
+
+async function uploadBlob(processedPath, blobName, credential) {
+  const client = new BlobServiceClient(STORAGE_ACCOUNT_URL, credential);
+  const containerClient = client.getContainerClient(CONTAINER_NAME);
+  const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+
+  const ext = path.extname(processedPath).toLowerCase();
+  const contentType = CONTENT_TYPES[ext] || 'application/octet-stream';
+
+  await blockBlobClient.uploadFile(processedPath, {
+    blobHTTPHeaders: {
+      blobContentType: contentType,
+      blobCacheControl: 'public, max-age=31536000',
+    },
+  });
+}
+
+module.exports = {
+  getBlobName,
+  getAzureUrl,
+  getCredential,
+  uploadBlob,
+  STORAGE_ACCOUNT_URL,
+  CONTAINER_NAME,
+};
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+node --test eng/upload-assets/azure.test.js
+```
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add eng/upload-assets/azure.js eng/upload-assets/azure.test.js
+git commit -m "feat: add Azure blob name, URL computation, and upload module"
+```
+
+---
+
+### Task 6: upload-assets.js Phase 1 — `--prepare`
+
+**Files:**
+- Create: `eng/upload-assets.js`
+
+This is the CLI entry point. Phase 1 wires together `compress.js`, `link-replacer.js`, `azure.js`, and `manifest.js`. Manual smoke-test replaces unit tests here since it orchestrates file I/O, sharp, and the manifest.
+
+- [ ] **Step 1: Create upload-assets.js with Phase 1**
+
+Create `eng/upload-assets.js`:
+
+```js
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { scanImages, backup, processImage, SKIP_BELOW_BYTES } = require('./upload-assets/compress');
+const { getOldLinks, findReferences, replaceLinks } = require('./upload-assets/link-replacer');
+const { getBlobName, getAzureUrl, getCredential, uploadBlob, STORAGE_ACCOUNT_URL } = require('./upload-assets/azure');
+const { read: readManifest, write: writeManifest } = require('./upload-assets/manifest');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_SOURCE = path.join(REPO_ROOT, 'static', 'img');
+const BACKUP_ROOT = path.join(REPO_ROOT, '.asset-backup');
+const TMP_DIR = path.join(REPO_ROOT, 'eng', 'upload-assets', '.tmp');
+const DOCS_ROOT = path.join(REPO_ROOT, 'docs');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  return {
+    prepare: args.includes('--prepare'),
+    upload: args.includes('--upload'),
+    noConvert: args.includes('--no-convert'),
+    yes: args.includes('--yes'),
+    deleteAfter: args.includes('--delete'),
+    source: (() => {
+      const i = args.indexOf('--source');
+      return i !== -1 ? path.resolve(args[i + 1]) : DEFAULT_SOURCE;
+    })(),
+  };
+}
+
+async function runPrepare({ source, noConvert }) {
+  console.log(`\n📂 Scanning ${source} for images...`);
+  const files = scanImages(source);
+
+  if (files.length === 0) {
+    console.log('No image files found. Exiting.');
+    process.exit(0);
+  }
+  console.log(`   Found ${files.length} image(s).`);
+
+  console.log('\n💾 Backing up originals...');
+  const backupDir = await backup(files, source, BACKUP_ROOT);
+  console.log(`   Backup saved to: ${backupDir}`);
+
+  // Clear tmp dir for fresh run
+  if (fs.existsSync(TMP_DIR)) fs.rmSync(TMP_DIR, { recursive: true });
+  fs.mkdirSync(TMP_DIR, { recursive: true });
+
+  console.log('\n🔧 Processing images...');
+  let totalOriginalBytes = 0;
+  let totalProcessedBytes = 0;
+  let skippedCount = 0;
+
+  const processedFiles = [];
+
+  for (const filePath of files) {
+    const blobName = getBlobName(filePath, REPO_ROOT, noConvert);
+    const relToSource = path.relative(source, filePath).replace(/\\/g, '/');
+    const processedName = noConvert
+      ? relToSource
+      : relToSource.replace(/\.(png|jpg|jpeg)$/i, '.webp');
+    const processedPath = path.join(TMP_DIR, processedName);
+
+    const result = await processImage(filePath, processedPath, noConvert);
+    if (result === null) {
+      skippedCount++;
+      continue;
+    }
+
+    totalOriginalBytes += result.originalSize;
+    totalProcessedBytes += result.processedSize;
+
+    const azureUrl = getAzureUrl(blobName);
+    const oldLinks = getOldLinks(filePath, REPO_ROOT);
+
+    processedFiles.push({
+      originalPath: path.relative(REPO_ROOT, filePath).replace(/\\/g, '/'),
+      processedPath: path.relative(REPO_ROOT, processedPath).replace(/\\/g, '/'),
+      azureUrl,
+      oldLinks,
+      newLink: azureUrl,
+      referencedIn: [],
+      status: 'ready',
+    });
+  }
+
+  console.log('\n🔍 Finding doc references...');
+  const entries = processedFiles.map((e) => ({
+    originalPath: path.join(REPO_ROOT, e.originalPath),
+    oldLinks: e.oldLinks,
+  }));
+  const refs = findReferences(entries, DOCS_ROOT);
+  for (const entry of processedFiles) {
+    const absPath = path.join(REPO_ROOT, entry.originalPath);
+    entry.referencedIn = (refs.get(absPath) || []).map((f) =>
+      path.relative(REPO_ROOT, f).replace(/\\/g, '/')
+    );
+  }
+
+  const manifest = {
+    preparedAt: new Date().toISOString(),
+    entries: processedFiles,
+  };
+  writeManifest(REPO_ROOT, manifest);
+
+  const savedPct =
+    totalOriginalBytes > 0
+      ? Math.round((1 - totalProcessedBytes / totalOriginalBytes) * 100)
+      : 0;
+
+  console.log(`\n✅ Prepare complete`);
+  console.log(`   Processed : ${processedFiles.length} file(s)`);
+  console.log(`   Skipped   : ${skippedCount} file(s) (under ${SKIP_BELOW_BYTES / 1024}KB)`);
+  console.log(
+    `   Size      : ${(totalOriginalBytes / 1024).toFixed(1)}KB → ${(totalProcessedBytes / 1024).toFixed(1)}KB (${savedPct}% savings)`
+  );
+  console.log('\nReview asset-upload-manifest.json, then run: npm run assets:upload');
+}
+
+async function runUpload({ yes, deleteAfter }) {
+  // Implemented in Task 7
+  console.error('--upload not yet implemented');
+  process.exit(1);
+}
+
+(async () => {
+  const opts = parseArgs(process.argv);
+  if (opts.prepare) {
+    await runPrepare(opts);
+  } else if (opts.upload) {
+    await runUpload(opts);
+  } else {
+    console.error('Usage: node eng/upload-assets.js --prepare | --upload');
+    console.error('       Add --no-convert, --yes, --delete, --source <path> as needed.');
+    process.exit(1);
+  }
+})();
+```
+
+- [ ] **Step 2: Smoke-test Phase 1 against the actual static/img folder**
+
+```bash
+node eng/upload-assets.js --prepare
+```
+
+Expected output (abbreviated):
+```
+📂 Scanning .../static/img for images...
+   Found N image(s).
+💾 Backing up originals...
+   Backup saved to: .../asset-backup/2026-...
+🔧 Processing images...
+🔍 Finding doc references...
+✅ Prepare complete
+   Processed : N file(s)
+```
+
+Check that `asset-upload-manifest.json` exists at repo root and contains valid JSON with entries.
+
+- [ ] **Step 3: Verify manifest looks correct**
+
+```bash
+node -e "const m = require('./asset-upload-manifest.json'); console.log(JSON.stringify(m.entries.slice(0,2), null, 2))"
+```
+
+Each entry should have `originalPath`, `processedPath`, `azureUrl`, `oldLinks`, `newLink`, `referencedIn`, `status: 'ready'`.
+
+- [ ] **Step 4: Run with --no-convert flag to verify it works**
+
+```bash
+node eng/upload-assets.js --prepare --no-convert
+```
+
+Expected: entries have `processedPath` ending in `.png` / `.jpg` (not `.webp`), and `azureUrl` also preserves original extension.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add eng/upload-assets.js
+git commit -m "feat: add upload-assets CLI Phase 1 (--prepare)"
+```
+
+---
+
+### Task 7: upload-assets.js Phase 2 — `--upload`
+
+**Files:**
+- Modify: `eng/upload-assets.js` (replace the stub `runUpload` function)
+
+- [ ] **Step 1: Replace the runUpload stub in upload-assets.js**
+
+Replace the existing `runUpload` function (the stub from Task 6) with:
+
+```js
+async function runUpload({ yes, deleteAfter }) {
+  const manifest = readManifest(REPO_ROOT);
+  if (!manifest) {
+    console.error('❌ No manifest found. Run: npm run assets:prepare first.');
+    process.exit(1);
+  }
+
+  const ageMs = Date.now() - new Date(manifest.preparedAt).getTime();
+  if (ageMs > 24 * 60 * 60 * 1000) {
+    console.warn(`⚠️  Manifest is ${Math.round(ageMs / 3600000)}h old. Consider re-running prepare.`);
+  }
+
+  const pending = manifest.entries.filter((e) => e.status === 'ready');
+  if (pending.length === 0) {
+    console.log('No entries with status=ready. Nothing to upload.');
+    process.exit(0);
+  }
+
+  console.log(`\n📋 ${pending.length} file(s) to upload:\n`);
+  for (const entry of pending) {
+    console.log(`  ${entry.originalPath}`);
+    console.log(`    → ${entry.azureUrl}`);
+  }
+
+  if (!yes) {
+    const { createInterface } = require('readline');
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise((resolve) =>
+      rl.question('\nProceed with upload? (y/N) ', resolve)
+    );
+    rl.close();
+    if (answer.trim().toLowerCase() !== 'y') {
+      console.log('Aborted.');
+      process.exit(0);
+    }
+  }
+
+  console.log('\n🔐 Checking Azure credentials...');
+  let credential;
+  try {
+    credential = await getCredential();
+    console.log('   Authenticated via DefaultAzureCredential ✓');
+  } catch (err) {
+    console.error('❌ Azure authentication failed. Run: az login');
+    console.error(`   Details: ${err.message}`);
+    process.exit(1);
+  }
+
+  console.log('\n☁️  Uploading...');
+  let uploadedCount = 0;
+  let failedCount = 0;
+
+  for (const entry of manifest.entries) {
+    if (entry.status !== 'ready') continue;
+    const processedAbsPath = path.join(REPO_ROOT, entry.processedPath);
+    const blobName = entry.azureUrl.replace(`${STORAGE_ACCOUNT_URL}/$web/`, '');
+    try {
+      await uploadBlob(processedAbsPath, blobName, credential);
+      entry.status = 'uploaded';
+      uploadedCount++;
+      console.log(`   ✓ ${entry.originalPath}`);
+    } catch (err) {
+      entry.status = 'failed';
+      failedCount++;
+      console.error(`   ✗ ${entry.originalPath}: ${err.message}`);
+    }
+    writeManifest(REPO_ROOT, manifest);
+  }
+
+  console.log('\n🔗 Replacing links in docs...');
+  const replacements = replaceLinks(manifest.entries, DOCS_ROOT);
+  console.log(`   ${replacements} link(s) replaced.`);
+
+  if (deleteAfter) {
+    console.log('\n🗑️  Deleting source files...');
+    for (const entry of manifest.entries) {
+      if (entry.status !== 'uploaded') continue;
+      const absPath = path.join(REPO_ROOT, entry.originalPath);
+      if (fs.existsSync(absPath)) {
+        fs.unlinkSync(absPath);
+        console.log(`   Deleted: ${entry.originalPath}`);
+      }
+    }
+  } else {
+    const remaining = manifest.entries
+      .filter((e) => e.status === 'uploaded')
+      .map((e) => e.originalPath);
+    if (remaining.length > 0) {
+      console.log('\n📁 Source files still in static/ (remove before committing):');
+      for (const p of remaining) console.log(`   ${p}`);
+    }
+  }
+
+  console.log(`\n✅ Upload complete`);
+  console.log(`   Uploaded  : ${uploadedCount}`);
+  console.log(`   Failed    : ${failedCount}`);
+  console.log(`   Links replaced: ${replacements}`);
+
+  if (failedCount > 0) {
+    console.log('\n⚠️  Some uploads failed. Re-run: npm run assets:upload to retry.');
+    process.exit(1);
+  }
+
+  console.log('\nRun `npm run build` to verify no broken links.');
+}
+```
+
+(`STORAGE_ACCOUNT_URL` was already added to the azure import in Task 6 — no additional import needed.)
+
+- [ ] **Step 2: Verify the full script still shows usage when called with no flags**
+
+```bash
+node eng/upload-assets.js
+```
+
+Expected:
+```
+Usage: node eng/upload-assets.js --prepare | --upload
+       Add --no-convert, --yes, --delete, --source <path> as needed.
+```
+
+- [ ] **Step 3: Verify --upload validates missing manifest**
+
+```bash
+rm -f asset-upload-manifest.json && node eng/upload-assets.js --upload
+```
+
+Expected: `❌ No manifest found. Run: npm run assets:prepare first.` and exit code 1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add eng/upload-assets.js
+git commit -m "feat: add upload-assets CLI Phase 2 (--upload)"
+```
+
+---
+
+### Task 8: Claude skill — `/upload-assets`
+
+**Files:**
+- Create: `.claude/skills/upload-assets/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory and SKILL.md**
+
+Create `.claude/skills/upload-assets/SKILL.md`:
+
+```markdown
+---
+name: upload-assets
+description: Upload static images to Azure Blob Storage — compresses, converts to WebP, uploads, and replaces Markdown links. Run when adding new images to static/img/ that need to go to Azure CDN.
+---
+
+Guide the user through uploading static assets to Azure Blob Storage in three checkpoints.
+
+## Checkpoint 1 — Pre-flight
+
+Run `az account show` to check the Azure login session:
+
+```bash
+az account show
+```
+
+If this fails, tell the user: "You need to log in first. Run `! az login` in the prompt."
+
+Once authenticated, check for new images in static/img/:
+
+```bash
+git status static/img/
+```
+
+Ask the user:
+1. Do you want to process all of `static/img/`, a specific subfolder, or specific files?
+   - All: use default (no --source flag)
+   - Subfolder: use `--source static/img/<subfolder>`
+2. Do any of your images need to stay as PNG/JPG instead of converting to WebP? (e.g., images with transparency that WebP handles differently, or images that must keep a specific filename)
+   - If yes: add the `--no-convert` flag
+
+## Checkpoint 2 — Prepare and review manifest
+
+Run the prepare phase with the chosen flags:
+
+```bash
+npm run assets:prepare
+# or with flags: node eng/upload-assets.js --prepare --source static/img/subfolder --no-convert
+```
+
+After it completes, show the user a summary by reading the manifest:
+
+```bash
+node -e "
+const m = require('./asset-upload-manifest.json');
+console.log('Files to upload:', m.entries.length);
+m.entries.forEach(e => console.log(' ', e.originalPath, '->', e.azureUrl));
+"
+```
+
+Ask: "Does this manifest look correct? Any files you don't want to upload, or wrong paths?"
+
+If anything looks wrong: the user can delete or move files from `static/img/`, then re-run `npm run assets:prepare`.
+
+## Checkpoint 3 — Upload and verify
+
+Before uploading, ask: "Do you want to delete the source files from `static/img/` automatically after upload? (Adds `--delete` flag)"
+
+Run the upload phase:
+
+```bash
+npm run assets:upload --yes
+# or with delete: node eng/upload-assets.js --upload --yes --delete
+```
+
+After completion:
+- Show the upload summary (uploaded count, failed count, links replaced)
+- If there were failures, show which files failed and offer: "Want me to retry? Just run `npm run assets:upload --yes` again — it skips already-uploaded entries."
+- If `--delete` was not used, list the source files remaining in `static/` and remind the user to remove them before committing
+- Remind the user to run `npm run build` to check for broken links:
+
+```bash
+npm run build
+```
+
+If the build passes, the assets are live and links are updated. Commit the changed docs files.
+```
+
+- [ ] **Step 2: Verify the skill file is discoverable**
+
+```bash
+node -e "const fs = require('fs'); const s = fs.readFileSync('.claude/skills/upload-assets/SKILL.md', 'utf8'); console.log('Skill found, length:', s.length)"
+```
+
+Expected: `Skill found, length: <number>` — no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/upload-assets/SKILL.md
+git commit -m "feat: add /upload-assets Claude skill"
+```
+
+---
+
+### Task 9: Run all tests and final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+node --test eng/upload-assets/manifest.test.js eng/upload-assets/compress.test.js eng/upload-assets/link-replacer.test.js eng/upload-assets/azure.test.js
+```
+
+Expected: all tests pass, 0 failures.
+
+- [ ] **Step 2: Run a full end-to-end prepare smoke test**
+
+```bash
+node eng/upload-assets.js --prepare
+node -e "const m=require('./asset-upload-manifest.json'); console.log('Entries:', m.entries.length, '| First entry status:', m.entries[0]?.status)"
+```
+
+Expected: `Entries: N | First entry status: ready`
+
+- [ ] **Step 3: Verify npm scripts work**
+
+```bash
+npm run assets:prepare -- --help 2>&1 | head -3
+```
+
+Expected: usage line from the script.
+
+- [ ] **Step 4: Commit final state**
+
+```bash
+git add -A
+git status
+```
+
+Verify only expected files are staged, then:
+
+```bash
+git commit -m "feat: complete asset upload utility implementation" --allow-empty-message 2>/dev/null || true
+# (only commit if there are uncommitted changes from the above tasks)
+```

--- a/eng/upload-assets.js
+++ b/eng/upload-assets.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { scanImages, backup, processImage, SKIP_BELOW_BYTES } = require('./upload-assets/compress');
+const { getOldLinks, findReferences, replaceLinks } = require('./upload-assets/link-replacer');
+const { getBlobName, getAzureUrl, getCredential, uploadBlob, STORAGE_ACCOUNT_URL } = require('./upload-assets/azure');
+const { read: readManifest, write: writeManifest } = require('./upload-assets/manifest');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_SOURCE = path.join(REPO_ROOT, 'static', 'img');
+const BACKUP_ROOT = path.join(REPO_ROOT, '.asset-backup');
+const TMP_DIR = path.join(REPO_ROOT, 'eng', 'upload-assets', '.tmp');
+const DOCS_ROOT = path.join(REPO_ROOT, 'docs');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  return {
+    prepare: args.includes('--prepare'),
+    upload: args.includes('--upload'),
+    noConvert: args.includes('--no-convert'),
+    yes: args.includes('--yes'),
+    deleteAfter: args.includes('--delete'),
+    source: (() => {
+      const i = args.indexOf('--source');
+      return i !== -1 ? path.resolve(args[i + 1]) : DEFAULT_SOURCE;
+    })(),
+  };
+}
+
+async function runPrepare({ source, noConvert }) {
+  console.log(`\n📂 Scanning ${source} for images...`);
+  const files = scanImages(source);
+
+  if (files.length === 0) {
+    console.log('No image files found. Exiting.');
+    process.exit(0);
+  }
+  console.log(`   Found ${files.length} image(s).`);
+
+  console.log('\n💾 Backing up originals...');
+  const backupDir = await backup(files, source, BACKUP_ROOT);
+  console.log(`   Backup saved to: ${backupDir}`);
+
+  if (fs.existsSync(TMP_DIR)) fs.rmSync(TMP_DIR, { recursive: true });
+  fs.mkdirSync(TMP_DIR, { recursive: true });
+
+  console.log('\n🔧 Processing images...');
+  let totalOriginalBytes = 0;
+  let totalProcessedBytes = 0;
+  let skippedCount = 0;
+
+  const processedFiles = [];
+
+  for (const filePath of files) {
+    const blobName = getBlobName(filePath, REPO_ROOT, noConvert);
+    const relToSource = path.relative(source, filePath).replace(/\\/g, '/');
+    const processedName = noConvert
+      ? relToSource
+      : relToSource.replace(/\.(png|jpg|jpeg)$/i, '.webp');
+    const processedPath = path.join(TMP_DIR, processedName);
+
+    const result = await processImage(filePath, processedPath, noConvert);
+    if (result === null) {
+      skippedCount++;
+      continue;
+    }
+
+    totalOriginalBytes += result.originalSize;
+    totalProcessedBytes += result.processedSize;
+
+    const azureUrl = getAzureUrl(blobName);
+    const oldLinks = getOldLinks(filePath, REPO_ROOT);
+
+    processedFiles.push({
+      originalPath: path.relative(REPO_ROOT, filePath).replace(/\\/g, '/'),
+      processedPath: path.relative(REPO_ROOT, processedPath).replace(/\\/g, '/'),
+      azureUrl,
+      oldLinks,
+      newLink: azureUrl,
+      referencedIn: [],
+      status: 'ready',
+    });
+  }
+
+  console.log('\n🔍 Finding doc references...');
+  const entries = processedFiles.map((e) => ({
+    originalPath: path.join(REPO_ROOT, e.originalPath),
+    oldLinks: e.oldLinks,
+  }));
+  const refs = findReferences(entries, DOCS_ROOT);
+  for (const entry of processedFiles) {
+    const absPath = path.join(REPO_ROOT, entry.originalPath);
+    entry.referencedIn = (refs.get(absPath) || []).map((f) =>
+      path.relative(REPO_ROOT, f).replace(/\\/g, '/')
+    );
+  }
+
+  const manifest = {
+    preparedAt: new Date().toISOString(),
+    entries: processedFiles,
+  };
+  writeManifest(REPO_ROOT, manifest);
+
+  const savedPct =
+    totalOriginalBytes > 0
+      ? Math.round((1 - totalProcessedBytes / totalOriginalBytes) * 100)
+      : 0;
+
+  console.log(`\n✅ Prepare complete`);
+  console.log(`   Processed : ${processedFiles.length} file(s)`);
+  console.log(`   Skipped   : ${skippedCount} file(s) (under ${SKIP_BELOW_BYTES / 1024}KB)`);
+  console.log(
+    `   Size      : ${(totalOriginalBytes / 1024).toFixed(1)}KB → ${(totalProcessedBytes / 1024).toFixed(1)}KB (${savedPct}% savings)`
+  );
+  console.log('\nReview asset-upload-manifest.json, then run: npm run assets:upload');
+}
+
+async function runUpload({ yes, deleteAfter }) {
+  // Implemented in Task 7
+  console.error('--upload not yet implemented');
+  process.exit(1);
+}
+
+(async () => {
+  const opts = parseArgs(process.argv);
+  if (opts.prepare) {
+    await runPrepare(opts);
+  } else if (opts.upload) {
+    await runUpload(opts);
+  } else {
+    console.error('Usage: node eng/upload-assets.js --prepare | --upload');
+    console.error('       Add --no-convert, --yes, --delete, --source <path> as needed.');
+    process.exit(1);
+  }
+})();

--- a/eng/upload-assets.js
+++ b/eng/upload-assets.js
@@ -118,9 +118,109 @@ async function runPrepare({ source, noConvert }) {
 }
 
 async function runUpload({ yes, deleteAfter }) {
-  // Implemented in Task 7
-  console.error('--upload not yet implemented');
-  process.exit(1);
+  const manifest = readManifest(REPO_ROOT);
+  if (!manifest) {
+    console.error('❌ No manifest found. Run: npm run assets:prepare first.');
+    process.exit(1);
+  }
+
+  const ageMs = Date.now() - new Date(manifest.preparedAt).getTime();
+  if (ageMs > 24 * 60 * 60 * 1000) {
+    console.warn(`⚠️  Manifest is ${Math.round(ageMs / 3600000)}h old. Consider re-running prepare.`);
+  }
+
+  const pending = manifest.entries.filter((e) => e.status === 'ready');
+  if (pending.length === 0) {
+    console.log('No entries with status=ready. Nothing to upload.');
+    process.exit(0);
+  }
+
+  console.log(`\n📋 ${pending.length} file(s) to upload:\n`);
+  for (const entry of pending) {
+    console.log(`  ${entry.originalPath}`);
+    console.log(`    → ${entry.azureUrl}`);
+  }
+
+  if (!yes) {
+    const { createInterface } = require('readline');
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise((resolve) =>
+      rl.question('\nProceed with upload? (y/N) ', resolve)
+    );
+    rl.close();
+    if (answer.trim().toLowerCase() !== 'y') {
+      console.log('Aborted.');
+      process.exit(0);
+    }
+  }
+
+  console.log('\n🔐 Checking Azure credentials...');
+  let credential;
+  try {
+    credential = await getCredential();
+    console.log('   Authenticated via DefaultAzureCredential ✓');
+  } catch (err) {
+    console.error('❌ Azure authentication failed. Run: az login');
+    console.error(`   Details: ${err.message}`);
+    process.exit(1);
+  }
+
+  console.log('\n☁️  Uploading...');
+  let uploadedCount = 0;
+  let failedCount = 0;
+
+  for (const entry of manifest.entries) {
+    if (entry.status !== 'ready') continue;
+    const processedAbsPath = path.join(REPO_ROOT, entry.processedPath);
+    const blobName = entry.azureUrl.replace(`${STORAGE_ACCOUNT_URL}/$web/`, '');
+    try {
+      await uploadBlob(processedAbsPath, blobName, credential);
+      entry.status = 'uploaded';
+      uploadedCount++;
+      console.log(`   ✓ ${entry.originalPath}`);
+    } catch (err) {
+      entry.status = 'failed';
+      failedCount++;
+      console.error(`   ✗ ${entry.originalPath}: ${err.message}`);
+    }
+    writeManifest(REPO_ROOT, manifest);
+  }
+
+  console.log('\n🔗 Replacing links in docs...');
+  const replacements = replaceLinks(manifest.entries, DOCS_ROOT);
+  console.log(`   ${replacements} link(s) replaced.`);
+
+  if (deleteAfter) {
+    console.log('\n🗑️  Deleting source files...');
+    for (const entry of manifest.entries) {
+      if (entry.status !== 'uploaded') continue;
+      const absPath = path.join(REPO_ROOT, entry.originalPath);
+      if (fs.existsSync(absPath)) {
+        fs.unlinkSync(absPath);
+        console.log(`   Deleted: ${entry.originalPath}`);
+      }
+    }
+  } else {
+    const remaining = manifest.entries
+      .filter((e) => e.status === 'uploaded')
+      .map((e) => e.originalPath);
+    if (remaining.length > 0) {
+      console.log('\n📁 Source files still in static/ (remove before committing):');
+      for (const p of remaining) console.log(`   ${p}`);
+    }
+  }
+
+  console.log(`\n✅ Upload complete`);
+  console.log(`   Uploaded  : ${uploadedCount}`);
+  console.log(`   Failed    : ${failedCount}`);
+  console.log(`   Links replaced: ${replacements}`);
+
+  if (failedCount > 0) {
+    console.log('\n⚠️  Some uploads failed. Re-run: npm run assets:upload to retry.');
+    process.exit(1);
+  }
+
+  console.log('\nRun `npm run build` to verify no broken links.');
 }
 
 (async () => {

--- a/eng/upload-assets/azure.js
+++ b/eng/upload-assets/azure.js
@@ -1,0 +1,67 @@
+const { BlobServiceClient } = require('@azure/storage-blob');
+const { DefaultAzureCredential } = require('@azure/identity');
+const fs = require('fs');
+const path = require('path');
+
+const STORAGE_ACCOUNT_URL =
+  process.env.AZURE_STORAGE_ACCOUNT_URL || 'https://edfidocs.blob.core.windows.net';
+const CONTAINER_NAME = '$web';
+
+const CONVERT_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg']);
+
+const CONTENT_TYPES = {
+  '.webp': 'image/webp',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+};
+
+function getBlobName(filePath, repoRoot, noConvert) {
+  const rel = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+  const withoutStatic = rel.replace(/^static\//, '');
+
+  if (!noConvert) {
+    const ext = path.extname(withoutStatic).toLowerCase();
+    if (CONVERT_EXTENSIONS.has(ext)) {
+      return withoutStatic.slice(0, -ext.length) + '.webp';
+    }
+  }
+  return withoutStatic;
+}
+
+function getAzureUrl(blobName) {
+  return `${STORAGE_ACCOUNT_URL}/$web/${blobName.replace(/\\/g, '/')}`;
+}
+
+async function getCredential() {
+  const credential = new DefaultAzureCredential();
+  await credential.getToken('https://storage.azure.com/.default');
+  return credential;
+}
+
+async function uploadBlob(processedPath, blobName, credential) {
+  const client = new BlobServiceClient(STORAGE_ACCOUNT_URL, credential);
+  const containerClient = client.getContainerClient(CONTAINER_NAME);
+  const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+
+  const ext = path.extname(processedPath).toLowerCase();
+  const contentType = CONTENT_TYPES[ext] || 'application/octet-stream';
+
+  await blockBlobClient.uploadFile(processedPath, {
+    blobHTTPHeaders: {
+      blobContentType: contentType,
+      blobCacheControl: 'public, max-age=31536000',
+    },
+  });
+}
+
+module.exports = {
+  getBlobName,
+  getAzureUrl,
+  getCredential,
+  uploadBlob,
+  STORAGE_ACCOUNT_URL,
+  CONTAINER_NAME,
+};

--- a/eng/upload-assets/azure.test.js
+++ b/eng/upload-assets/azure.test.js
@@ -1,0 +1,58 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { getBlobName, getAzureUrl, STORAGE_ACCOUNT_URL, CONTAINER_NAME } = require('./azure');
+
+test('getBlobName strips static/ prefix and changes extension to .webp by default', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/sdlc/foo.png';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/sdlc/foo.webp');
+});
+
+test('getBlobName preserves original extension when noConvert=true', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/sdlc/foo.png';
+  const result = getBlobName(filePath, repoRoot, true);
+  assert.equal(result, 'img/sdlc/foo.png');
+});
+
+test('getBlobName handles JPG extension change to webp', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/photo.jpg';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/photo.webp');
+});
+
+test('getBlobName does not change extension for SVG', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/icon.svg';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/icon.svg');
+});
+
+test('getBlobName does not change extension for GIF', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/anim.gif';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/anim.gif');
+});
+
+test('getBlobName handles nested subdirectories', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/reference/ods-api/fig1.png';
+  const result = getBlobName(filePath, repoRoot, false);
+  assert.equal(result, 'img/reference/ods-api/fig1.webp');
+});
+
+test('getAzureUrl returns correct blob storage URL', () => {
+  const url = getAzureUrl('img/sdlc/foo.webp');
+  assert.equal(url, `${STORAGE_ACCOUNT_URL}/$web/img/sdlc/foo.webp`);
+});
+
+test('STORAGE_ACCOUNT_URL defaults to edfidocs', () => {
+  assert.equal(STORAGE_ACCOUNT_URL, 'https://edfidocs.blob.core.windows.net');
+});
+
+test('CONTAINER_NAME is $web', () => {
+  assert.equal(CONTAINER_NAME, '$web');
+});

--- a/eng/upload-assets/compress.js
+++ b/eng/upload-assets/compress.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+
+const SKIP_BELOW_BYTES = 10 * 1024;
+const CONVERT_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg']);
+const PASSTHROUGH_EXTENSIONS = new Set(['.svg', '.gif']);
+const ALL_EXTENSIONS = new Set([...CONVERT_EXTENSIONS, ...PASSTHROUGH_EXTENSIONS, '.webp']);
+const WEBP_QUALITY = 85;
+const JPEG_QUALITY = 85;
+const PNG_COMPRESSION = 9;
+
+function scanImages(sourceDir) {
+  const results = [];
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (ALL_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+        results.push(fullPath);
+      }
+    }
+  }
+  walk(sourceDir);
+  return results;
+}
+
+async function backup(files, sourceDir, backupRoot) {
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/:/g, '-')
+    .replace(/\..+$/, '');
+  const backupDir = path.join(backupRoot, timestamp);
+  if (fs.existsSync(backupDir)) {
+    throw new Error(
+      `Backup directory already exists: ${backupDir}. Wait a moment and retry.`
+    );
+  }
+  fs.mkdirSync(backupDir, { recursive: true });
+  for (const file of files) {
+    const rel = path.relative(sourceDir, file);
+    const dest = path.join(backupDir, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(file, dest);
+  }
+  return backupDir;
+}
+
+async function processImage(srcPath, destPath, noConvert) {
+  const stat = fs.statSync(srcPath);
+  if (stat.size < SKIP_BELOW_BYTES) return null;
+
+  const ext = path.extname(srcPath).toLowerCase();
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+
+  if (PASSTHROUGH_EXTENSIONS.has(ext) || ext === '.webp') {
+    fs.copyFileSync(srcPath, destPath);
+    return { originalSize: stat.size, processedSize: fs.statSync(destPath).size };
+  }
+
+  if (noConvert) {
+    if (ext === '.png') {
+      await sharp(srcPath).png({ compressionLevel: PNG_COMPRESSION }).toFile(destPath);
+    } else {
+      await sharp(srcPath).jpeg({ quality: JPEG_QUALITY }).toFile(destPath);
+    }
+  } else {
+    await sharp(srcPath).webp({ quality: WEBP_QUALITY }).toFile(destPath);
+  }
+
+  return { originalSize: stat.size, processedSize: fs.statSync(destPath).size };
+}
+
+module.exports = { scanImages, backup, processImage, SKIP_BELOW_BYTES };

--- a/eng/upload-assets/compress.js
+++ b/eng/upload-assets/compress.js
@@ -26,7 +26,7 @@ function scanImages(sourceDir) {
   return results;
 }
 
-async function backup(files, sourceDir, backupRoot) {
+function backup(files, sourceDir, backupRoot) {
   const timestamp = new Date()
     .toISOString()
     .replace(/:/g, '-')
@@ -56,7 +56,7 @@ async function processImage(srcPath, destPath, noConvert) {
 
   if (PASSTHROUGH_EXTENSIONS.has(ext) || ext === '.webp') {
     fs.copyFileSync(srcPath, destPath);
-    return { originalSize: stat.size, processedSize: fs.statSync(destPath).size };
+    return { originalSize: stat.size, processedSize: stat.size };
   }
 
   if (noConvert) {

--- a/eng/upload-assets/compress.test.js
+++ b/eng/upload-assets/compress.test.js
@@ -1,4 +1,4 @@
-const { test, before, after } = require('node:test');
+const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');
@@ -79,7 +79,7 @@ test('backup aborts if timestamp folder already exists', async () => {
   fs.mkdirSync(path.join(backupRoot, ts));
 
   await assert.rejects(
-    () => backup([file], srcDir, backupRoot),
+    () => Promise.resolve().then(() => backup([file], srcDir, backupRoot)),
     /already exists/
   );
 });
@@ -122,6 +122,24 @@ test('processImage compresses PNG without converting when noConvert=true', async
   // Verify it's still a valid PNG (sharp can read it back)
   const meta = await sharp(dest).metadata();
   assert.equal(meta.format, 'png');
+});
+
+test('processImage compresses JPG without converting when noConvert=true', async () => {
+  const dir = makeTmpDir();
+  const src = path.join(dir, 'large.jpg');
+  const dest = path.join(dir, 'large-compressed.jpg');
+  // Create a large JPG using sharp
+  const noise = Buffer.alloc(300 * 300 * 3);
+  for (let i = 0; i < noise.length; i++) noise[i] = Math.floor(Math.random() * 256);
+  await sharp(noise, { raw: { width: 300, height: 300, channels: 3 } }).jpeg().toFile(src);
+  assert.ok(fs.statSync(src).size > SKIP_BELOW_BYTES, 'test jpg should be > SKIP_BELOW_BYTES');
+
+  const result = await processImage(src, dest, true);
+
+  assert.ok(result !== null);
+  assert.ok(fs.existsSync(dest), 'compressed jpg should exist');
+  const meta = await sharp(dest).metadata();
+  assert.equal(meta.format, 'jpeg');
 });
 
 test('processImage copies SVG as-is regardless of size or noConvert flag', async () => {

--- a/eng/upload-assets/compress.test.js
+++ b/eng/upload-assets/compress.test.js
@@ -1,0 +1,139 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const sharp = require('sharp');
+const { scanImages, backup, processImage, SKIP_BELOW_BYTES } = require('./compress');
+
+// Helpers
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'compress-test-'));
+}
+
+function touchFile(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '');
+}
+
+async function makeLargePng(destPath) {
+  // 300x300 truly random noise image ~270KB, well above SKIP_BELOW_BYTES
+  const noise = Buffer.allocUnsafe(300 * 300 * 3);
+  for (let i = 0; i < noise.length; i++) noise[i] = Math.floor(Math.random() * 256);
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  await sharp(noise, { raw: { width: 300, height: 300, channels: 3 } })
+    .png()
+    .toFile(destPath);
+}
+
+// scanImages tests
+test('scanImages finds png, jpg, jpeg, gif, svg, webp files', () => {
+  const dir = makeTmpDir();
+  touchFile(path.join(dir, 'a.png'));
+  touchFile(path.join(dir, 'sub', 'b.jpg'));
+  touchFile(path.join(dir, 'c.jpeg'));
+  touchFile(path.join(dir, 'd.gif'));
+  touchFile(path.join(dir, 'e.svg'));
+  touchFile(path.join(dir, 'f.webp'));
+  touchFile(path.join(dir, 'ignored.txt'));
+  const found = scanImages(dir);
+  assert.equal(found.length, 6);
+  assert.ok(found.some((f) => f.endsWith('a.png')));
+  assert.ok(found.some((f) => f.endsWith('b.jpg')));
+  assert.ok(!found.some((f) => f.endsWith('.txt')));
+});
+
+test('scanImages is case-insensitive for extensions', () => {
+  const dir = makeTmpDir();
+  touchFile(path.join(dir, 'A.PNG'));
+  touchFile(path.join(dir, 'B.JPG'));
+  const found = scanImages(dir);
+  assert.equal(found.length, 2);
+});
+
+// backup tests
+test('backup copies files preserving structure and returns backup dir path', async () => {
+  const srcDir = makeTmpDir();
+  const backupRoot = makeTmpDir();
+  const file1 = path.join(srcDir, 'a.png');
+  const file2 = path.join(srcDir, 'sub', 'b.jpg');
+  fs.writeFileSync(file1, 'img1');
+  fs.mkdirSync(path.dirname(file2), { recursive: true });
+  fs.writeFileSync(file2, 'img2');
+
+  const backupDir = await backup([file1, file2], srcDir, backupRoot);
+
+  assert.ok(fs.existsSync(path.join(backupDir, 'a.png')));
+  assert.ok(fs.existsSync(path.join(backupDir, 'sub', 'b.jpg')));
+  assert.equal(fs.readFileSync(path.join(backupDir, 'a.png'), 'utf8'), 'img1');
+});
+
+test('backup aborts if timestamp folder already exists', async () => {
+  const srcDir = makeTmpDir();
+  const backupRoot = makeTmpDir();
+  const file = path.join(srcDir, 'a.png');
+  fs.writeFileSync(file, 'x');
+
+  // Pre-create the dir backup would create this second (same timestamp format)
+  const ts = new Date().toISOString().replace(/:/g, '-').replace(/\..+$/, '');
+  fs.mkdirSync(path.join(backupRoot, ts));
+
+  await assert.rejects(
+    () => backup([file], srcDir, backupRoot),
+    /already exists/
+  );
+});
+
+// processImage tests
+test('processImage returns null for files under SKIP_BELOW_BYTES', async () => {
+  const dir = makeTmpDir();
+  const src = path.join(dir, 'tiny.png');
+  const dest = path.join(dir, 'tiny.webp');
+  fs.writeFileSync(src, Buffer.alloc(100)); // 100 bytes, well under 10KB
+  const result = await processImage(src, dest, false);
+  assert.equal(result, null);
+});
+
+test('processImage converts PNG to WebP by default', async () => {
+  const dir = makeTmpDir();
+  const src = path.join(dir, 'large.png');
+  const dest = path.join(dir, 'large.webp');
+  await makeLargePng(src);
+  assert.ok(fs.statSync(src).size > SKIP_BELOW_BYTES, 'test image should be > SKIP_BELOW_BYTES');
+
+  const result = await processImage(src, dest, false);
+
+  assert.ok(result !== null);
+  assert.ok(fs.existsSync(dest), 'webp output should exist');
+  assert.ok(result.processedSize > 0);
+  assert.ok(result.originalSize > SKIP_BELOW_BYTES);
+});
+
+test('processImage compresses PNG without converting when noConvert=true', async () => {
+  const dir = makeTmpDir();
+  const src = path.join(dir, 'large.png');
+  const dest = path.join(dir, 'large-compressed.png');
+  await makeLargePng(src);
+
+  const result = await processImage(src, dest, true);
+
+  assert.ok(result !== null);
+  assert.ok(fs.existsSync(dest), 'compressed png should exist');
+  // Verify it's still a valid PNG (sharp can read it back)
+  const meta = await sharp(dest).metadata();
+  assert.equal(meta.format, 'png');
+});
+
+test('processImage copies SVG as-is regardless of size or noConvert flag', async () => {
+  const dir = makeTmpDir();
+  const src = path.join(dir, 'icon.svg');
+  const dest = path.join(dir, 'icon-out.svg');
+  const svgContent = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100"/></svg>';
+  // Pad to exceed SKIP_BELOW_BYTES
+  fs.writeFileSync(src, svgContent.padEnd(SKIP_BELOW_BYTES + 100, ' '));
+
+  const result = await processImage(src, dest, false);
+
+  assert.ok(result !== null);
+  assert.ok(fs.readFileSync(dest, 'utf8').startsWith('<svg'));
+});

--- a/eng/upload-assets/link-replacer.js
+++ b/eng/upload-assets/link-replacer.js
@@ -54,9 +54,10 @@ function replaceLinks(entries, docsRoot) {
 
     for (const entry of uploadedEntries) {
       for (const oldLink of entry.oldLinks) {
-        if (content.includes(oldLink)) {
-          content = content.split(oldLink).join(entry.newLink);
-          totalReplacements++;
+        const parts = content.split(oldLink);
+        if (parts.length > 1) {
+          content = parts.join(entry.newLink);
+          totalReplacements += parts.length - 1;
           changed = true;
         }
       }

--- a/eng/upload-assets/link-replacer.js
+++ b/eng/upload-assets/link-replacer.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+
+function getOldLinks(filePath, repoRoot) {
+  const rel = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+  const withoutStatic = rel.replace(/^static\//, '');
+  return [rel, `/${withoutStatic}`];
+}
+
+function findDocFiles(docsRoot) {
+  const results = [];
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.name.endsWith('.md') || entry.name.endsWith('.mdx')) {
+        results.push(fullPath);
+      }
+    }
+  }
+  walk(docsRoot);
+  return results;
+}
+
+function findReferences(entries, docsRoot) {
+  const docFiles = findDocFiles(docsRoot);
+  const result = new Map();
+
+  for (const docFile of docFiles) {
+    const content = fs.readFileSync(docFile, 'utf8');
+    for (const { originalPath, oldLinks } of entries) {
+      for (const link of oldLinks) {
+        if (content.includes(link)) {
+          if (!result.has(originalPath)) result.set(originalPath, new Set());
+          result.get(originalPath).add(docFile);
+          break;
+        }
+      }
+    }
+  }
+
+  return new Map([...result].map(([k, v]) => [k, [...v]]));
+}
+
+function replaceLinks(entries, docsRoot) {
+  const docFiles = findDocFiles(docsRoot);
+  const uploadedEntries = entries.filter((e) => e.status === 'uploaded');
+  let totalReplacements = 0;
+
+  for (const docFile of docFiles) {
+    let content = fs.readFileSync(docFile, 'utf8');
+    let changed = false;
+
+    for (const entry of uploadedEntries) {
+      for (const oldLink of entry.oldLinks) {
+        if (content.includes(oldLink)) {
+          content = content.split(oldLink).join(entry.newLink);
+          totalReplacements++;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) fs.writeFileSync(docFile, content, 'utf8');
+  }
+
+  return totalReplacements;
+}
+
+module.exports = { getOldLinks, findReferences, replaceLinks };

--- a/eng/upload-assets/link-replacer.test.js
+++ b/eng/upload-assets/link-replacer.test.js
@@ -1,0 +1,132 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { getOldLinks, findReferences, replaceLinks } = require('./link-replacer');
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'link-test-'));
+}
+
+function writeDoc(dir, filename, content) {
+  const full = path.join(dir, filename);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+  return full;
+}
+
+// getOldLinks tests
+test('getOldLinks returns filesystem and Docusaurus served paths', () => {
+  const repoRoot = '/repo';
+  const filePath = '/repo/static/img/sdlc/foo.png';
+  const links = getOldLinks(filePath, repoRoot);
+  assert.ok(links.includes('static/img/sdlc/foo.png'), 'should include filesystem path');
+  assert.ok(links.includes('/img/sdlc/foo.png'), 'should include Docusaurus served path');
+});
+
+test('getOldLinks handles Windows-style backslashes', () => {
+  const repoRoot = 'C:\\repo';
+  const filePath = 'C:\\repo\\static\\img\\foo.png';
+  const links = getOldLinks(filePath, repoRoot);
+  assert.ok(links.some((l) => l.includes('/')), 'all links should use forward slashes');
+  assert.ok(!links.some((l) => l.includes('\\')), 'no backslashes in output');
+});
+
+// findReferences tests
+test('findReferences returns doc files that contain a matching link', () => {
+  const docsRoot = makeTmpDir();
+  writeDoc(docsRoot, 'page.md', '![foo](/img/sdlc/foo.png)');
+  writeDoc(docsRoot, 'other.md', 'no images here');
+
+  const entries = [
+    { originalPath: '/repo/static/img/sdlc/foo.png', oldLinks: ['static/img/sdlc/foo.png', '/img/sdlc/foo.png'] },
+  ];
+  const result = findReferences(entries, docsRoot);
+  const refs = result.get('/repo/static/img/sdlc/foo.png');
+  assert.ok(refs, 'should have references for this image');
+  assert.equal(refs.length, 1);
+  assert.ok(refs[0].endsWith('page.md'));
+});
+
+test('findReferences matches both static/ and /img/ link styles', () => {
+  const docsRoot = makeTmpDir();
+  writeDoc(docsRoot, 'page-a.md', '![a](static/img/foo.png)');
+  writeDoc(docsRoot, 'page-b.md', '![b](/img/foo.png)');
+
+  const entries = [
+    { originalPath: '/repo/static/img/foo.png', oldLinks: ['static/img/foo.png', '/img/foo.png'] },
+  ];
+  const result = findReferences(entries, docsRoot);
+  const refs = result.get('/repo/static/img/foo.png');
+  assert.equal(refs.length, 2);
+});
+
+test('findReferences returns empty map when no docs reference the image', () => {
+  const docsRoot = makeTmpDir();
+  writeDoc(docsRoot, 'page.md', 'no images');
+
+  const entries = [
+    { originalPath: '/repo/static/img/foo.png', oldLinks: ['static/img/foo.png', '/img/foo.png'] },
+  ];
+  const result = findReferences(entries, docsRoot);
+  assert.ok(!result.has('/repo/static/img/foo.png'));
+});
+
+// replaceLinks tests
+test('replaceLinks replaces old links with new Azure URL in doc files', () => {
+  const docsRoot = makeTmpDir();
+  const docPath = writeDoc(docsRoot, 'page.md', '![foo](/img/foo.png) and ![foo](static/img/foo.png)');
+
+  const entries = [
+    {
+      originalPath: '/repo/static/img/foo.png',
+      oldLinks: ['static/img/foo.png', '/img/foo.png'],
+      newLink: 'https://edfidocs.blob.core.windows.net/$web/img/foo.webp',
+      status: 'uploaded',
+    },
+  ];
+  const count = replaceLinks(entries, docsRoot);
+  const content = fs.readFileSync(docPath, 'utf8');
+  assert.ok(!content.includes('/img/foo.png'), 'old /img/ link should be replaced');
+  assert.ok(!content.includes('static/img/foo.png'), 'old static/ link should be replaced');
+  assert.ok(content.includes('https://edfidocs.blob.core.windows.net/$web/img/foo.webp'), 'new Azure URL should appear');
+  assert.equal(count, 2, 'should count 2 replacements');
+});
+
+test('replaceLinks skips entries that are not status=uploaded', () => {
+  const docsRoot = makeTmpDir();
+  const docPath = writeDoc(docsRoot, 'page.md', '![foo](/img/foo.png)');
+
+  const entries = [
+    {
+      originalPath: '/repo/static/img/foo.png',
+      oldLinks: ['/img/foo.png'],
+      newLink: 'https://azure.example.com/foo.webp',
+      status: 'failed',
+    },
+  ];
+  replaceLinks(entries, docsRoot);
+  const content = fs.readFileSync(docPath, 'utf8');
+  assert.ok(content.includes('/img/foo.png'), 'failed entry should not be replaced');
+});
+
+test('replaceLinks processes .md and .mdx files', () => {
+  const docsRoot = makeTmpDir();
+  writeDoc(docsRoot, 'page.md', '![x](/img/x.png)');
+  writeDoc(docsRoot, 'page.mdx', '<img src="/img/x.png" />');
+  writeDoc(docsRoot, 'other.txt', '/img/x.png');
+
+  const entries = [
+    {
+      originalPath: '/repo/static/img/x.png',
+      oldLinks: ['/img/x.png'],
+      newLink: 'https://azure.example.com/x.webp',
+      status: 'uploaded',
+    },
+  ];
+  replaceLinks(entries, docsRoot);
+  assert.ok(!fs.readFileSync(path.join(docsRoot, 'page.md'), 'utf8').includes('/img/x.png'));
+  assert.ok(!fs.readFileSync(path.join(docsRoot, 'page.mdx'), 'utf8').includes('/img/x.png'));
+  assert.ok(fs.readFileSync(path.join(docsRoot, 'other.txt'), 'utf8').includes('/img/x.png'));
+});

--- a/eng/upload-assets/manifest.js
+++ b/eng/upload-assets/manifest.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const MANIFEST_FILENAME = 'asset-upload-manifest.json';
+
+function read(repoRoot) {
+  const filePath = path.join(repoRoot, MANIFEST_FILENAME);
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function write(repoRoot, manifest) {
+  const filePath = path.join(repoRoot, MANIFEST_FILENAME);
+  fs.writeFileSync(filePath, JSON.stringify(manifest, null, 2));
+}
+
+module.exports = { read, write, MANIFEST_FILENAME };

--- a/eng/upload-assets/manifest.test.js
+++ b/eng/upload-assets/manifest.test.js
@@ -1,0 +1,37 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { read, write, MANIFEST_FILENAME } = require('./manifest');
+
+test('read returns null when manifest file does not exist', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manifest-test-'));
+  const result = read(tmpDir);
+  assert.equal(result, null);
+});
+
+test('write creates manifest file with correct content', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manifest-test-'));
+  const manifest = { preparedAt: '2026-05-26T00:00:00.000Z', entries: [] };
+  write(tmpDir, manifest);
+  const filePath = path.join(tmpDir, MANIFEST_FILENAME);
+  assert.ok(fs.existsSync(filePath), 'manifest file should exist');
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  assert.deepEqual(parsed, manifest);
+});
+
+test('read returns written manifest', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manifest-test-'));
+  const manifest = {
+    preparedAt: '2026-05-26T00:00:00.000Z',
+    entries: [{ originalPath: 'static/img/foo.png', status: 'ready' }],
+  };
+  write(tmpDir, manifest);
+  const result = read(tmpDir);
+  assert.deepEqual(result, manifest);
+});
+
+test('MANIFEST_FILENAME is asset-upload-manifest.json', () => {
+  assert.equal(MANIFEST_FILENAME, 'asset-upload-manifest.json');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "ed-fi-tech",
       "version": "0.0.0",
       "dependencies": {
+        "@azure/identity": "^4.13.1",
+        "@azure/storage-blob": "^12.31.0",
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/plugin-content-docs": "^3.10.1",
         "@docusaurus/preset-classic": "^3.10.1",
@@ -17,7 +19,8 @@
         "eslint": "^10.3.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react-dom": "^18.0.0",
+        "sharp": "^0.34.5"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.7.0",
@@ -296,6 +299,294 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure/core-client": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+      "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.2",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@azure/storage-blob": {
+      "version": "12.31.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.31.0.tgz",
+      "integrity": "sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.3.0",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.3.0.tgz",
+      "integrity": "sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4153,6 +4444,16 @@
         "node": ">=20.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -4384,6 +4685,471 @@
         "kolorist": "^1.8.0",
         "local-pkg": "^1.1.1",
         "mlly": "^1.7.4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4700,6 +5466,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6217,6 +6995,20 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -6496,6 +7288,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/aggregate-error": {
@@ -7099,6 +7900,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -9109,6 +9916,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -9301,6 +10117,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -10149,6 +10974,44 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.18.0",
@@ -11356,6 +12219,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http-proxy-middleware": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
@@ -11403,6 +12279,19 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -12099,6 +12988,49 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.25",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.25.tgz",
@@ -12335,10 +13267,52 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -15917,6 +16891,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
@@ -18926,9 +19915,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -19163,6 +20152,50 @@
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -19698,6 +20731,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-object": {
       "version": "1.0.8",
@@ -21510,6 +22555,21 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,14 @@
     "format": "npx prettier . --write",
     "lint": "markdownlint-cli2 **/*.md #node_modules && eslint **/*.mdx",
     "lint:folder": "node eng/lint-folder.js",
-    "lint:fix": "markdownlint-cli2 **/*.md #node_modules --fix"
+    "lint:fix": "markdownlint-cli2 **/*.md #node_modules --fix",
+    "assets:prepare": "node eng/upload-assets.js --prepare",
+    "assets:upload": "node eng/upload-assets.js --upload",
+    "assets": "node eng/upload-assets.js --prepare && node eng/upload-assets.js --upload"
   },
   "dependencies": {
+    "@azure/identity": "^4.13.1",
+    "@azure/storage-blob": "^12.31.0",
     "@docusaurus/core": "^3.10.1",
     "@docusaurus/plugin-content-docs": "^3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",
@@ -27,7 +32,8 @@
     "eslint": "^10.3.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "sharp": "^0.34.5"
   },
   "overrides": {
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4"


### PR DESCRIPTION
## Summary

- Adds a two-phase Node.js CLI (`eng/upload-assets.js`) that compresses/converts static images to WebP via `sharp`, uploads them to Azure Blob Storage (`$web` container) using `DefaultAzureCredential`, and replaces Markdown/MDX image links in `docs/` automatically
- Adds `npm run assets:prepare` / `assets:upload` / `assets` scripts to `package.json`
- Adds a `.claude/skills/upload-assets/SKILL.md` Claude skill (`/upload-assets`) that guides users through the workflow with checkpoints

## Modules

| File | Purpose |
|---|---|
| `eng/upload-assets.js` | CLI entry point — `--prepare` and `--upload` phases |
| `eng/upload-assets/manifest.js` | Read/write `asset-upload-manifest.json` |
| `eng/upload-assets/compress.js` | Scan images, backup originals, process with sharp |
| `eng/upload-assets/link-replacer.js` | Find references in docs, replace links |
| `eng/upload-assets/azure.js` | Blob name/URL computation, credential check, upload |

## Test Plan

- [x] 30 unit tests pass (`manifest`, `compress`, `link-replacer`, `azure` modules)
- [x] `--prepare` smoke-tested against `static/img/` — 101 files processed, 46% size savings
- [x] `--no-convert` flag verified — extensions preserved in manifest and Azure URLs
- [x] `--upload` with no manifest exits with clear error message
- [x] No flags shows usage line

## Notes

- Images under 10KB are skipped (too small for compression to be meaningful)
- SVG and GIF are copied as-is (no conversion)
- Originals are backed up to `.asset-backup/<timestamp>/` before any processing
- `.asset-backup/`, `asset-upload-manifest.json`, and `eng/upload-assets/.tmp/` added to `.gitignore`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)