### PR TITLE
[DMS-1194] Document DMS v1.0 Change Queries deferred features in v8.0 What's New

### DIFF
--- a/odsApi_versioned_docs/version-8.0/whats-new/whats-new-in-this-release.md
+++ b/odsApi_versioned_docs/version-8.0/whats-new/whats-new-in-this-release.md
@@ -1,0 +1,53 @@
+---
+description: New features, notable changes, and known limitations in Ed-Fi API v8.0, including Change Queries deferred features.
+sidebar_position: 1
+---
+
+# What's New In This Release
+
+:::warning Upcoming Release
+
+Ed-Fi API v8 is under active development and is not yet available for production
+use. This page is being expanded as the release approaches.
+
+:::
+
+This page describes notable changes and known limitations in Ed-Fi API v8.0, the
+next-generation platform previously known as the Ed-Fi Data Management Service
+(DMS). Additional release content will be added as the release approaches.
+
+## Change Queries — deferred features in DMS v1.0
+
+Change Queries are available in DMS v1.0 (Ed-Fi API v8.0), including the
+`/deletes`, `/keyChanges`, and `/availableChangeVersions` endpoints and the
+`minChangeVersion`/`maxChangeVersion` filters on live resource and descriptor
+GET-many endpoints. Several ODS capabilities are deferred in this release; do not
+assume full ODS parity in the following areas:
+
+- **Snapshot / read-replica isolation is not supported.** The `Use-Snapshot`
+  request header is not part of the DMS v1.0 Change Queries contract. DMS v1.0
+  silently ignores `Use-Snapshot` on `/deletes`, `/keyChanges`,
+  `/availableChangeVersions`, and live resource/descriptor GET-many requests: the
+  request is processed against current data without snapshot isolation, no
+  `Warning` header is returned, and no snapshot-specific error is emitted.
+- **Ed-Fi API Publisher guidance.** The Ed-Fi API Publisher sends
+  `Use-Snapshot: true` by default when its source API major version is 7 or
+  higher. Because DMS v1.0 silently ignores the header, reads from a DMS v1.0
+  source are not snapshot-isolated — concurrent writes against the source may be
+  visible mid-publish and can produce inconsistent published data. When publishing
+  from a DMS v1.0 source, run the Publisher with `--ignoreIsolation=true` to
+  explicitly acknowledge that source isolation is unavailable (or accept the risk
+  of inconsistent reads).
+- **No option to disable Change Queries.** Change Queries are always on in DMS
+  v1.0. DMS v1.0 does not provide the ODS-style `ApiSettings:Features:ChangeQueries`
+  disable setting, and the corresponding `Feature Disabled` response is not part of
+  the v1.0 contract.
+- **Custom view-based `ReadChanges` authorization is not supported.** Custom
+  view-based authorization strategies are not supported for the `/deletes` and
+  `/keyChanges` Change Query endpoints in DMS v1.0. Other Change Query
+  authorization strategies are supported, but Change Query authorization should not
+  be assumed to be at full ODS parity.
+
+Snapshot/read-replica support, a runtime option to disable Change Queries, and
+custom view-based `ReadChanges` authorization are planned for a later release
+(targeted for Ed-Fi API v8.1).


### PR DESCRIPTION
## What

Adds the Ed-Fi API v8.0 "What's New In This Release" page, seeded with the Change Queries deferred-feature limitations for DMS v1.0.

## Why

This is the documentation deliverable for **DMS-1194** (https://edfi.atlassian.net/browse/DMS-1194), fix version Ed-Fi API v8.0. DMS v1.0 ships Change Queries but intentionally defers snapshot/read-replica isolation, a feature-disable option, and custom view-based `ReadChanges` authorization. The release notes must call these out explicitly so operators, Ed-Fi API Publisher users, and implementers do not assume ODS parity. The wording is faithful to the DMS Change Queries design doc (`reference/design/backend-redesign/design-docs/change-queries.md`, sections "Snapshot support is deferred" and "Out of scope") in the Data-Management-Service repo.

## Cross-repo context (for reviewers)

The DMS-1194 ticket and design work live in `Ed-Fi-Alliance-OSS/Data-Management-Service`. The reviewed source/handoff text was committed there in PR #1035 (https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service/pull/1035). Because the canonical release notes are published from *this* repo, this PR applies that reviewed text to the actual v8.0 release-notes page. The v8.0 docs tree currently contains only the "Upcoming" `readme.md` stub, so this PR creates the first content page under `version-8.0/whats-new/`.

## Changes

- New file: `odsApi_versioned_docs/version-8.0/whats-new/whats-new-in-this-release.md`
  - Frontmatter (`description`, `sidebar_position: 1`) mirrors the v7.3 "What's New In This Release" page.
  - Includes the standard "Upcoming Release" admonition used by the v8.0 `readme.md`.
  - Documents the four Change Queries deferrals: silent-ignore of `Use-Snapshot` (no `Warning` header, no snapshot ProblemDetails); API Publisher `--ignoreIsolation=true` guidance; no `ApiSettings:Features:ChangeQueries` disable / no `Feature Disabled` response; and unsupported custom view-based `ReadChanges` for `/deletes` and `/keyChanges`. All three are noted as targeted for v8.1.
- No other files changed. The versioned sidebar is `autogenerated`, so this page appears in the v8.0 nav without a sidebar edit.

## Notes for docs maintainers

- This page is intentionally **link-free** so the Docusaurus broken-link build stays green; please add cross-links as the v8.0 docs tree fills out.
- It is scoped to the Change Queries deferrals only (the specific DMS-1194 deliverable). It is meant to be **expanded** with the rest of the v8.0 release content as the release approaches; feel free to adjust the page/section structure to match your planned v8.0 layout.

## Verification

- `git diff --check` clean; single new file, additions only.
- Page authored to mirror existing v7.3 conventions; no Docusaurus build was run locally (no local site toolchain). CI build / link-check on this PR is the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
