### PR TITLE
EDFI-2779: Restructure the Windows IIS installation guide

### DIFF
--- a/docs/reference/5-admin-app/configuration/configuring-admin-app.md
+++ b/docs/reference/5-admin-app/configuration/configuring-admin-app.md
@@ -37,10 +37,7 @@ module.exports = {
     ISSUER: 'https://your-oidc-provider/realms/edfi',
     CLIENT_ID: 'edfiadminapp',
     CLIENT_SECRET: 'your-client-secret',
-    MACHINE_AUDIENCE: 'edfiadminapp-api',
-    MANAGEMENT_DOMAIN: 'your-domain.com',
-    MANAGEMENT_CLIENT_ID: 'edfiadminapp-machine',
-    MANAGEMENT_CLIENT_SECRET: 'machine-client-secret'
+    MACHINE_AUDIENCE: 'edfiadminapp-api', // only used for direct bearer-token API access
   },
 
   SAMPLE_OIDC_CONFIG: {
@@ -54,8 +51,10 @@ module.exports = {
 
   // Database Encryption (for storing sensitive data)
   DB_ENCRYPTION_SECRET_VALUE: {
-    // Can replace with `openssl rand -hex 32` or `node -e "console.log('KEY: '+ require('crypto').randomBytes(32).toString('hex'))"
-    KEY: 'your-32-character-encryption-key'
+    // A 32-byte key, hex-encoded (64 hex characters).
+    // Generate with: openssl rand -hex 32
+    // or: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+    KEY: 'your-64-hex-char-encryption-key'
   },
 
   // Application URLs
@@ -65,13 +64,18 @@ module.exports = {
 
   // API Configuration
   API_PORT: 3333,
-  _OPEN_API: false, // Set to true for Swagger documentation
+  ENABLE_OPEN_API: false, // Set to true for Swagger documentation
 
   // Database Options
   DB_SSL: true, // Use SSL for database connections
   DB_RUN_MIGRATIONS: true, // Auto-run database migrations
   DB_SYNCHRONIZE: false, // Never use in production
   TYPEORM_LOGGING: false, // Enable for debugging
+
+  // Outbound TLS: verify the certificate of the ODS/API and Admin API the app calls.
+  // Keep true. For a local upstream with a self-signed cert, trust it via
+  // NODE_EXTRA_CA_CERTS rather than disabling this.
+  SSL_VERIFICATION: true,
 
   // Optional Features
   USE_YOPASS: false, // Enable Yopass integration
@@ -83,6 +87,10 @@ module.exports = {
   WHITELISTED_REDIRECTS: ['https://your-domain.com/adminapp']
 };
 ```
+
+:::note
+These URL examples assume a single public origin behind a reverse proxy (path-based `/adminapp` and `/adminapp-api`). For a direct two-site deployment such as the Windows/IIS install, use each site's own HTTPS URL (for example `https://host:3443`) instead.
+:::
 
 ### Environment Variables Unix
 
@@ -96,7 +104,7 @@ DATABASE_SECRET={"username":"user","password":"pass","host":"localhost","port":5
 AUTH0_CONFIG_SECRET={"ISSUER":"https://keycloak/realms/edfi","CLIENT_ID":"edfiadminapp","CLIENT_SECRET":"secret","MACHINE_AUDIENCE":"edfiadminapp-api"}
 
 # Encryption
-DB_ENCRYPTION_SECRET={"KEY":"your-32-char-key","IV":"your-16-char-iv"}
+DB_ENCRYPTION_SECRET={"KEY":"your-64-hex-char-key"}
 
 # URLs
 FE_URL=https://your-domain.com/adminapp
@@ -125,7 +133,7 @@ VITE_OIDC_ID=1  # ID of OIDC configuration in database
 VITE_BASE_PATH=/adminapp/
 
 # Help Documentation
-VITE_HELP_GUIDE=https://docs.ed-fi.org/
+VITE_HELP_GUIDE=https://docs.ed-fi.org/reference/admin-app
 
 # UI Configuration
 VITE_STARTING_GUIDE=https://docs.ed-fi.org/reference/admin-app/configuration/global-administration-tasks
@@ -133,6 +141,10 @@ VITE_CONTACT=https://community.ed-fi.org/
 VITE_APPLICATION_NAME="Ed-Fi Admin App"
 VITE_IDP_ACCOUNT_URL=https://your-domain.com/auth/realms/edfi/account/
 ```
+
+:::note
+`VITE_API_URL` and `VITE_BASE_PATH` depend on how the app is exposed. Behind a reverse proxy on a single origin, use path-based values (`.../adminapp-api` and `/adminapp/`) as shown. For a direct two-site deployment such as the Windows/IIS install, use the API site's own HTTPS URL (for example `https://host:3443`) and serve the frontend from root (`VITE_BASE_PATH="/"`).
+:::
 
 **Variable Descriptions:**
 
@@ -151,18 +163,9 @@ This should point to the **account management interface** (`/auth/realms/{realm-
 
 :::
 
-These variables must be set during the build process:
+Set these before building — put them in `packages/fe/.env` (copy `.copyme.env.local` to `.env`) or export them in the shell — because they are baked into the bundle at build time:
 
 ```bash
-# Build with custom configuration
-VITE_API_URL=https://your-domain.com/adminapp-api \
-VITE_OIDC_ID=1 \
-VITE_BASE_PATH=/adminapp/ \
-VITE_HELP_GUIDE=https://your-help-site.com/ \
-VITE_STARTING_GUIDE=https://docs.ed-fi.org/reference/admin-app/configuration/global-administration-tasks \
-VITE_CONTACT=https://community.ed-fi.org/ \
-VITE_APPLICATION_NAME="Ed-Fi Admin App" \
-VITE_IDP_ACCOUNT_URL=https://your-domain.com/auth/realms/edfi/account/ \
 npm run build:fe
 ```
 
@@ -173,14 +176,16 @@ npm run build:fe
 1. **Create database and user**:
 
    ```sql
-   -- Connect as postgres superuser
+   -- Connect as the postgres superuser
    CREATE DATABASE sbaa;
    CREATE USER edfiadminapp WITH PASSWORD 'your_secure_password';
-   GRANT ALL PRIVILEGES ON DATABASE sbaa TO edfiadminapp;
 
-   -- Connect to sbaa database
+   -- Least privilege: CONNECT + CREATE on the database (so the app can create the
+   -- citext extension and its pgboss job-queue schema at first boot) and ownership
+   -- of the public schema so it can create its own tables. Not database-wide ALL.
+   GRANT CONNECT, CREATE ON DATABASE sbaa TO edfiadminapp;
    \c sbaa
-   GRANT ALL ON SCHEMA public TO edfiadminapp;
+   ALTER SCHEMA public OWNER TO edfiadminapp;
    ```
 
 2. **Configure PostgreSQL** (`postgresql.conf`):
@@ -255,7 +260,7 @@ The Admin App uses OpenID Connect (OIDC) for authentication. Keycloak is the rec
    }
    ```
 
-3. **Create Client for Machine-to-Machine**:
+3. **Create Client for Machine-to-Machine** _(optional — only for direct bearer-token API access, e.g. Postman/curl/CI; the browser login flow does not need it)_:
 
    ```json
    {
@@ -268,7 +273,7 @@ The Admin App uses OpenID Connect (OIDC) for authentication. Keycloak is the rec
    }
    ```
 
-4. **Create Client Scope**:
+4. **Create Client Scope** _(optional — used by the machine-to-machine client above)_:
    - Name: `login:app`
    - Type: Default
    - Protocol: openid-connect
@@ -279,7 +284,7 @@ The Admin App uses OpenID Connect (OIDC) for authentication. Keycloak is the rec
 The OIDC configuration is stored in the application database. Insert configuration:
 
 ```sql
-INSERT INTO oidc_client (issuer, "clientId", "clientSecret", scope) VALUES
+INSERT INTO oidc (issuer, "clientId", "clientSecret", scope) VALUES
 ('https://your-domain.com/auth/realms/edfi', 'edfiadminapp', 'your-client-secret', '');
 ```
 

--- a/docs/reference/5-admin-app/configuration/configuring-admin-app.md
+++ b/docs/reference/5-admin-app/configuration/configuring-admin-app.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Configuring Ed-Fi Admin App
 
-This page describes how to configure the Ed-Fi Admin App after installation, regardless of which installation path you followed ([Docker Compose](../getting-started/docker-installation.md), [Windows IIS](../getting-started/windows-iis-installation.md), or [Unix-like Systems](../getting-started/unix-installation.md)). It covers backend API configuration, frontend build-time configuration, database setup and migrations, and authentication.
+This page describes how to configure the Ed-Fi Admin App after installation, regardless of which installation path you followed ([Docker Compose](../getting-started/docker-installation.md), [Windows IIS](../getting-started/windows-iis-installation/readme.md), or [Unix-like Systems](../getting-started/unix-installation.md)). It covers backend API configuration, frontend build-time configuration, database setup and migrations, and authentication.
 
 ## Backend API Configuration
 

--- a/docs/reference/5-admin-app/configuration/identity-provider.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Configuring an Identity Provider for Ed-Fi Admin App
 
-The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing users accounts. In theory any OIDC-compatible IdP will suffice. The Ed-Fi Alliance development to date has only tested Keycloak. Another development team has used Auth0. Further documentation on alternatives to Keycloak will be provided here when available.
+The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing users accounts. In theory any OIDC-compatible IdP will suffice. The Ed-Fi Alliance development to date has only tested Keycloak.
 
 ## General IdP Guidance and Configuration
 

--- a/docs/reference/5-admin-app/configuration/identity-provider.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider.md
@@ -17,7 +17,7 @@ Key configuration parameters include:
 - **Authority URL**: The base URL of your IdP (e.g., `https://your-keycloak-server/realms/edfi`)
 - **Client ID**: The client identifier registered in your IdP (e.g., `edfiadminapp`)
 - **Client Secret**: The confidential secret associated with the client
-- **Redirect URI**: The callback URL where the IdP sends authentication responses (e.g., `https://your-admin-app-url/api/auth/callback/1`)
+- **Redirect URI**: The callback URL where the IdP sends authentication responses (e.g., `https://your-admin-app-api-url/api/auth/callback/<oidc-id>`, where `<oidc-id>` is the id of the `oidc` table row)
 - **Post Logout Redirect URI**: Where users are redirected after logging out (e.g., `https://your-admin-app-url/api/auth/post-logout`)
 - **Response Type**: Typically set to `code` for authorization code flow
 - **Scope**: The OIDC scopes requested, typically `openid profile email`
@@ -142,9 +142,12 @@ If you need to create the client manually:
      ```text
      https://your-admin-app-url/*
      https://your-admin-app-url/auth/callback
-     https://your-admin-app-url-api-url/api/auth/callback/1
-     https://your-admin-app-url-api-url/api/auth/post-logout
+     https://your-admin-app-api-url/api/auth/callback/<oidc-id>
+     https://your-admin-app-api-url/api/auth/post-logout
      ```
+
+     `<oidc-id>` is the id of the row in the `oidc` database table — resolve it
+     from that table; it is not always `1`.
 
    - **Valid post logout redirect URIs**: `https://your-admin-app-url/*`
    - **Web origins**: `https://your-admin-app-api-url`

--- a/docs/reference/5-admin-app/configuration/identity-provider.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Configuring an Identity Provider for Ed-Fi Admin App
 
-The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing users accounts. In theory any OIDC-compatible IdP will suffice. The Ed-Fi Alliance development to date has only tested Keycloak.
+The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing user accounts. Keycloak is the only fully supported provider in this release; Microsoft Entra ID and Google Workspace have been tested and gain full support in Admin App v4.1. The guidance below uses Keycloak as the example.
 
 ## General IdP Guidance and Configuration
 

--- a/docs/reference/5-admin-app/configuration/security-considerations.md
+++ b/docs/reference/5-admin-app/configuration/security-considerations.md
@@ -24,7 +24,7 @@ Review the following recommendations before running the Ed-Fi Admin App in a pro
 - **Environment variables**: Never commit secrets to source control
 - **Input validation**: All inputs are validated on both client and server
 - **CORS configuration**: Properly configure allowed origins
-- **Security headers**: The Windows/IIS install ships enforcing security headers by default (HSTS, an enforcing Content-Security-Policy, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`) on both sites; if you front the app with a reverse proxy, set equivalent headers there. See the [Windows IIS Installation guide](../getting-started/windows-iis-installation.md#security-headers).
+- **Security headers**: The Windows/IIS install ships enforcing security headers by default (HSTS, an enforcing Content-Security-Policy, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`) on both sites; if you front the app with a reverse proxy, set equivalent headers there. See the [Windows IIS Installation guide](../getting-started/windows-iis-installation/manual.md#security-headers).
 
 ## Authentication Security
 

--- a/docs/reference/5-admin-app/configuration/security-considerations.md
+++ b/docs/reference/5-admin-app/configuration/security-considerations.md
@@ -24,7 +24,7 @@ Review the following recommendations before running the Ed-Fi Admin App in a pro
 - **Environment variables**: Never commit secrets to source control
 - **Input validation**: All inputs are validated on both client and server
 - **CORS configuration**: Properly configure allowed origins
-- **Security headers**: Implement proper security headers via reverse proxy
+- **Security headers**: The Windows/IIS install ships enforcing security headers by default (HSTS, an enforcing Content-Security-Policy, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`) on both sites; if you front the app with a reverse proxy, set equivalent headers there. See the [Windows IIS Installation guide](../getting-started/windows-iis-installation.md#security-headers).
 
 ## Authentication Security
 
@@ -32,3 +32,14 @@ Review the following recommendations before running the Ed-Fi Admin App in a pro
 - **Token validation**: Implement proper JWT validation
 - **Session management**: Configure appropriate session timeouts
 - **Multi-factor authentication**: Enable MFA in your OIDC provider
+
+## Built-in Protections
+
+The Ed-Fi Admin App provides several protections out of the box across all installation paths (with Windows/IIS specifics noted):
+
+- **TLS by default**: Each installation path terminates TLS itself — Docker and Unix through NGiNX, Windows through two IIS sites over HTTPS (the HTTP bindings redirect). On the Windows install, when no certificate is supplied a self-signed one is generated and trusted **only on the install host**; in every path, supply a CA-issued certificate for anything beyond that host.
+- **Encryption at rest**: Stored ODS/API and Admin API secrets are encrypted with a per-install key (`DB_ENCRYPTION_SECRET.KEY`). The Windows scripted install generates this key per install and records it only in an Administrators-only `install-summary.txt`.
+- **Upstream TLS verification**: `SSL_VERIFICATION` is on by default, so the app verifies the TLS certificate of the ODS/API and Admin API it calls. For a self-signed upstream, trust it via `NODE_EXTRA_CA_CERTS` rather than disabling verification.
+- **Rate limiting**: The API rate-limits requests (configurable via `RATE_LIMIT_TTL` / `RATE_LIMIT_LIMIT`).
+- **One-time credential sharing**: Newly created API client secrets can be delivered as one-time, self-destructing links via the optional [Yopass](./yopass-administrators-guide/readme.md) integration instead of being shown inline.
+- **Least-privilege database access**: Deploy with a dedicated non-admin database login (SQL Server: `db_owner` on its own database, not `sa`; PostgreSQL: a non-superuser owning `public` with `CONNECT` + `CREATE`).

--- a/docs/reference/5-admin-app/getting-started/docker-installation.md
+++ b/docs/reference/5-admin-app/getting-started/docker-installation.md
@@ -27,7 +27,7 @@ environment variable configuration.
 The Docker Compose stack supports **both** PostgreSQL and SQL Server — you need only one. **PostgreSQL is the default.** To use SQL Server instead, set `DB_ENGINE=mssql` in `.env`, uncomment the `MSSQL_*` variables there (`MSSQL_SA_PASSWORD`, `MSSQL_ACCEPT_EULA=Y`), and start the stack with the `-MSSQL` switch:
 
 ```powershell
-./start-services.ps1 -MSSQL
+compose/start-services.ps1 -MSSQL
 ```
 
 ## Quick Start

--- a/docs/reference/5-admin-app/getting-started/docker-installation.md
+++ b/docs/reference/5-admin-app/getting-started/docker-installation.md
@@ -22,6 +22,14 @@ environment variable configuration.
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
 - [PowerShell](https://docs.microsoft.com/en-us/powershell/) (Windows)
 
+## Database engine
+
+The Docker Compose stack supports **both** PostgreSQL and SQL Server — you need only one. **PostgreSQL is the default.** To use SQL Server instead, set `DB_ENGINE=mssql` in `.env`, uncomment the `MSSQL_*` variables there (`MSSQL_SA_PASSWORD`, `MSSQL_ACCEPT_EULA=Y`), and start the stack with the `-MSSQL` switch:
+
+```powershell
+./start-services.ps1 -MSSQL
+```
+
 ## Quick Start
 
 1. **Clone the Admin App repository:**

--- a/docs/reference/5-admin-app/getting-started/docker-installation.md
+++ b/docs/reference/5-admin-app/getting-started/docker-installation.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 Docker provides the easiest deployment method with consistent environments across platforms. OCI-compliant containers provide a consistent deployment experience across many platforms, including Docker Desktop, Kubernetes, and other services. The following quick start instructions demonstrate application startup in Docker. They illustrate how to configure the applications, including environment variables, persistent storage, and networking. These notes can also serve as a template for building your own deployment in the container runtime engine of your choice, whether on-premises or in the Cloud.
 
 :::note
-This is one of three alternative installation paths. If you instead want to host the Admin App on Windows IIS or on a Unix-like server, see [Windows IIS Installation](./windows-iis-installation.md) or [Unix-like Systems Installation](./unix-installation.md).
+This is one of three alternative installation paths. If you instead want to host the Admin App on Windows IIS or on a Unix-like server, see [Windows IIS Installation](./windows-iis-installation/readme.md) or [Unix-like Systems Installation](./unix-installation.md).
 :::
 
 ## Docker Installation Guide for Ed-Fi Admin App

--- a/docs/reference/5-admin-app/getting-started/docker-installation.md
+++ b/docs/reference/5-admin-app/getting-started/docker-installation.md
@@ -130,8 +130,8 @@ VITE_API_URL=https://yourdomain.com/adminapp-api
 FE_URL=https://yourdomain.com/adminapp
 MY_URL=https://yourdomain.com/adminapp-api
 
-# This line is only necessary when you are using a self-signed certificate.
-NODE_EXTRA_CA_CERTS=/app/ssl/your-production-cert.crt
+# Only needed when the app must trust a self-signed/private-CA certificate.
+NODE_EXTRA_CA_CERTS=/app/ssl/your-cert.crt
 
 # Administrator credentials
 KEYCLOAK_ADMIN=admin

--- a/docs/reference/5-admin-app/getting-started/docker-installation.md
+++ b/docs/reference/5-admin-app/getting-started/docker-installation.md
@@ -143,6 +143,10 @@ VITE_APPLICATION_NAME="Ed-Fi Admin App"
 VITE_IDP_ACCOUNT_URL=https://yourdomain.com/auth/realms/edfi/account/
 ```
 
+:::warning
+Some special characters are not currently supported in the database password (for example `POSTGRES_PASSWORD`, or `MSSQL_SA_PASSWORD` when using SQL Server). Use only letters, digits, and these symbols: `! $ ( ) * , - . _ ~`. A password that includes other characters (for example `@ : / ? # % & = ;`, `"`, `< >`, `|`, or a space) can stop the API from connecting to the database at startup.
+:::
+
 :::note
 **Important:** The `VITE_IDP_ACCOUNT_URL` value may differ from your Keycloak admin console URL.
 This should point to the **account management interface** (`/auth/realms/{realm-name}/account/`), not the admin console.

--- a/docs/reference/5-admin-app/getting-started/readme.md
+++ b/docs/reference/5-admin-app/getting-started/readme.md
@@ -25,11 +25,9 @@ deployments. It consists of:
   for the Admin App (the examples use the name `sbaa`)
 - **OIDC Provider** (Required) - Keycloak or similar see
   - [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
-- **Reverse Proxy** (Recommended) - NGiNX, IIS, or similar
-  - Provides SSL/TLS termination and security headers
-  - Efficient static file serving and caching
-  - Single entry point for frontend and API (eliminates CORS issues)
-  - Better performance, security, and scalability for production deployments
+- **Reverse Proxy** (Recommended for production) - NGiNX, IIS, or similar
+  - Provides a single public entry point for the frontend and API — this avoids cross-origin/CORS between the two sites — plus caching, load balancing, and a place to enforce edge security (e.g. a WAF).
+  - Not required to obtain HTTPS: each installation path terminates TLS itself. The Windows install scripts deploy the API and frontend as two IIS sites directly (no front-facing proxy) with TLS and enforcing security headers, and the app is architecturally optional behind a proxy (v4.0 PRD), honoring `X-Forwarded-*` headers when used.
 
 :::tip
 
@@ -67,18 +65,18 @@ The Ed-Fi Admin App can be installed in one of three **alternative** ways. These
 are independent paths, not sequential steps — pick the one that matches your
 target environment and follow that page from start to finish.
 
-| Path | When to use |
+| Path | What it does |
 | --- | --- |
-| [Docker Compose Installation](./docker-installation.md) | The easiest path. Run the Admin App and its dependencies as containers, on-premises or in the Cloud. |
-| [Windows IIS Installation](./windows-iis-installation.md) | Host the backend API and frontend on Windows Server using Internet Information Services (IIS). |
-| [Unix-like Systems Installation](./unix-installation.md) | Host the backend API with systemd and serve the frontend with NGiNX on a Linux or other Unix-like server. |
+| [Docker Compose Installation](./docker-installation.md) | Runs the Admin App and its dependencies as containers, on-premises or in the Cloud. |
+| [Windows IIS Installation](./windows-iis-installation.md) | Hosts the backend API and frontend on Windows Server using Internet Information Services (IIS). |
+| [Unix-like Systems Installation](./unix-installation.md) | Hosts the backend API with systemd and serves the frontend with NGiNX on a Linux or other Unix-like server. |
 
 :::note
-You only need to complete **one** of the paths above. After installing,
-configure the application using the
-[Configuring Ed-Fi Admin App](../configuration/configuring-admin-app.md) page and review the
-[Security Considerations](../configuration/security-considerations.md) before going to
-production.
+You only need to complete **one** of the paths above — each one installs and
+configures the Admin App. The [Configuring Ed-Fi Admin App](../configuration/configuring-admin-app.md)
+page is a reference for the available configuration options, and it is worth
+reviewing [Security Considerations](../configuration/security-considerations.md)
+before going to production.
 :::
 
 ## Next steps

--- a/docs/reference/5-admin-app/getting-started/readme.md
+++ b/docs/reference/5-admin-app/getting-started/readme.md
@@ -68,7 +68,7 @@ target environment and follow that page from start to finish.
 | Path | What it does |
 | --- | --- |
 | [Docker Compose Installation](./docker-installation.md) | Runs the Admin App and its dependencies as containers, on-premises or in the Cloud. |
-| [Windows IIS Installation](./windows-iis-installation.md) | Hosts the backend API and frontend on Windows Server using Internet Information Services (IIS). |
+| [Windows IIS Installation](./windows-iis-installation/readme.md) | Hosts the backend API and frontend on Windows Server using Internet Information Services (IIS). |
 | [Unix-like Systems Installation](./unix-installation.md) | Hosts the backend API with systemd and serves the frontend with NGiNX on a Linux or other Unix-like server. |
 
 :::note

--- a/docs/reference/5-admin-app/getting-started/readme.md
+++ b/docs/reference/5-admin-app/getting-started/readme.md
@@ -31,11 +31,9 @@ deployments. It consists of:
 
 :::tip
 
-This application _should_ be capable of running with any Open ID Connect
-provider, not just Keycloak. At this time the Ed-Fi Alliance has not yet tested
-it with other providers. The product development team intends to test and
-document the experience working with other systems, beginning first with
-Microsoft Entra ID.
+This application runs with any Open ID Connect provider. Keycloak is the only
+fully supported provider in this release; Microsoft Entra ID and Google Workspace
+have been tested and gain full support in Admin App v4.1.
 
 :::
 

--- a/docs/reference/5-admin-app/getting-started/readme.md
+++ b/docs/reference/5-admin-app/getting-started/readme.md
@@ -14,7 +14,7 @@ installing the Admin App.
 The Ed-Fi Admin App is a user interface for managing Ed-Fi Technology Suite
 deployments. It consists of:
 
-- **Frontend**: React-based single-page application (SPA)
+- **Web Application**: React-based single-page application (SPA)
 - **Backend API**: Node.js/NestJS application
 - **Database**: PostgreSQL or SQL Server database for application data
 - **Authentication**: OpenID Connect (OIDC) integration (typically Keycloak)
@@ -25,9 +25,9 @@ deployments. It consists of:
   for the Admin App (the examples use the name `sbaa`)
 - **OIDC Provider** (Required) - Keycloak or similar see
   - [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
-- **Reverse Proxy** (Recommended for production) - NGiNX, IIS, or similar
-  - Provides a single public entry point for the frontend and API — this avoids cross-origin/CORS between the two sites — plus caching, load balancing, and a place to enforce edge security (e.g. a WAF).
-  - Not required to obtain HTTPS: each installation path terminates TLS itself. The Windows install scripts deploy the API and frontend as two IIS sites directly (no front-facing proxy) with TLS and enforcing security headers, and the app is architecturally optional behind a proxy (v4.0 PRD), honoring `X-Forwarded-*` headers when used.
+- **Reverse Proxy** (Recommended for production) - Nginx, IIS, or similar
+  - Provides a single public entry point for the Web Application and API (this avoids cross-origin/CORS between the two sites), plus caching, load balancing, and a place to enforce edge security (for example, a web application firewall).
+  - Not required to obtain HTTPS: each installation path terminates TLS itself. The Windows install scripts deploy the API and Web Application as two IIS sites directly (no front-facing proxy) with TLS and enforcing security headers, and the app is architecturally optional behind a proxy by design, honoring `X-Forwarded-*` headers when used.
 
 :::tip
 
@@ -68,8 +68,8 @@ target environment and follow that page from start to finish.
 | Path | What it does |
 | --- | --- |
 | [Docker Compose Installation](./docker-installation.md) | Runs the Admin App and its dependencies as containers, on-premises or in the Cloud. |
-| [Windows IIS Installation](./windows-iis-installation/readme.md) | Hosts the backend API and frontend on Windows Server using Internet Information Services (IIS). |
-| [Unix-like Systems Installation](./unix-installation.md) | Hosts the backend API with systemd and serves the frontend with NGiNX on a Linux or other Unix-like server. |
+| [Windows IIS Installation](./windows-iis-installation/readme.md) | Hosts the backend API and Web Application on Windows Server using Internet Information Services (IIS). |
+| [Unix-like Systems Installation](./unix-installation.md) | Hosts the backend API with systemd and serves the Web Application with Nginx on a Linux or other Unix-like server. |
 
 :::note
 You only need to complete **one** of the paths above — each one installs and

--- a/docs/reference/5-admin-app/getting-started/unix-installation.md
+++ b/docs/reference/5-admin-app/getting-started/unix-installation.md
@@ -17,6 +17,10 @@ This is one of three alternative installation paths. If you instead want to run 
 - **PostgreSQL**: Database server
 - **systemd**: For service management (most modern Linux distributions)
 
+:::note
+This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQL Server is not documented or validated for the Unix path; for SQL Server, use the [Docker Compose](./docker-installation.md) or [Windows IIS](./windows-iis-installation.md) path.
+:::
+
 ## Unix Backend API Installation
 
 1. **Create application user**:

--- a/docs/reference/5-admin-app/getting-started/unix-installation.md
+++ b/docs/reference/5-admin-app/getting-started/unix-installation.md
@@ -77,7 +77,7 @@ This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQ
      //this should match with a user in your Idp
      ADMIN_USERNAME: 'admin@example.com',
      DB_ENCRYPTION_SECRET_VALUE: {
-       KEY: 'your-32-char-encryption-key-here'
+       KEY: 'your-64-hex-char-encryption-key' // 32-byte key, hex-encoded (64 hex chars); see tip below
      },
      FE_URL: 'https://your-domain.com/adminapp',
      MY_URL: 'https://your-domain.com/adminapp-api',
@@ -87,7 +87,7 @@ This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQ
    ```
 
    :::tip
-   `your-32-char-encryption-key-here` Can be replaced with `openssl rand -hex 32` or `node -e "console.log('KEY: '+ require('crypto').randomBytes(32).toString('hex'))"`
+   `your-64-hex-char-encryption-key` can be generated with `openssl rand -hex 32` or `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
    :::
 
 4. **Create systemd service**:

--- a/docs/reference/5-admin-app/getting-started/unix-installation.md
+++ b/docs/reference/5-admin-app/getting-started/unix-installation.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 This page describes how to install the Ed-Fi Admin App on a Unix-like server (for example, Linux), using systemd to run the backend API and NGiNX to serve the frontend and proxy the API.
 
 :::note
-This is one of three alternative installation paths. If you instead want to run the Admin App in containers or on Windows IIS, see [Docker Compose Installation](./docker-installation.md) or [Windows IIS Installation](./windows-iis-installation.md).
+This is one of three alternative installation paths. If you instead want to run the Admin App in containers or on Windows IIS, see [Docker Compose Installation](./docker-installation.md) or [Windows IIS Installation](./windows-iis-installation/readme.md).
 :::
 
 ## Unix Prerequisites
@@ -18,7 +18,7 @@ This is one of three alternative installation paths. If you instead want to run 
 - **systemd**: For service management (most modern Linux distributions)
 
 :::note
-This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQL Server is not documented or validated for the Unix path; for SQL Server, use the [Docker Compose](./docker-installation.md) or [Windows IIS](./windows-iis-installation.md) path.
+This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQL Server is not documented or validated for the Unix path; for SQL Server, use the [Docker Compose](./docker-installation.md) or [Windows IIS](./windows-iis-installation/readme.md) path.
 :::
 
 ## Unix Backend API Installation

--- a/docs/reference/5-admin-app/getting-started/unix-installation.md
+++ b/docs/reference/5-admin-app/getting-started/unix-installation.md
@@ -86,6 +86,10 @@ This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQ
    EOF
    ```
 
+   :::warning
+   Some special characters are not currently supported in the Admin App database username or password (`DB_USERNAME` / `DB_PASSWORD`). Use only letters, digits, and these symbols: `! $ ( ) * , - . _ ~`. A value that includes other characters (for example `@ : / ? # % & = ;`, `"`, `< >`, `|`, or a space) can stop the API from connecting to the database at startup.
+   :::
+
    :::tip
    `your-64-hex-char-encryption-key` can be generated with `openssl rand -hex 32` or `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
    :::

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation.md
@@ -4,46 +4,227 @@ sidebar_position: 3
 
 # Windows IIS Installation
 
-This page describes how to install the Ed-Fi Admin App on Windows using Internet Information Services (IIS). It covers the backend API and the frontend single-page application.
+This page describes how to install the Ed-Fi Admin App on Windows using Internet Information Services (IIS). It covers the backend API and the frontend single-page application, deployed as two standalone IIS sites over HTTPS.
 
 :::note
 This is one of three alternative installation paths. If you instead want to run the Admin App in containers or on a Unix-like server, see [Docker Compose Installation](./docker-installation.md) or [Unix-like Systems Installation](./unix-installation.md).
 :::
 
+Every section can be completed **manually** or with an **optional PowerShell script** that automates it. The scripts ship in the [Admin App Installation Scripts repository](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts) under `windows-install/`. You can mix the two: automate some sections, do others by hand.
+
+## Before you start: decide three things
+
+1. **Database engine** — SQL Server (default) or PostgreSQL. You need only one.
+2. **Identity provider (IdP)** — the Admin App authenticates against an OIDC provider. This guide sets up **Keycloak**, running locally, as the example identity provider (a setup script provisions it). The Admin App's auth engine uses generic OIDC discovery, but Keycloak is the identity provider documented for this release.
+3. **Manual or automated** — follow the manual steps in each section, or run the script that automates it.
+
+:::info
+Both IIS sites are served over **HTTPS by default** — API on port **3443** and frontend on port **4443**. Each also keeps an HTTP binding (**3333** / **4200**) that returns a 301 redirect to its HTTPS URL. When no certificate is supplied, a self-signed certificate is generated and trusted on the local machine; supply a real certificate for anything beyond this host (see [TLS and certificates](#tls-and-certificates)). **IIS 10 or newer is required.**
+:::
+
+## Fast path: automation scripts
+
+To automate, clone the [Admin App Installation Scripts repository](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts) and run the scripts in `windows-install/` from an elevated PowerShell, in the order below. Each script maps to a manual section later on this page; any script can be skipped in favor of its manual steps.
+
+```powershell
+git clone https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts.git
+cd Admin-App-Installation-Scripts\windows-install
+```
+
+:::note
+On a bare machine without Git, download the repository as a ZIP from GitHub (**Code → Download ZIP**) and extract it — `setup-vm-prereqs.ps1` installs Git afterward. If PowerShell refuses to run the scripts (they carry the internet Mark of the Web), `setup-vm-prereqs.ps1` unblocks them and sets the execution policy; to do it by hand, run `Get-ChildItem *.ps1 | Unblock-File` and `Set-ExecutionPolicy -Scope Process Bypass`.
+:::
+
+| Order | Script | What it automates | Manual section |
+| --- | --- | --- | --- |
+| 0 (fresh VM) | `setup-vm-prereqs.ps1` | OS-level installs: IIS feature set, SQL Server Developer, Git. Scans first, installs only what is missing; also sets the execution policy and unblocks the scripts. | [Windows Prerequisites](#windows-prerequisites) |
+| 1 | `01-prereqs-iis.ps1` | URL Rewrite Module + the httpPlatform handler (HttpBridge by default, or Microsoft HttpPlatformHandler); unlocks the `handlers` configuration section. | [Windows Prerequisites](#windows-prerequisites) |
+| 2 | `02-prereqs-sql.ps1` | SQL Server Mixed Mode + TCP/IP + `sa`; creates the `sbaa` database and a dedicated least-privilege login (`edfi_adminapp`) the app connects as. | [Windows Prerequisites](#windows-prerequisites) |
+| 3 | `03-prereqs-node.ps1` | Installs Node.js (the major version pinned in `engines.node`); remediates a too-old Node via nvm-windows. | [Windows Prerequisites](#windows-prerequisites) |
+| 4 | `04-build.ps1` | `npm ci` + build API + build frontend. Seeds the frontend `.env` before building. | [Backend API](#backend-api-installation) / [Frontend](#frontend-installation) |
+| 5 | `05-deploy-api.ps1` | Deploys the API as standalone site `EdFi-AdminApp-API` (HTTPS :3443; HTTP :3333 redirects): web.config, App Pool, `production.js`, App-Pool-scoped npm cache. | [Backend API](#backend-api-installation) |
+| 6 | `06-deploy-fe.ps1` | Deploys the frontend as standalone site `EdFi-AdminApp-FE` (HTTPS :4443; HTTP :4200 redirects). | [Frontend](#frontend-installation) |
+| verify | `00-check-prereqs.ps1` | Read-only diagnostic: IIS (and version), database, Node, build artifacts, and whether ports 3333/4200/3443/4443 are free. | [Verify prerequisites](#verify-prerequisites) |
+| optional | `idp-keycloak-setup.ps1` | Installs a JDK, downloads and starts a local Keycloak, provisions realm `edfi`, client `edfiadminapp`, and a test user. | [Identity provider](#identity-provider) |
+| optional | `idp-keycloak-start.ps1` | Restarts the local Keycloak (e.g. after a reboot). | [Identity provider](#identity-provider) |
+| optional | `yopass-docker.ps1` | Stands up a local Yopass via Docker. | [Yopass](#yopass-optional) |
+| optional | `install-all.ps1` | Runs the whole sequence end to end, including the local Keycloak IdP setup. | (whole page) |
+
+To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and unsets `JAVA_HOME`; leaves the JDK installed).
+
+## Run everything at once
+
+To install the whole stack in one command, `install-all.ps1` runs the entire sequence end to end: the pre-flight check, all prerequisites, the build, the identity-provider setup, both deployments, and a smoke test. This is the fastest path; the manual sections below are for installing a piece by hand or understanding what each step does.
+
+On a fresh machine, run `setup-vm-prereqs.ps1` first (it installs the OS-level pieces: IIS, SQL Server, Git), then `install-all.ps1`. Run both from an elevated PowerShell in the `windows-install` folder. Choose the identity provider with the mandatory `-IdpProvider` parameter; this guide uses `keycloak`.
+
+`install-all.ps1` fetches the Admin App source for you — by default it clones the latest stable release of `Ed-Fi-AdminApp` as a sibling folder (for example `C:\Ed-Fi\Ed-Fi-AdminApp`). To build from a checkout you already have, pass `-SourcePath`; to pin a specific version, pass `-AdminAppRef <tag>` (for example `-AdminAppRef v4.0.1`).
+
+Local Keycloak example (SQL Server):
+
+```powershell
+.\install-all.ps1 -IdpProvider keycloak `
+  -SaPassword (Read-Host -AsSecureString 'SQL Server sa password') `
+  -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
+  -KeycloakAdminPassword (Read-Host -AsSecureString 'Keycloak admin password') `
+  -OidcClientSecret (Read-Host -AsSecureString 'OIDC client secret') `
+  -TestUserPassword (Read-Host -AsSecureString 'Keycloak test-user password')
+```
+
+The password parameters are `SecureString`s, so pass them with `Read-Host -AsSecureString` (as above) rather than plain quoted strings. `-AppDbPassword` sets the password for the least-privilege `edfi_adminapp` login the script creates; it is required for SQL Server. This stands up the local Keycloak (realm `edfi`, client `edfiadminapp`, and a test user) and deploys the API and frontend as part of the run.
+
+:::note
+By default the sites use a self-signed certificate (auto-trusted on this machine only). To bind a real certificate, pass `-CertificateThumbprint`, or `-CertificatePfxPath` with `-CertificatePassword` (see [TLS and certificates](#tls-and-certificates)). Yopass is off by default; add `-SetupYopassDocker` to stand up a local Yopass via Docker, or `-YopassUrl <url>` to point at an existing one.
+:::
+
+The script is idempotent: if a step fails, fix the cause and re-run. `-SkipPhase1` (skip prerequisites) and `-SkipPhase2` (skip build) speed up re-runs.
+
 ## Windows Prerequisites
 
-- **IIS with URL Rewrite Module**: Install from [Microsoft](https://www.iis.net/downloads/microsoft/url-rewrite)
-- **Node.js**: Download from [nodejs.org](https://nodejs.org/)
-- **PostgreSQL** or **SqlServer**: Install and configure database server
-  - Create an empty database, our example will use the name `sbaa`
-- **IISNode**: For running Node.js applications in IIS
-- **An Identity Provider (IdP)**: For more details see [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
-- **Yopass**: We recommend to use this in order to share secrets correctly. For more details see [Yopass Administrator Guide](../configuration/yopass-administrators-guide/readme.md)
+:::tip Automation shortcut
+On a fresh VM, `setup-vm-prereqs.ps1` installs the operating-system pieces (the IIS feature set, SQL Server, Git). Then automate the rest with `01-prereqs-iis.ps1`, `02-prereqs-sql.ps1`, and `03-prereqs-node.ps1`, plus the identity provider below. Or follow the manual steps in each subsection. **IIS 10 or newer is required.**
+:::
+
+### Operating system components (IIS, SQL Server, Git)
+
+_Automated by `setup-vm-prereqs.ps1` (scans first, installs only what is missing)._
+
+- **IIS**: Enable the IIS web server role and management tools. From an elevated PowerShell:
+
+  ```powershell
+  Enable-WindowsOptionalFeature -Online -All -FeatureName `
+    IIS-WebServerRole, IIS-WebServer, IIS-WebServerManagementTools, `
+    IIS-ManagementConsole, IIS-RequestFiltering, IIS-StaticContent, `
+    IIS-DefaultDocument, IIS-HttpErrors, IIS-HttpRedirect
+  ```
+
+- **SQL Server**: Install SQL Server (the Developer or Express edition is fine for local use). See [Microsoft SQL Server downloads](https://www.microsoft.com/sql-server/sql-server-downloads).
+- **Git**: Optional, used to clone the Admin App repository. See [git-scm.com](https://git-scm.com/).
+
+### IIS modules and configuration (URL Rewrite + httpPlatform handler) {#iis-modules}
+
+_Automated by `01-prereqs-iis.ps1` (assumes the IIS role above is already installed)._
+
+IIS hosts the Node.js API through the **httpPlatform handler**: IIS acts as a reverse proxy, launching the Node process (`main.js`) and forwarding requests to a loopback port it assigns via the `HTTP_PLATFORM_PORT` environment variable.
+
+1. Install the [IIS URL Rewrite Module](https://www.iis.net/downloads/microsoft/url-rewrite). It is used for the HTTP→HTTPS redirect and the frontend's SPA fallback.
+2. Install an httpPlatform handler. Two are compatible, and both register the same `httpPlatformHandler` module name:
+   - **HttpBridge** — the [LeXtudio fork](https://github.com/lextudio/httpbridge) (MIT, actively maintained). This is the scripts' default.
+   - **Microsoft HttpPlatformHandler** — the [original v1.2](https://www.iis.net/downloads/microsoft/httpplatformhandler) (signed, stable, frozen since ~2016).
+3. **Unlock the handlers configuration section** so the application's `web.config` can register the handler. From an elevated PowerShell:
+
+   ```powershell
+   & "$env:SystemRoot\System32\inetsrv\appcmd.exe" unlock config -section:system.webServer/handlers
+   ```
+
+:::warning
+Without unlocking the `handlers` section, requests to the API return **HTTP 500.19**. Unlocking it lets the `httpPlatformHandler` handler ship in the deployed `web.config`.
+:::
+
+### Database
+
+_Automated by `02-prereqs-sql.ps1` (SQL Server path)._
+
+The Admin App supports PostgreSQL 16+ and SQL Server 2017+, and needs only one. This guide uses **SQL Server** by default on Windows; PostgreSQL is available via Docker (`install-all.ps1 -DbEngine pgsql`; requires Docker Desktop in Linux-container mode).
+
+For SQL Server:
+
+1. Enable **Mixed Mode (SQL Server and Windows) authentication** (the Node `mssql` driver connects with SQL authentication).
+2. Enable the **TCP/IP** protocol and confirm it listens on port **1433** (the driver requires TCP).
+3. Enable the **`sa`** login and set a password. `sa` is used **only for setup** (enabling Mixed Mode and creating the database and app login); the Admin App itself does not connect as `sa`.
+4. Create an empty database. This guide uses the name **`sbaa`**.
+5. Create a dedicated least-privilege login for the Admin App to connect as. It is `db_owner` on the Admin App database **only** and holds no server-level role (it is not a sysadmin like `sa`). `db_owner` — rather than just `db_datareader`/`db_datawriter` — is required because the app creates and migrates its own schema on startup.
+
+   ```sql
+   CREATE LOGIN [edfi_adminapp] WITH PASSWORD = N'YourStrong!AppPassw0rd', CHECK_POLICY = ON;
+   USE [sbaa];
+   CREATE USER [edfi_adminapp] FOR LOGIN [edfi_adminapp];
+   ALTER ROLE db_owner ADD MEMBER [edfi_adminapp];
+   ```
+
+   This login and its password become `MSSQL_DB_USERNAME` / `MSSQL_DB_PASSWORD` in `production.js`. `CHECK_POLICY = ON` enforces the Windows password policy, so use a strong password (length ≥ 8 and at least 3 of: uppercase, lowercase, digit, symbol).
+
+:::note
+Installing the Admin App database in its own SQL Server instance, separate from the ODS/API databases (`EdFi_Admin`, `EdFi_Security`), is recommended.
+:::
+
+For PostgreSQL, see [Configuring the Admin App](../configuration/configuring-admin-app.md); the automated PostgreSQL path runs through `install-all.ps1 -DbEngine pgsql`.
+
+### Node.js
+
+_Automated by `03-prereqs-node.ps1` (upgrades a too-old version via nvm-windows)._
+
+Install the Node.js major version pinned in the Admin App's `package.json` (`engines.node`, currently `>=22`) from [nodejs.org](https://nodejs.org/). `03-prereqs-node.ps1` reads `engines.node` at runtime and remediates a too-old Node via nvm-windows.
+
+### Identity provider
+
+_Automated by `idp-keycloak-setup.ps1`._
+
+This guide uses **Keycloak**, running locally, as the example OIDC identity provider. `idp-keycloak-setup.ps1` installs a JDK, downloads and starts Keycloak, and provisions the `edfi` realm, the `edfiadminapp` confidential client, and a test user. To do it manually: install a supported LTS JDK — Keycloak 26 supports OpenJDK 17, 21, or 25 (the setup script installs OpenJDK 21) — download and start [Keycloak](https://www.keycloak.org/), then create the realm, a confidential client, and a user.
+
+:::note
+Register these in the Keycloak client (HTTPS, matching the default ports):
+
+- Redirect URI: `https://localhost:3443/api/auth/callback/<oidc-id>`
+- Post-logout redirect URI: `https://localhost:3443/api/auth/post-logout`
+- Web origin: `https://localhost:4443`
+
+`<oidc-id>` is the id of the row in the `oidc` database table; `install-all.ps1` resolves it and prints the exact callback URI to register (it is not always `1`). A user must exist in Keycloak whose email/username claim matches the Admin App admin user (`-AdminUsername`, default `admin@example.com`). Java is required **only** for the local Keycloak example.
+:::
+
+For more detail, see [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md).
+
+### Yopass (optional)
+
+_Automated by `yopass-docker.ps1`._
+
+Yopass lets the Admin App share newly created API client credentials as one-time, self-destructing links instead of showing them inline. Stand up a local Yopass via Docker, point the app at an existing Yopass, or leave it disabled (credentials are then shown inline, a supported configuration). See the [Yopass Administrator Guide](../configuration/yopass-administrators-guide/readme.md).
+
+### TLS and certificates
+
+_Automated by the deploy scripts: `05-deploy-api.ps1` / `06-deploy-fe.ps1` bind the certificate (a supplied `-CertificateThumbprint` / `-CertificatePfxPath`, or a generated self-signed one); `install-all.ps1` forwards the same parameters._
+
+Both IIS sites are served over HTTPS (API `:3443`, frontend `:4443`). Each also keeps an HTTP binding (`:3333` / `:4200`) that returns a 301 redirect to its HTTPS URL. The certificate is resolved in this order:
+
+1. **`-CertificateThumbprint`** — bind an existing certificate already in `LocalMachine\My`.
+2. **`-CertificatePfxPath`** + **`-CertificatePassword`** — import and bind a PFX you supply.
+3. **None supplied** — a **self-signed** certificate (CN/SAN `localhost` plus the machine name) is generated, bound, and added to `LocalMachine\Root` so local browsers trust it. Opt out of the trust step with `-SkipSelfSignedTrust`.
+
+:::warning
+A self-signed certificate is auto-trusted **only on this machine**; other machines browsing to it still see a trust warning. Supply a real certificate (thumbprint or PFX) for anything beyond this host.
+:::
+
+To configure TLS manually, generate or obtain a certificate and place it in `LocalMachine\My`. For a self-signed certificate (local use), from an elevated PowerShell:
+
+```powershell
+New-SelfSignedCertificate -DnsName 'localhost', $env:COMPUTERNAME `
+  -CertStoreLocation Cert:\LocalMachine\My -FriendlyName 'Ed-Fi Admin App'
+```
+
+Then add an HTTPS binding to each IIS site (in IIS Manager, or with `New-WebBinding` + `New-Item IIS:\SslBindings`), selecting that certificate.
+
+### Verify prerequisites
+
+Run the read-only diagnostic before continuing:
+
+```powershell
+.\00-check-prereqs.ps1
+```
+
+It reports IIS (and that it is version 10 or newer), the database, Node.js, build artifacts, and whether ports 3333, 4200, 3443, and 4443 are free. It does not check the identity provider.
 
 ## Backend API Installation
 
-You can deploy the Node.js backend directly to IIS using only iisnode. This approach is simpler but requires a slightly different configuration.
+:::tip Automation shortcut
+The build (step 1) is automated by `04-build.ps1`; the deploy (steps 2-8) by `05-deploy-api.ps1`. Or follow the manual steps.
+:::
 
-### Prerequisites for Direct IIS Deployment
+The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP binding on port 3333 and an HTTPS binding on port 3443; the HTTP binding only 301-redirects to HTTPS. IIS hosts the Node.js process through the **httpPlatform handler** (reverse proxy), which comes from [IIS modules and configuration](#iis-modules).
 
-- **IIS with iisnode**: Install iisnode from [GitHub Releases](https://github.com/Azure/iisnode/releases)
-- **PostgreSQL** or **SqlServer**: Install and configure database server
-  - Create an empty database, our example will use the name `sbaa`
-- **Node.js**: Install Node.js on the server
-- **An Identity Provider (IdP)**: We use Keycloak. For more details see [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
-- **Yopass**: We recommend to use this in order to share secrets correctly. For more details see [Yopass Administrator Guide](../configuration/yopass-administrators-guide/readme.md)
-
-### Steps for Direct Deployment
-
-1. **Install iisnode only**:
-   - Download the latest iisnode installer from GitHub
-   - Run the installer to integrate iisnode with IIS
-
-2. **Build the application**:
+1. **Build the application**:
 
    :::note
-   Always install from a **stable release tag**, not the default `main` branch (which reflects active development).
-   Visit the [Releases page](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-AdminApp/releases) to find the latest stable release tag, then use it in the command below.
+   Always install from a **stable release tag**, not the default `main` branch (which reflects active development). Use the **latest stable release tag** — the same release the automated `install-all.ps1` path resolves for you. Find it on the [Releases page](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-AdminApp/releases), then use it below.
    :::
 
    ```powershell
@@ -52,285 +233,243 @@ You can deploy the Node.js backend directly to IIS using only iisnode. This appr
 
    git clone --branch $TAG --depth 1 https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-AdminApp.git
    cd Ed-Fi-AdminApp
-   npm ci
+   npm ci --legacy-peer-deps
    npm run build:api
    ```
 
-3. **Create a folder for the website**:
+2. **Create a folder for the website and copy three pieces into it**:
 
-   We recommend creating a new folder for your app. Typically IIS uses the path `C:\inetpub` for this purpose so create a folder called `C:\inetpub\EdFi-AdminApp-API` and move the following files into it:
-   - `main.js` file and `assets` folder located in folder `dist/packages/api/`
-   - `node_modules` folder located in source code after running the `npm ci` command
-   - Create a folder `packages/api/config` and copy the file `default.js` located in folder `packages/api/config` from your source to the new folder
+   Create a dedicated folder for the API, for example `C:\inetpub\EdFi-AdminApp-API` (a standalone directory, not nested under another site's root), and copy in:
+   - The `main.js` file and `assets` folder from `dist/packages/api/` (the build output).
+   - The `packages/api/config` folder from the source. It contains `production.js-edfi`, the configuration template you will base `production.js` on in step 6.
+   - The `node_modules` folder from the repository root (after `npm ci --legacy-peer-deps`).
 
-4. **Create IIS Website**:
-   - Open IIS Manager
-   - Right-click on "Sites" and choose "Add Website"
-   - Set **Site name**: `EdFi-AdminApp-API`
-   - Set **Physical path**: Point to your built application directory (eg. `C:\inetpub\EdFi-AdminApp-API`)
-   - Set **Port**: 3333 (or your preferred port)
-   - **Important**: Leave **Host name** blank for localhost testing, or set it only if you have proper DNS setup
+3. **Create the IIS site and its Application Pool**:
 
-5. **Configure web.config for Direct IIS Deployment**:
-   Create a `web.config` file in the **same directory** as your `main.js` file:
+   Create a standalone IIS site (not an application nested under another site):
+   - Open IIS Manager, right-click **Sites**, and choose **Add Website**.
+   - **Site name**: `EdFi-AdminApp-API`
+   - **Physical path**: the folder from step 2 (for example `C:\inetpub\EdFi-AdminApp-API`)
+   - **Binding**: type **http**, port **3333**
+   - Leave **Host name** blank for localhost testing.
+
+   Then, on the site's Application Pool (`EdFi-AdminApp-API`):
+   - Set **.NET CLR version** to **No Managed Code**.
+   - Under **Advanced Settings**, set **Load User Profile** to **True**.
+
+4. **Add the HTTPS binding**:
+
+   Add a second binding to the site: type **https**, port **3443**, and select a certificate. See [TLS and certificates](#tls-and-certificates) for how to obtain one (a self-signed certificate is fine for local use). The HTTP binding on 3333 remains only to redirect to HTTPS.
+
+5. **Configure `web.config`**:
+
+   Create a `web.config` in the same directory as `main.js`. IIS forwards every request to the Node process that the httpPlatform handler launches; the rewrite rule redirects HTTP to HTTPS.
 
    ```xml
    <?xml version="1.0" encoding="utf-8"?>
    <configuration>
      <system.webServer>
-       <!-- URL Rewrite rules - CRITICAL for proper routing -->
        <rewrite>
          <rules>
-           <rule name="NodeJS" stopProcessing="true">
-             <match url=".*"/>
-             <conditions logicalGrouping="MatchAll">
-               <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true"/>
-               <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true"/>
+           <rule name="HTTP to HTTPS redirect" stopProcessing="true">
+             <match url="(.*)" />
+             <conditions>
+               <add input="{HTTPS}" pattern="off" />
+               <add input="{HTTP_HOST}" pattern="^([^:]+)(:\d+)?$" />
              </conditions>
-             <action type="Rewrite" url="main.js"/>
+             <action type="Redirect" url="https://{C:1}:3443/{R:1}" redirectType="Permanent" appendQueryString="true" />
            </rule>
          </rules>
        </rewrite>
-
-       <!-- iisnode configuration -->
-       <iisnode
-         nodeProcessCommandLine="node.exe"
-         watchedFiles="web.config;*.js"
-         loggingEnabled="true"
-         logDirectory="iisnode"
-         debuggingEnabled="true"
-         devErrorsEnabled="true"
-         node_env="production"
-         promoteServerVars="PORT"
-         maxConcurrentRequestsPerProcess="1024"
-         maxNamedPipeConnectionRetry="100"
-         namedPipeConnectionRetryDelay="250"
-         maxNamedPipeConnectionPoolSize="512"
-         maxNamedPipePooledConnectionAge="30000"
-         asyncCompletionThreadCount="0"
-         initialRequestBufferSize="4096"
-         maxRequestBufferSize="65536"
-         uncFileChangesPollingInterval="5000"
-         gracefulShutdownTimeout="60000"
-         recycleSignalEnabled="false"
-         idlePageOutTimePeriod="0"
-         configOverrides="iisnode.yml" />
-
-       <!-- Default document -->
-       <defaultDocument>
-         <files>
-           <clear />
-           <add value="main.js" />
-         </files>
-       </defaultDocument>
-
-       <!-- Error pages for detailed debugging -->
-       <httpErrors errorMode="Detailed"/>
+       <handlers>
+         <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
+       </handlers>
+       <httpPlatform processPath="C:\Program Files\nodejs\node.exe" arguments="main.js" stdoutLogEnabled="true" stdoutLogFile=".\logs\node-stdout.log" startupTimeLimit="60">
+         <environmentVariables>
+           <environmentVariable name="NODE_ENV" value="production" />
+         </environmentVariables>
+       </httpPlatform>
+       <httpProtocol>
+         <customHeaders>
+           <remove name="X-Powered-By" />
+           <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" />
+           <add name="Referrer-Policy" value="no-referrer" />
+           <add name="Content-Security-Policy" value="default-src 'none'; frame-ancestors 'none'; base-uri 'none'" />
+         </customHeaders>
+       </httpProtocol>
+       <httpErrors errorMode="DetailedLocalOnly" />
      </system.webServer>
-
-     <system.web>
-       <compilation debug="true"/>
-     </system.web>
    </configuration>
    ```
 
-   **Key Configuration Notes:**
-   - **URL Rewrite Rules**: Essential for routing API requests (like `/api/*`) to your Node.js application
-   - **Handler Mappings**: Configure these in IIS Manager, not in web.config (due to security restrictions)
-   - **Node.js Path**: Use `node.exe` to let IIS find Node.js in the system PATH
-   - **Environment**: Set `node_env="development"` for easier debugging, change to `"production"` for live deployments
-   - **configOverrides**: This section allow you to have a separated file to override you `iisnode` configuration. [For more info](https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/iisnode.yml). Create a file `iisnode.yml` in the folder root. Eg:
-
-   ```xml
-   loggingEnabled: true
-   debuggingEnabled: true
-   devErrorsEnabled: true
-   node_env: production
-   ```
-
-6. **Configure Handler Mappings in IIS Manager**:
-
-   Since handler configuration in web.config may be restricted by IIS security policies, configure handlers through IIS Manager:
-
-   - Open **IIS Manager** as Administrator
-   - Navigate to your website
-   - Double-click **"Handler Mappings"**
-   - Click **"Add Module Mapping..."**
-   - Configure:
-     - **Request path**: `*`
-     - **Module**: Select `iisnode`
-     - **Executable**: empty
-     - **Name**: `iisnode-all`
-     - Click on `Request restrictions...` button and then **Uncheck** `Invoke handler only if request is mapped to: File or Folder`in the `Mapping` tab. Click `Ok` button to save nad close this window.
-     - Click `Ok` to close and save.
-   - **Move this handler to the top** of the list (above StaticFile handler)
-
-7. **Environment Configuration**:
-   Create `packages/api/config/production.js` with your settings.
-
    :::note
-   You can also use the template located in the source code `Ed-Fi-AdminApp/packages/api/config/production.js-edfi` as an example
+   Key details in this `web.config`:
+
+   - The `httpPlatformHandler` handler is declared here, which works because the `handlers` section was unlocked in [IIS modules and configuration](#iis-modules). If it is still locked, the API returns HTTP 500.19.
+   - `processPath` must point at a **machine-wide** `node.exe` (for example `C:\Program Files\nodejs\node.exe`). The App Pool virtual account cannot execute a Node installed under a user profile (an nvm-windows default), which fails with HTTP 502.5 / Access Denied.
+   - httpPlatform passes the loopback port it assigns to Node in the `HTTP_PLATFORM_PORT` environment variable; the app reads it in step 6 (`API_PORT`).
+   - The security headers are a baseline. The API also sets `X-Content-Type-Options` and `X-Frame-Options` in-app, so they are not repeated here.
    :::
 
+6. **Configure the environment (`production.js`)**:
+
+   Copy `production.js-edfi` to `production.js` in `packages/api/config`, then set the values. The example below is a local SQL Server install with the local Keycloak example identity provider.
+
    ```javascript
-   // This the frontend URL we will create in the 'Frontend Installation' section, in this guide we will use http://localhost:4200, change it in case you will use a different port or host
-   const FE_URL = 'http://localhost:4200';
+   // Frontend URL from the 'Frontend Installation' section (HTTPS).
+   const FE_URL = 'https://localhost:4443';
 
    module.exports = {
-     DB_ENGINE: 'pgsql',// 'pgsql' or 'mssql'
-     DB_TRUST_CERTIFICATE: false, // For MSSQL local development using self-signed certs, set to true
-     DB_TTL_IN_MINUTES: 120, // Time to live for DB sessions in minutes
-     DB_SSL: false, //set true if your database server support SSL
+     DB_ENGINE: 'mssql', // 'mssql' (this guide) or 'pgsql'
+     DB_TRUST_CERTIFICATE: true, // true for a local SQL Server using a self-signed certificate
+     DB_TTL_IN_MINUTES: 120,
+     DB_SSL: false,
      DB_SECRET_VALUE: {
-       // If you are using DB_ENGINE:'pgsql' set the following values
-       DB_USERNAME: 'your_db_user',
-       DB_PASSWORD: 'your_db_password',
-       DB_HOST: 'localhost',
-       DB_PORT: 5432,
-       DB_DATABASE: 'sbaa', //The database must exist in the server
-
-       // If you are using DB_ENGINE:'mssql' set the following values
-       MSSQL_DB_HOST: 'edfiadminapp-mssql',
+       MSSQL_DB_HOST: 'localhost',
        MSSQL_DB_PORT: 1433,
-       MSSQL_DB_USERNAME: 'sa',
-       MSSQL_DB_DATABASE: 'sbaa', //The database must exist in the server
-       MSSQL_DB_PASSWORD: 'YourStrong!Passw0rd',
+       MSSQL_DB_USERNAME: 'edfi_adminapp', // the least-privilege login, not sa
+       MSSQL_DB_DATABASE: 'sbaa', // the database must already exist on the server
+       MSSQL_DB_PASSWORD: 'YourStrong!AppPassw0rd',
      },
      DB_ENCRYPTION_SECRET_VALUE: {
-       // Can replace with `openssl rand -hex 32` or `node -e "console.log('KEY: '+ require('crypto').randomBytes(32).toString('hex'))"`
-       KEY: 'your-32-char-encryption-key'
+       // Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+       KEY: 'your-64-hex-char-encryption-key',
      },
 
-     USE_YOPASS: true, //If true, you must provide the YOPASS_URL
-     YOPASS_URL: 'http://your-yopass-site',
+     // Verify TLS certificates on the API's OUTBOUND calls to the ODS/API, Admin API,
+     // and Yopass. Keep true. If a local ODS/API presents a self-signed certificate,
+     // adding an Environment fails with a certificate error; make Node trust it via
+     // NODE_EXTRA_CA_CERTS rather than turning this off.
+     SSL_VERIFICATION: true,
+
+     // Yopass: set USE_YOPASS true with a YOPASS_URL to share credentials as one-time
+     // links. Leave false to show newly created credentials inline (a supported configuration).
+     USE_YOPASS: false,
+     YOPASS_URL: '',
 
      AUTH0_CONFIG_SECRET_VALUE: {
-       ISSUER: 'https://your-keycloak-server/auth/realms/edfi',
+       ISSUER: 'http://localhost:8080/realms/edfi',
        CLIENT_ID: 'edfiadminapp',
        CLIENT_SECRET: 'your-client-secret',
-       MACHINE_AUDIENCE: 'edfiadminapp-api'
+       MACHINE_AUDIENCE: 'edfiadminapp-api',
      },
 
-     //Identity provider (Idp) information
+     // Identity provider (OIDC). The values below are the local Keycloak example.
      SAMPLE_OIDC_CONFIG: {
-      issuer: 'https://your-keycloak-server/realms/edfi',
-      clientId: 'edfiadminapp',
-      clientSecret: 'your-client-secret',
-      scope: '',
+       issuer: 'http://localhost:8080/realms/edfi',
+       clientId: 'edfiadminapp',
+       clientSecret: 'your-client-secret',
+       scope: 'openid email profile',
      },
-     // If your IdP has enabled PCKE, set to true
      USE_PKCE: true,
-     //this should match with a user in your IdP
-     ADMIN_USERNAME: 'admin@example.com',
+     ADMIN_USERNAME: 'admin@example.com', // must match a user in your IdP
 
      FE_URL: FE_URL,
-     // The site you have create in the '4. Create IIS Website' step
-     MY_URL: 'http://localhost:3333',
-     // The port must be match with the port you have set for the site
-     API_PORT: process.env.PORT || 3333,
+     MY_URL: 'https://localhost:3443', // the API site's HTTPS URL
+     API_PORT: process.env.HTTP_PLATFORM_PORT || 3333, // httpPlatform assigns the port
      WHITELISTED_REDIRECTS: [FE_URL],
-     // The time to live in milliseconds
      RATE_LIMIT_TTL: 60000,
-     // The maximum number of requests within the ttl
      RATE_LIMIT_LIMIT: 10,
    };
    ```
 
-8. **Set IIS Application Pool**:
-   - In IIS Manager, go to Application Pools
-   - Find your application pool (usually named after your site, in our case `EdFi-AdminApp-API`)
-   - Set **.NET CLR version** to "No Managed Code"
-   - Set **Identity** to an account with appropriate permissions
-   - Set **Start Mode** to "AlwaysRunning" for better performance
-
-9. **Create Required Directories**:
-   - Create the iisnode log directory. In our case `C:\inetpub\EdFi-AdminApp-API\iisnode`
-   - Grant full permissions to the IIS App Pool user. In our case `IIS APPPOOL\EdFi-AdminApp-API`
+7. **Create the log directory**:
+   - Create `C:\inetpub\EdFi-AdminApp-API\logs` (httpPlatform writes Node's stdout to `logs\node-stdout.log`).
+   - Grant the App Pool identity (`IIS APPPOOL\EdFi-AdminApp-API`) modify rights over `logs\` and over `packages\`.
 
    :::note
-   Ensure your IIS directory has:
+   The deployed directory should look like this:
 
    ```text
    C:\inetpub\EdFi-AdminApp-API\
-   ├── assets (the built folder)
-   ├── main.js (the built file)
+   ├── assets\              (built API assets)
+   ├── main.js              (built entry point)
    ├── web.config
-   ├── iisnode.yml (optional)
-   ├── node_modules\ (complete folder after running the `npm ci` command in source code)
-   ├── packages\api\config (with your config files production.js and default.js)
-   └── iisnode\ (log directory)
+   ├── node_modules\        (full folder, from npm ci)
+   ├── packages\api\config\ (production.js and the production.js-edfi template)
+   └── logs\                (Node stdout log directory)
    ```
 
    :::
 
-### Critical Success Factors
+8. **Set the App-Pool npm cache (if npm runs under the pool)**:
 
-**URL Rewrite Rules are Essential**: The `<rewrite>` section in web.config is **critical** for proper routing. Without these rules:
+   `05-deploy-api.ps1` sets `NPM_CONFIG_CACHE` on the `EdFi-AdminApp-API` App Pool's environment (an IIS 10+ feature) and grants that identity write access, so npm has a writable cache scoped to the pool. If you configure manually and npm fails to write its cache, set that environment variable on the pool to a writable folder such as `C:\npm-cache`.
 
-- API requests like `/api/*` will return 404 errors
-- IIS will try to serve requests as static files instead of routing them to Node.js
-- The Node.js application won't receive dynamic requests
+### Critical success factors
 
-**Handler Order Matters**: When configuring handlers in IIS Manager, ensure the iisnode handler with path `*` is at the **top** of the handler mappings list, above the StaticFile handler.
+- **`node.exe` must be machine-wide.** The App Pool virtual account cannot execute a Node under a user profile; that fails with HTTP 502.5. Install Node to `C:\Program Files\nodejs`.
+- **The `handlers` section must be unlocked.** The `httpPlatformHandler` handler is declared in `web.config`; if the section is still locked at the server level, the API returns HTTP 500.19. See [IIS modules and configuration](#iis-modules).
+- **`API_PORT` must read `HTTP_PLATFORM_PORT`.** httpPlatform assigns the loopback port at runtime; a hard-coded port makes IIS and Node disagree and the site returns 502.
+- **The HTTPS binding needs a certificate.** Without one bound to port 3443, the site cannot start over HTTPS. See [TLS and certificates](#tls-and-certificates).
 
-See [Troubleshooting](../troubleshooting.md#backend-troubleshooting) section in case you have errors.
+See the [Troubleshooting](../troubleshooting.md#backend-troubleshooting) section if you hit errors.
 
 ## Frontend Installation
 
-1. We will need to build the frontend, to do so go to `packages/fe` folder of your source code, copy or rename the file `.copyme.env.local` to create `.env` and modify the values depending on your environment. This is an example:
+:::tip Automation shortcut
+The `.env` and build (steps 1-2) are automated by `04-build.ps1`; the deploy (steps 3-6) by `06-deploy-fe.ps1`. Or follow the manual steps.
+:::
 
-   ```xml
-   VITE_API_URL=http://localhost:3333
+The frontend is a Vite single-page application, deployed as a second standalone IIS site, `EdFi-AdminApp-FE`, with an HTTP binding on port 4200 and an HTTPS binding on port 4443; the HTTP binding only 301-redirects to HTTPS.
+
+1. **Configure the build-time environment (`.env`)**:
+
+   In `packages/fe`, copy `.copyme.env.local` to `.env` and set the values for your environment:
+
+   ```text
+   VITE_API_URL=https://localhost:3443
    VITE_OIDC_ID=1
    VITE_BASE_PATH="/"
    VITE_HELP_GUIDE=https://docs.ed-fi.org/reference/admin-app
    VITE_STARTING_GUIDE=https://docs.ed-fi.org/reference/admin-app/configuration/global-administration-tasks
    VITE_CONTACT=https://community.ed-fi.org/
    VITE_APPLICATION_NAME="Ed-Fi Admin App"
-   VITE_IDP_ACCOUNT_URL=https://localhost/auth/realms/edfi/account/
+   VITE_IDP_ACCOUNT_URL=http://localhost:8080/realms/edfi/account/
    ```
 
-   **Environment Variable Descriptions:**
-   - `VITE_API_URL`: Backend API endpoint
-   - `VITE_OIDC_ID`: OpenID Connect configuration ID from database
-   - `VITE_HELP_GUIDE`: URL to general help documentation
-   - `VITE_STARTING_GUIDE`: URL to getting started/system administrator guide
-   - `VITE_CONTACT`: URL to community support or contact page
-   - `VITE_APPLICATION_NAME`: Display name shown in the UI (customize for branding)
-   - `VITE_IDP_ACCOUNT_URL`: Identity provider account management page URL
+   **Environment variable descriptions:**
+   - `VITE_API_URL`: Backend API endpoint (the API site's HTTPS URL, `https://localhost:3443`).
+   - `VITE_OIDC_ID`: OpenID Connect configuration ID from the database (the id of the `oidc` row; must match the redirect-URI callback id).
+   - `VITE_BASE_PATH`: URL path the app is served from. Keep it `"/"`: the frontend is served from the root of its own site.
+   - `VITE_HELP_GUIDE`: URL to general help documentation.
+   - `VITE_STARTING_GUIDE`: URL to the getting-started / system administrator guide.
+   - `VITE_CONTACT`: URL to a community support or contact page.
+   - `VITE_APPLICATION_NAME`: Display name shown in the UI.
+   - `VITE_IDP_ACCOUNT_URL`: Identity provider account-management page URL.
 
-   :::note
-   **Important:** The `VITE_IDP_ACCOUNT_URL` value may differ from your Keycloak admin console URL.
-   This should point to the **account management interface** (`/realms/{realm-name}/account/`), not the admin console.
-   Ensure this matches your actual Keycloak realm configuration and domain.
+   :::warning
+   These values are baked into the bundle at build time, so set `.env` **before** building (step 2); changing it afterward has no effect. For the local Keycloak example, `VITE_IDP_ACCOUNT_URL` is the account-management interface (`/realms/{realm-name}/account/`), not the admin console.
    :::
 
 2. **Build the frontend**:
 
    ```powershell
-   # Go to the cloned folder
+   # From the cloned repository
    cd Ed-Fi-AdminApp
-   # Build the frontend
    npm run build:fe
    ```
 
-3. **Create a folder for the website**:
+3. **Create the website folder**:
 
-   We recommend creating a new folder for your app. Typically IIS uses the path `C:\inetpub` for this purpose so create a folder called `C:\inetpub\EdFi-AdminApp-FE` and move the following files into it:
-   - `index.html` file and `assets` folder located in folder `dist/packages/fe/`
+   Create a dedicated folder, for example `C:\inetpub\EdFi-AdminApp-FE`, and copy into it the `index.html` file and the `assets` folder from `dist/packages/fe/`.
 
-4. **Create IIS Website**:
-   - Open IIS Manager
-   - Right-click on "Sites" and choose "Add Website"
-   - Set **Site name**: `EdFi-AdminApp-FE`
-   - Set **Physical path**: Point to your built application directory (eg. `C:\inetpub\EdFi-AdminApp-FE`)
-   - Set **Port**: 4200 (or your preferred port)
-   - **Important**: Leave **Host name** blank for localhost testing, or set it only if you have proper DNS setup
-   - Configure IIS site with proper bindings (HTTPS recommended)
+4. **Create the IIS site**:
 
-5. **Configure URL Rewrite** for React Router:
+   Create a standalone IIS site (not nested under another site):
+   - Open IIS Manager, right-click **Sites**, and choose **Add Website**.
+   - **Site name**: `EdFi-AdminApp-FE`
+   - **Physical path**: the folder from step 3 (for example `C:\inetpub\EdFi-AdminApp-FE`)
+   - **Binding**: type **http**, port **4200**
+   - Leave **Host name** blank for localhost testing.
 
-   Create a `web.config` file in the path (eg. `C:\inetpub\EdFi-AdminApp-FE`) with the following content:
+5. **Add the HTTPS binding**:
+
+   Add a second binding: type **https**, port **4443**, and select a certificate (the same one used for the API is fine). See [TLS and certificates](#tls-and-certificates).
+
+6. **Configure `web.config`**:
+
+   Create a `web.config` in the site folder. It redirects HTTP to HTTPS, falls back client-side routes to `index.html`, and sets the frontend's security headers.
 
    ```xml
    <?xml version="1.0" encoding="utf-8"?>
@@ -338,46 +477,90 @@ See [Troubleshooting](../troubleshooting.md#backend-troubleshooting) section in 
      <system.webServer>
        <rewrite>
          <rules>
+           <rule name="HTTP to HTTPS redirect" stopProcessing="true">
+             <match url="(.*)" />
+             <conditions>
+               <add input="{HTTPS}" pattern="off" />
+               <add input="{HTTP_HOST}" pattern="^([^:]+)(:\d+)?$" />
+             </conditions>
+             <action type="Redirect" url="https://{C:1}:4443/{R:1}" redirectType="Permanent" appendQueryString="true" />
+           </rule>
            <rule name="React Routes" stopProcessing="true">
              <match url=".*" />
              <conditions logicalGrouping="MatchAll">
                <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
                <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
-               <add input="{REQUEST_URI}" pattern="^/(api)" negate="true" />
              </conditions>
-             <action type="Rewrite" url="/" />
+             <action type="Rewrite" url="index.html" />
            </rule>
          </rules>
        </rewrite>
-       <staticContent>
-         <!-- Remove existing MIME types before adding to prevent duplicates -->
-         <remove fileExtension=".json" />
-         <remove fileExtension=".woff" />
-         <remove fileExtension=".woff2" />
-         <mimeMap fileExtension=".json" mimeType="application/json" />
-         <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
-         <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
-       </staticContent>
-       <httpCompression>
-         <dynamicTypes>
-           <add mimeType="application/json" enabled="true" />
-         </dynamicTypes>
-         <staticTypes>
-           <add mimeType="application/javascript" enabled="true" />
-           <add mimeType="text/css" enabled="true" />
-         </staticTypes>
-       </httpCompression>
-       <!-- Error handling -->
-       <httpErrors errorMode="Detailed" />
+       <httpProtocol>
+         <customHeaders>
+           <remove name="X-Powered-By" />
+           <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" />
+           <add name="X-Content-Type-Options" value="nosniff" />
+           <add name="X-Frame-Options" value="DENY" />
+           <add name="Referrer-Policy" value="no-referrer" />
+           <add name="Content-Security-Policy" value="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https://localhost:3443; form-action 'self'" />
+         </customHeaders>
+       </httpProtocol>
      </system.webServer>
    </configuration>
    ```
 
-   **Important**: The `<remove>` elements are **critical** to prevent duplicate MIME type errors. IIS may already have these MIME types configured at the server level.
+   :::note
+   The `connect-src` in the Content-Security-Policy must name the exact API origin the bundle calls (`VITE_API_URL`), or the browser blocks the frontend's API requests. Here it is `https://localhost:3443`.
+   :::
 
-See [Troubleshooting](../troubleshooting.md#frontend-troubleshooting) section in case you have errors.
+   :::note
+   If your web fonts fail to load (HTTP 404 for `.woff2` files), your IIS may be missing that MIME type. See [Troubleshooting](../troubleshooting.md#frontend-troubleshooting).
+   :::
+
+See the [Troubleshooting](../troubleshooting.md#frontend-troubleshooting) section if you hit errors.
+
+## Security headers
+
+Both IIS sites emit a baseline set of response headers (shown in each site's `web.config` above) and remove `X-Powered-By`. Both send `Strict-Transport-Security` (HSTS) and `Referrer-Policy`, and each carries an **enforcing** `Content-Security-Policy`:
+
+- **API** — `default-src 'none'`, since it serves only JSON in production (Swagger UI is disabled there).
+- **Frontend** — allows its own origin plus the API origin in `connect-src`; `style-src` allows `'unsafe-inline'` because the UI framework injects styles at runtime.
+
+The API additionally sets `X-Content-Type-Options` and `X-Frame-Options` in application code. Adjust these headers if you place the sites behind a reverse proxy that sets its own.
+
+## Production considerations
+
+The default install is suitable for a local or trusted-network deployment. Before exposing the Admin App more broadly:
+
+- **Use a CA-issued certificate.** The default self-signed certificate is trusted only on the install host. Bind a real certificate (`-CertificateThumbprint` or `-CertificatePfxPath`) so other machines trust the sites without warnings.
+- **Do not run the example Keycloak in production.** The local Keycloak example runs in `start-dev` (HTTP, embedded H2 database, hostname strictness off) and is for local development only. For production, run `kc.bat start` with `--hostname`, a real database, and TLS — or use your own OIDC provider.
+- **Keep upstream TLS verification on.** `SSL_VERIFICATION` defaults to `true`, so the API verifies the certificate of the ODS/API and Admin API it calls. If an upstream presents a self-signed or dev certificate, make Node trust it rather than disabling verification:
+  1. Export the upstream's certificate (or its issuing CA) to a PEM file (`.crt`/`.pem`).
+  2. Set `NODE_EXTRA_CA_CERTS` to that file's path for the API process — add an `<environmentVariable name="NODE_EXTRA_CA_CERTS" value="C:\path\to\upstream-ca.crt" />` inside `<httpPlatform><environmentVariables>` in the API site's `web.config` (next to `NODE_ENV`), or set it on the `EdFi-AdminApp-API` App Pool's environment.
+  3. Restart the API site so Node re-reads the value.
+
+  On Node 22.15+ you can instead set `NODE_OPTIONS=--use-system-ca`, which honors the Windows certificate store.
+- **Review secrets handling.** A manual install keeps credentials in `production.js`; a scripted `install-all.ps1` run keeps them in the API App Pool's environment and writes the generated encryption key to an ACL-restricted `install-summary.txt`. Protect or rotate them wherever they live, per your policy.
+- **Harden the database and App Pool identities.** This guide already connects as a least-privilege SQL login (`edfi_adminapp`, not `sa`); keep that separation in production.
+
+## Uninstall
+
+This works the same whether you installed with the scripts or by hand, as long as you used the site names, paths, and database name from this guide.
+
+- `uninstall.ps1` removes the generic Admin App install: the `EdFi-AdminApp-API` and `EdFi-AdminApp-FE` sites, the App Pool, the deployed directories, the `sbaa` database, the dockerized PostgreSQL/Yopass stacks (if used), and the npm cache folder. It leaves Node.js, SQL Server, and IIS in place. It prompts for confirmation; pass `-Force` for a non-interactive run, and `-SaPassword` to drop the SQL Server database over SQL authentication.
+- `uninstall-keycloak.ps1` tears down the local Keycloak example: it stops the Keycloak process, deletes the Keycloak install directory, and unsets the machine `JAVA_HOME`. The JDK itself is left installed.
 
 ## Next steps
+
+The Admin App is now running, but it manages **Ed-Fi ODS/API** instances that run separately — this guide does not install an ODS/API. To start using the Admin App, sign in and connect a running ODS/API environment (ODS/API 6.x or 7.x) by its Discovery API URL.
+
+:::note First sign-in
+Open the frontend at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the seeded user — email `admin@example.com` (the `-AdminUsername` / `-TestUserEmail` default) and the password you passed as `-TestUserPassword`. This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
+:::
+
+:::note
+If the ODS/API or Admin API presents a self-signed or dev certificate — common for a local ODS/API — adding an Environment fails with a certificate error (`DEPTH_ZERO_SELF_SIGNED_CERT`) in the API log (`logs\node-stdout.log`). Make Node trust the upstream certificate via `NODE_EXTRA_CA_CERTS`; see [Production considerations](#production-considerations).
+:::
 
 - [Configuring Ed-Fi Admin App](../configuration/configuring-admin-app.md)
 - [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/_category_.json
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Windows IIS Installation",
+  "position": 3
+}

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/_category_.json
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Windows IIS Installation",
-  "position": 3
-}

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -25,6 +25,12 @@ On a fresh machine, run `setup-vm-prereqs.ps1` first (it installs the OS-level p
 
 `install-all.ps1` fetches the Admin App source for you — by default it clones the latest stable release of `Ed-Fi-AdminApp` as a sibling folder (for example `C:\Ed-Fi\Ed-Fi-AdminApp`). To build from a checkout you already have, pass `-SourcePath`; to pin a specific version, pass `-AdminAppRef <tag>` (for example `-AdminAppRef v4.0.1`).
 
+:::tip
+Run the examples below **exactly as written** — do not substitute your own passwords into them. Each `(Read-Host -AsSecureString '...')` tells PowerShell to **prompt you for that value at the console** when the command runs (your input stays hidden). Paste the whole command, press Enter, and type each secret when prompted. Replacing the `Read-Host` calls with literal password text is what causes errors, so leave them as-is.
+:::
+
+For the full list of parameters and configuration options, see the [`windows-install/README.md`](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts/blob/main/windows-install/README.md) in the scripts repository, or run `Get-Help .\install-all.ps1 -Full`.
+
 **Local Keycloak, SQL Server** — the default:
 
 ```powershell

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 2
+---
+
+# Automated
+
+The fastest path: install the whole stack with the PowerShell scripts from the [Admin App Installation Scripts repository](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts), with no manual steps. For what each step configures under the hood, see [Manual](./manual.md).
+
+## Get the scripts
+
+Clone the repository and open the `windows-install` folder from an elevated PowerShell:
+
+```powershell
+git clone https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts.git
+cd Admin-App-Installation-Scripts\windows-install
+```
+
+:::note
+On a bare machine without Git, download the repository as a ZIP from GitHub (**Code → Download ZIP**) and extract it — `setup-vm-prereqs.ps1` installs Git afterward. If PowerShell refuses to run the scripts (they carry the internet Mark of the Web), `setup-vm-prereqs.ps1` unblocks them and sets the execution policy; to do it by hand, run `Get-ChildItem *.ps1 | Unblock-File` and `Set-ExecutionPolicy -Scope Process Bypass`.
+:::
+
+## Run everything at once
+
+On a fresh machine, run `setup-vm-prereqs.ps1` first (it installs the OS-level pieces: IIS, SQL Server, Git), then `install-all.ps1`. Both run from an elevated PowerShell in the `windows-install` folder. Choose the identity provider with the mandatory `-IdpProvider` parameter; this guide uses `keycloak`.
+
+`install-all.ps1` fetches the Admin App source for you — by default it clones the latest stable release of `Ed-Fi-AdminApp` as a sibling folder (for example `C:\Ed-Fi\Ed-Fi-AdminApp`). To build from a checkout you already have, pass `-SourcePath`; to pin a specific version, pass `-AdminAppRef <tag>` (for example `-AdminAppRef v4.0.1`).
+
+**Local Keycloak, SQL Server** — the default:
+
+```powershell
+.\install-all.ps1 -IdpProvider keycloak `
+  -SaPassword (Read-Host -AsSecureString 'SQL Server sa password') `
+  -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
+  -KeycloakAdminPassword (Read-Host -AsSecureString 'Keycloak admin password') `
+  -OidcClientSecret (Read-Host -AsSecureString 'OIDC client secret') `
+  -TestUserPassword (Read-Host -AsSecureString 'Keycloak test-user password')
+```
+
+The password parameters are `SecureString`s, so pass them with `Read-Host -AsSecureString` (as above) rather than plain quoted strings. `-AppDbPassword` sets the password for the least-privilege `edfi_adminapp` login the script creates; it is required for SQL Server. This stands up the local Keycloak (realm `edfi`, client `edfiadminapp`, and a test user) and deploys the API and frontend as part of the run.
+
+**Local Keycloak, PostgreSQL via Docker** — no local SQL Server; the bundled docker-compose runs PostgreSQL (requires Docker Desktop in Linux-container mode):
+
+```powershell
+.\install-all.ps1 -IdpProvider keycloak `
+  -DbEngine pgsql -UsePostgresDocker `
+  -PostgresSuperuserPassword (Read-Host -AsSecureString 'Postgres superuser password') `
+  -PostgresAppPassword (Read-Host -AsSecureString 'Postgres app password') `
+  -KeycloakAdminPassword (Read-Host -AsSecureString 'Keycloak admin password') `
+  -OidcClientSecret (Read-Host -AsSecureString 'OIDC client secret') `
+  -TestUserPassword (Read-Host -AsSecureString 'Keycloak test-user password')
+```
+
+:::note
+By default the sites use a self-signed certificate (auto-trusted on this machine only). To bind a real certificate, pass `-CertificateThumbprint`, or `-CertificatePfxPath` with `-CertificatePassword` (see [TLS and certificates](./manual.md#tls-and-certificates)). Yopass is off by default; add `-SetupYopassDocker` to stand up a local Yopass via Docker, or `-YopassUrl <url>` to point at an existing one.
+:::
+
+The script is idempotent: if a step fails, fix the cause and re-run. `-SkipPhase1` (skip prerequisites) and `-SkipPhase2` (skip build) speed up re-runs.
+
+To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and unsets `JAVA_HOME`; leaves the JDK installed).
+
+## First sign-in
+
+Open the frontend at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the seeded user — email `admin@example.com` (the `-AdminUsername` / `-TestUserEmail` default) and the password you passed as `-TestUserPassword`. This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
+
+## Next steps
+
+- [Configuring Ed-Fi Admin App](../../configuration/configuring-admin-app.md)
+- [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md)
+- [Security Considerations](../../configuration/security-considerations.md)
+- [Global Administration Tasks](../../configuration/global-administration-tasks.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -35,7 +35,6 @@ For the full list of parameters and configuration options, see the [`windows-ins
 
 ```powershell
 .\install-all.ps1 -IdpProvider keycloak `
-  -SaPassword (Read-Host -AsSecureString 'SQL Server sa password') `
   -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
   -KeycloakAdminPassword (Read-Host -AsSecureString 'Keycloak admin password') `
   -OidcClientSecret (Read-Host -AsSecureString 'OIDC client secret') `

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -19,6 +19,13 @@ cd Admin-App-Installation-Scripts\windows-install
 On a bare machine without Git, download the repository as a ZIP from GitHub (**Code → Download ZIP**) and extract it — `setup-vm-prereqs.ps1` installs Git afterward. If PowerShell refuses to run the scripts (they carry the internet Mark of the Web), `setup-vm-prereqs.ps1` unblocks them and sets the execution policy; to do it by hand, run `Get-ChildItem *.ps1 | Unblock-File` and `Set-ExecutionPolicy -Scope Process Bypass`.
 :::
 
+## Windows Server prerequisite: install winget
+
+The scripts use the Windows Package Manager (`winget`) to install Node.js, OpenJDK, SQL Server, and Git. It ships with Windows 10 and Windows 11 but is **not** included on Windows Server 2019 or 2022, so install it there before running `setup-vm-prereqs.ps1`. (`00-check-prereqs.ps1` reports when winget is missing.)
+
+- **Official Microsoft guidance:** see [Install WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget). Because Windows Server 2019/2022 do not include the Microsoft Store, install the App Installer package directly from the official [microsoft/winget-cli releases](https://github.com/microsoft/winget-cli/releases).
+- **Community helper (optional):** the [`winget-install`](https://www.powershellgallery.com/packages/winget-install) PowerShell Gallery script is a third-party tool that installs winget in a single command. It downloads only from official Microsoft and GitHub sources, though it is not maintained or endorsed by Ed-Fi or Microsoft.
+
 ## Run everything at once
 
 On a fresh machine, run `setup-vm-prereqs.ps1` first (it installs the OS-level pieces: IIS, SQL Server, Git), then `install-all.ps1`. Both run from an elevated PowerShell in the `windows-install` folder. Choose the identity provider with the mandatory `-IdpProvider` parameter; this guide uses `keycloak`.

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -28,35 +28,37 @@ The scripts use the Windows Package Manager (`winget`) to install Node.js, OpenJ
 
 ## Run everything at once
 
-On a fresh machine, run `setup-vm-prereqs.ps1` first (it installs the OS-level pieces: IIS, SQL Server, Git), then `install-all.ps1`. Both run from an elevated PowerShell in the `windows-install` folder. Choose the identity provider with the mandatory `-IdpProvider` parameter; this guide uses `keycloak`.
+On a fresh machine, run `setup-vm-prereqs.ps1` first (it installs the operating-system-level pieces: IIS, SQL Server, Git), then `install-all.ps1`. Both run from an elevated PowerShell in the `windows-install` folder. Choose the identity provider with the mandatory `-IdpProvider` parameter; this guide uses `keycloak`.
+
+You can run `install-all.ps1` with **no parameters**: it applies sensible defaults (SQL Server, the latest stable Admin App release, and the seeded administrator `admin@example.com`) and prompts you at the console for the identity provider and any secrets it needs. The blocks below are **examples of common configurations** to copy and adapt; you do not have to pass these parameters.
 
 `install-all.ps1` fetches the Admin App source for you — by default it clones the latest stable release of `Ed-Fi-AdminApp` as a sibling folder (for example `C:\Ed-Fi\Ed-Fi-AdminApp`). To build from a checkout you already have, pass `-SourcePath`; to pin a specific version, pass `-AdminAppRef <tag>` (for example `-AdminAppRef v4.0.1`).
 
 :::tip
-Run the examples below **exactly as written** — do not substitute your own passwords into them. Each `(Read-Host -AsSecureString '...')` tells PowerShell to **prompt you for that value at the console** when the command runs (your input stays hidden). Paste the whole command, press Enter, and type each secret when prompted. Replacing the `Read-Host` calls with literal password text is what causes errors, so leave them as-is.
+**If you use one of the examples below**, run it **exactly as written** — do not substitute your own passwords into them. Each `(Read-Host -AsSecureString '...')` tells PowerShell to **prompt you for that value at the console** when the command runs (your input stays hidden). Paste the whole command, press Enter, and type each secret when prompted. Replacing the `Read-Host` calls with literal password text is what causes errors, so leave them as-is.
 :::
 
 For the full list of parameters and configuration options, see the [`windows-install/README.md`](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts/blob/main/windows-install/README.md) in the scripts repository, or run `Get-Help .\install-all.ps1 -Full`.
 
-**Local Keycloak, SQL Server** — the default:
+**Example — local Keycloak, SQL Server (the default):**
 
 ```powershell
 .\install-all.ps1 -IdpProvider keycloak `
-  -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
+  -AppDbPassword (Read-Host -AsSecureString 'Admin App database login password') `
   -KeycloakAdminPassword (Read-Host -AsSecureString 'Keycloak admin password') `
   -OidcClientSecret (Read-Host -AsSecureString 'OIDC client secret') `
   -TestUserPassword (Read-Host -AsSecureString 'Keycloak test-user password')
 ```
 
-The password parameters are `SecureString`s, so pass them with `Read-Host -AsSecureString` (as above) rather than plain quoted strings. `-AppDbPassword` sets the password for the least-privilege `edfi_adminapp` login the script creates; it is required for SQL Server. This stands up the local Keycloak (realm `edfi`, client `edfiadminapp`, and a test user) and deploys the API and frontend as part of the run.
+The password parameters are `SecureString`s, so pass them with `Read-Host -AsSecureString` (as above) rather than plain quoted strings. `-AppDbPassword` sets the password for the least-privilege `edfi_adminapp` login the script creates; it is required for SQL Server. This stands up the local Keycloak (realm `edfi`, client `edfiadminapp`, and a test user) and deploys the API and Web Application as part of the run.
 
-**Local Keycloak, PostgreSQL via Docker** — no local SQL Server; the bundled docker-compose runs PostgreSQL (requires Docker Desktop in Linux-container mode):
+**Example — local Keycloak, PostgreSQL via Docker** (no local SQL Server; the bundled docker-compose runs PostgreSQL, and requires Docker Desktop in Linux-container mode):
 
 ```powershell
 .\install-all.ps1 -IdpProvider keycloak `
   -DbEngine pgsql -UsePostgresDocker `
-  -PostgresSuperuserPassword (Read-Host -AsSecureString 'Postgres superuser password') `
-  -PostgresAppPassword (Read-Host -AsSecureString 'Postgres app password') `
+  -PostgresSuperuserPassword (Read-Host -AsSecureString 'PostgreSQL superuser password') `
+  -PostgresAppPassword (Read-Host -AsSecureString 'PostgreSQL app password') `
   -KeycloakAdminPassword (Read-Host -AsSecureString 'Keycloak admin password') `
   -OidcClientSecret (Read-Host -AsSecureString 'OIDC client secret') `
   -TestUserPassword (Read-Host -AsSecureString 'Keycloak test-user password')
@@ -72,7 +74,7 @@ To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak,
 
 ## First sign-in
 
-Open the frontend at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the seeded user — email `admin@example.com` (the `-AdminUsername` / `-TestUserEmail` default) and the password you passed as `-TestUserPassword`. This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
+Open the Web Application at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the seeded user — email `admin@example.com` (the `-AdminUsername` / `-TestUserEmail` default) and the password you passed as `-TestUserPassword`. This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
 
 ## Next steps
 

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -8,15 +8,28 @@ The fastest path: install the whole stack with the PowerShell scripts from the [
 
 ## Get the scripts
 
-Clone the repository and open the `windows-install` folder from an elevated PowerShell:
+Clone the repository into a dedicated parent folder, then open the `windows-install` folder from an elevated PowerShell:
 
 ```powershell
-git clone https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts.git
-cd Admin-App-Installation-Scripts\windows-install
+git clone https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts.git C:\Ed-Fi\Admin-App-Installation-Scripts
+cd C:\Ed-Fi\Admin-App-Installation-Scripts\windows-install
 ```
 
+:::info Where the folders end up
+`install-all.ps1` clones the Admin App source **beside** the scripts repository, not inside it, so where you put the scripts determines where the source lands. With the commands above:
+
+```text
+C:\Ed-Fi\
+├── Admin-App-Installation-Scripts\   the scripts you cloned
+│   └── windows-install\              run the scripts from here
+└── Ed-Fi-AdminApp\                   the Admin App source, cloned for you
+```
+
+Avoid a user profile folder like `Downloads`, since the Admin App source lands beside it. To put the source somewhere else, pass `-SourcePath`. If the scripts already sit inside an Admin App checkout, that checkout is used instead of a new clone.
+:::
+
 :::note
-On a bare machine without Git, download the repository as a ZIP from GitHub (**Code → Download ZIP**) and extract it — `setup-vm-prereqs.ps1` installs Git afterward. If PowerShell refuses to run the scripts (they carry the internet Mark of the Web), `setup-vm-prereqs.ps1` unblocks them and sets the execution policy; to do it by hand, run `Get-ChildItem *.ps1 | Unblock-File` and `Set-ExecutionPolicy -Scope Process Bypass`.
+On a bare machine without Git, download the repository as a ZIP from GitHub (**Code → Download ZIP**) and extract it under `C:\Ed-Fi`, so it sits where the clone above would have put it. Only the location matters, not the extracted folder's name. `setup-vm-prereqs.ps1` installs Git afterward. If PowerShell refuses to run the scripts (they carry the internet Mark of the Web), `setup-vm-prereqs.ps1` unblocks them and sets the execution policy; to do it by hand, run `Get-ChildItem *.ps1 | Unblock-File` and `Set-ExecutionPolicy -Scope Process Bypass`.
 :::
 
 ## Windows Server prerequisite: install winget
@@ -28,53 +41,59 @@ The scripts use the Windows Package Manager (`winget`) to install Node.js, OpenJ
 
 ## Run everything at once
 
-On a fresh machine, run `setup-vm-prereqs.ps1` first (it installs the operating-system-level pieces: IIS, SQL Server, Git), then `install-all.ps1`. Both run from an elevated PowerShell in the `windows-install` folder. Choose the identity provider with the mandatory `-IdpProvider` parameter; this guide uses `keycloak`.
+On a fresh machine, run `setup-vm-prereqs.ps1` first — it installs the operating-system-level pieces: IIS, SQL Server, and Git — then `install-all.ps1`.
 
-You can run `install-all.ps1` with **no parameters**: it applies sensible defaults (SQL Server, the latest stable Admin App release, and the seeded administrator `admin@example.com`) and prompts you at the console for the identity provider and any secrets it needs. The blocks below are **examples of common configurations** to copy and adapt; you do not have to pass these parameters.
+`install-all.ps1` fetches the Admin App source for you — by default it clones the latest stable release of `Ed-Fi-AdminApp` beside the scripts repository, as shown in [Get the scripts](#get-the-scripts). To build from a checkout you already have, pass `-SourcePath`; to pin a specific version, pass `-AdminAppRef <tag>` (for example `-AdminAppRef v4.0.1`).
 
-`install-all.ps1` fetches the Admin App source for you — by default it clones the latest stable release of `Ed-Fi-AdminApp` as a sibling folder (for example `C:\Ed-Fi\Ed-Fi-AdminApp`). To build from a checkout you already have, pass `-SourcePath`; to pin a specific version, pass `-AdminAppRef <tag>` (for example `-AdminAppRef v4.0.1`).
+`install-all.ps1` can be run with **no parameters**. It applies sensible defaults (SQL Server, the latest stable Admin App release, and the seeded administrator `admin@example.com`) and prompts at the console for anything it requires, including the identity provider (`-IdpProvider`) and any secrets. It always asks for the identity provider, so the choice is explicit; this guide uses `keycloak`.
 
-:::tip
-**If you use one of the examples below**, run it **exactly as written** — do not substitute your own passwords into them. Each `(Read-Host -AsSecureString '...')` tells PowerShell to **prompt you for that value at the console** when the command runs (your input stays hidden). Paste the whole command, press Enter, and type each secret when prompted. Replacing the `Read-Host` calls with literal password text is what causes errors, so leave them as-is.
-:::
+Running with the defaults stands up the local Keycloak (realm `edfi`, client `edfiadminapp`, and a test user), creates the least-privilege `edfi_adminapp` database login, and deploys the API and Web Application in the same run.
 
-For the full list of parameters and configuration options, see the [`windows-install/README.md`](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts/blob/main/windows-install/README.md) in the scripts repository, or run `Get-Help .\install-all.ps1 -Full`.
+Pass a parameter only to change something the defaults do not cover. PostgreSQL is the common case: the engine and the bundled container are not prompted for, though its passwords are.
 
-**Example — local Keycloak, SQL Server (the default):**
+**Example — PostgreSQL via Docker** (no local SQL Server; the bundled docker-compose runs PostgreSQL and requires Docker Desktop in Linux-container mode):
 
 ```powershell
-.\install-all.ps1 -IdpProvider keycloak `
-  -AppDbPassword (Read-Host -AsSecureString 'Admin App database login password') `
-  -KeycloakAdminPassword (Read-Host -AsSecureString 'Keycloak admin password') `
-  -OidcClientSecret (Read-Host -AsSecureString 'OIDC client secret') `
-  -TestUserPassword (Read-Host -AsSecureString 'Keycloak test-user password')
-```
-
-The password parameters are `SecureString`s, so pass them with `Read-Host -AsSecureString` (as above) rather than plain quoted strings. `-AppDbPassword` sets the password for the least-privilege `edfi_adminapp` login the script creates; it is required for SQL Server. This stands up the local Keycloak (realm `edfi`, client `edfiadminapp`, and a test user) and deploys the API and Web Application as part of the run.
-
-**Example — local Keycloak, PostgreSQL via Docker** (no local SQL Server; the bundled docker-compose runs PostgreSQL, and requires Docker Desktop in Linux-container mode):
-
-```powershell
-.\install-all.ps1 -IdpProvider keycloak `
-  -DbEngine pgsql -UsePostgresDocker `
-  -PostgresSuperuserPassword (Read-Host -AsSecureString 'PostgreSQL superuser password') `
-  -PostgresAppPassword (Read-Host -AsSecureString 'PostgreSQL app password') `
-  -KeycloakAdminPassword (Read-Host -AsSecureString 'Keycloak admin password') `
-  -OidcClientSecret (Read-Host -AsSecureString 'OIDC client secret') `
-  -TestUserPassword (Read-Host -AsSecureString 'Keycloak test-user password')
+.\install-all.ps1 -DbEngine pgsql -UsePostgresDocker
 ```
 
 :::note
 By default the sites use a self-signed certificate (auto-trusted on this machine only). To bind a real certificate, pass `-CertificateThumbprint`, or `-CertificatePfxPath` with `-CertificatePassword` (see [TLS and certificates](./manual.md#tls-and-certificates)). Yopass is off by default; add `-SetupYopassDocker` to stand up a local Yopass via Docker, or `-YopassUrl <url>` to point at an existing one.
 :::
 
-The script is idempotent: if a step fails, fix the cause and re-run. `-SkipPhase1` (skip prerequisites) and `-SkipPhase2` (skip build) speed up re-runs.
+`install-all.ps1` is idempotent: if a step fails, fix the cause and re-run. `-SkipPhase1` (skip prerequisites) and `-SkipPhase2` (skip build) speed up re-runs.
 
-To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and unsets `JAVA_HOME`; leaves the JDK installed).
+To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and its startup task, and unsets `JAVA_HOME`; leaves the JDK installed).
+
+For the full list of parameters and configuration options, see the [`windows-install/README.md`](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts/blob/main/windows-install/README.md) in the scripts repository, or run `Get-Help .\install-all.ps1 -Full`.
 
 ## First sign-in
 
-Open the Web Application at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the seeded user — email `admin@example.com` (the `-AdminUsername` / `-TestUserEmail` default) and the password you passed as `-TestUserPassword`. This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
+Open the Web Application at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the seeded user — email `admin@example.com` (the `-AdminUsername` / `-TestUserEmail` default) and the test-user password you entered when the script prompted for it (`-TestUserPassword`). This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
+
+## After a restart: the Keycloak startup task
+
+After the host restarts, the local Keycloak is not running. The API needs Keycloak to be answering requests by the time the API starts, so the two have to come back in that order: Keycloak first, then the API.
+
+The install does this for you. `install-all.ps1` (through `idp-keycloak-setup.ps1`) registers a scheduled task named `Ed-Fi Admin App Keycloak`, triggered at system startup and running as `SYSTEM`, which:
+
+1. Starts Keycloak from its install folder (`C:\keycloak` by default).
+2. Waits for the OIDC discovery endpoint to respond, up to `-ReadyTimeoutSeconds` (120 by default).
+3. Recycles the `EdFi-AdminApp-API` App Pool, so the API starts again with Keycloak already running.
+
+No manual step is needed after a restart, though a sign-in attempted before the task finishes can fail. If sign-in does not work, wait a moment and retry; if it still fails, check the task's log at `C:\keycloak\keycloak-startup-task.log`.
+
+To start Keycloak again without restarting the host, run `idp-keycloak-start.ps1`.
+
+`uninstall-keycloak.ps1` removes the task along with Keycloak. To remove only the task:
+
+```powershell
+schtasks /delete /tn 'Ed-Fi Admin App Keycloak' /f
+```
+
+:::note
+This task belongs to the local Keycloak example. It is not registered when the Admin App points at an external identity provider, which is expected: an external provider does not need to be started on this host.
+:::
 
 ## Next steps
 

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -1,93 +1,24 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
-# Windows IIS Installation
+# Manual
 
-This page describes how to install the Ed-Fi Admin App on Windows using Internet Information Services (IIS). It covers the backend API and the frontend single-page application, deployed as two standalone IIS sites over HTTPS.
-
-:::note
-This is one of three alternative installation paths. If you instead want to run the Admin App in containers or on a Unix-like server, see [Docker Compose Installation](./docker-installation.md) or [Unix-like Systems Installation](./unix-installation.md).
-:::
-
-Every section can be completed **manually** or with an **optional PowerShell script** that automates it. The scripts ship in the [Admin App Installation Scripts repository](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts) under `windows-install/`. You can mix the two: automate some sections, do others by hand.
-
-## Before you start: decide three things
-
-1. **Database engine** — SQL Server (default) or PostgreSQL. You need only one.
-2. **Identity provider (IdP)** — the Admin App authenticates against an OIDC provider. This guide sets up **Keycloak**, running locally, as the example identity provider (a setup script provisions it). The Admin App's auth engine uses generic OIDC discovery, but Keycloak is the identity provider documented for this release.
-3. **Manual or automated** — follow the manual steps in each section, or run the script that automates it.
-
-:::info
-Both IIS sites are served over **HTTPS by default** — API on port **3443** and frontend on port **4443**. Each also keeps an HTTP binding (**3333** / **4200**) that returns a 301 redirect to its HTTPS URL. When no certificate is supplied, a self-signed certificate is generated and trusted on the local machine; supply a real certificate for anything beyond this host (see [TLS and certificates](#tls-and-certificates)). **IIS 10 or newer is required.**
-:::
-
-## Fast path: automation scripts
-
-To automate, clone the [Admin App Installation Scripts repository](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts) and run the scripts in `windows-install/` from an elevated PowerShell, in the order below. Each script maps to a manual section later on this page; any script can be skipped in favor of its manual steps.
-
-```powershell
-git clone https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts.git
-cd Admin-App-Installation-Scripts\windows-install
-```
-
-:::note
-On a bare machine without Git, download the repository as a ZIP from GitHub (**Code → Download ZIP**) and extract it — `setup-vm-prereqs.ps1` installs Git afterward. If PowerShell refuses to run the scripts (they carry the internet Mark of the Web), `setup-vm-prereqs.ps1` unblocks them and sets the execution policy; to do it by hand, run `Get-ChildItem *.ps1 | Unblock-File` and `Set-ExecutionPolicy -Scope Process Bypass`.
-:::
-
-| Order | Script | What it automates | Manual section |
-| --- | --- | --- | --- |
-| 0 (fresh VM) | `setup-vm-prereqs.ps1` | OS-level installs: IIS feature set, SQL Server Developer, Git. Scans first, installs only what is missing; also sets the execution policy and unblocks the scripts. | [Windows Prerequisites](#windows-prerequisites) |
-| 1 | `01-prereqs-iis.ps1` | URL Rewrite Module + the httpPlatform handler (HttpBridge by default, or Microsoft HttpPlatformHandler); unlocks the `handlers` configuration section. | [Windows Prerequisites](#windows-prerequisites) |
-| 2 | `02-prereqs-sql.ps1` | SQL Server Mixed Mode + TCP/IP + `sa`; creates the `sbaa` database and a dedicated least-privilege login (`edfi_adminapp`) the app connects as. | [Windows Prerequisites](#windows-prerequisites) |
-| 3 | `03-prereqs-node.ps1` | Installs Node.js (the major version pinned in `engines.node`); remediates a too-old Node via nvm-windows. | [Windows Prerequisites](#windows-prerequisites) |
-| 4 | `04-build.ps1` | `npm ci` + build API + build frontend. Seeds the frontend `.env` before building. | [Backend API](#backend-api-installation) / [Frontend](#frontend-installation) |
-| 5 | `05-deploy-api.ps1` | Deploys the API as standalone site `EdFi-AdminApp-API` (HTTPS :3443; HTTP :3333 redirects): web.config, App Pool, `production.js`, App-Pool-scoped npm cache. | [Backend API](#backend-api-installation) |
-| 6 | `06-deploy-fe.ps1` | Deploys the frontend as standalone site `EdFi-AdminApp-FE` (HTTPS :4443; HTTP :4200 redirects). | [Frontend](#frontend-installation) |
-| verify | `00-check-prereqs.ps1` | Read-only diagnostic: IIS (and version), database, Node, build artifacts, and whether ports 3333/4200/3443/4443 are free. | [Verify prerequisites](#verify-prerequisites) |
-| optional | `idp-keycloak-setup.ps1` | Installs a JDK, downloads and starts a local Keycloak, provisions realm `edfi`, client `edfiadminapp`, and a test user. | [Identity provider](#identity-provider) |
-| optional | `idp-keycloak-start.ps1` | Restarts the local Keycloak (e.g. after a reboot). | [Identity provider](#identity-provider) |
-| optional | `yopass-docker.ps1` | Stands up a local Yopass via Docker. | [Yopass](#yopass-optional) |
-| optional | `install-all.ps1` | Runs the whole sequence end to end, including the local Keycloak IdP setup. | (whole page) |
-
-To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and unsets `JAVA_HOME`; leaves the JDK installed).
-
-## Run everything at once
-
-To install the whole stack in one command, `install-all.ps1` runs the entire sequence end to end: the pre-flight check, all prerequisites, the build, the identity-provider setup, both deployments, and a smoke test. This is the fastest path; the manual sections below are for installing a piece by hand or understanding what each step does.
-
-On a fresh machine, run `setup-vm-prereqs.ps1` first (it installs the OS-level pieces: IIS, SQL Server, Git), then `install-all.ps1`. Run both from an elevated PowerShell in the `windows-install` folder. Choose the identity provider with the mandatory `-IdpProvider` parameter; this guide uses `keycloak`.
-
-`install-all.ps1` fetches the Admin App source for you — by default it clones the latest stable release of `Ed-Fi-AdminApp` as a sibling folder (for example `C:\Ed-Fi\Ed-Fi-AdminApp`). To build from a checkout you already have, pass `-SourcePath`; to pin a specific version, pass `-AdminAppRef <tag>` (for example `-AdminAppRef v4.0.1`).
-
-Local Keycloak example (SQL Server):
-
-```powershell
-.\install-all.ps1 -IdpProvider keycloak `
-  -SaPassword (Read-Host -AsSecureString 'SQL Server sa password') `
-  -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
-  -KeycloakAdminPassword (Read-Host -AsSecureString 'Keycloak admin password') `
-  -OidcClientSecret (Read-Host -AsSecureString 'OIDC client secret') `
-  -TestUserPassword (Read-Host -AsSecureString 'Keycloak test-user password')
-```
-
-The password parameters are `SecureString`s, so pass them with `Read-Host -AsSecureString` (as above) rather than plain quoted strings. `-AppDbPassword` sets the password for the least-privilege `edfi_adminapp` login the script creates; it is required for SQL Server. This stands up the local Keycloak (realm `edfi`, client `edfiadminapp`, and a test user) and deploys the API and frontend as part of the run.
-
-:::note
-By default the sites use a self-signed certificate (auto-trusted on this machine only). To bind a real certificate, pass `-CertificateThumbprint`, or `-CertificatePfxPath` with `-CertificatePassword` (see [TLS and certificates](#tls-and-certificates)). Yopass is off by default; add `-SetupYopassDocker` to stand up a local Yopass via Docker, or `-YopassUrl <url>` to point at an existing one.
-:::
-
-The script is idempotent: if a step fails, fix the cause and re-run. `-SkipPhase1` (skip prerequisites) and `-SkipPhase2` (skip build) speed up re-runs.
+This page documents the full manual Windows/IIS installation — every prerequisite, both IIS sites, and the exact `web.config` and `production.js` that a working install contains. It is the authoritative reference for what gets configured; the [Automated](./automated.md) and [Semi-automated](./semi-automated.md) paths produce the same result.
 
 ## Windows Prerequisites
 
-:::tip Automation shortcut
-On a fresh VM, `setup-vm-prereqs.ps1` installs the operating-system pieces (the IIS feature set, SQL Server, Git). Then automate the rest with `01-prereqs-iis.ps1`, `02-prereqs-sql.ps1`, and `03-prereqs-node.ps1`, plus the identity provider below. Or follow the manual steps in each subsection. **IIS 10 or newer is required.**
-:::
+Prepare the following on the Windows host before deploying the API and frontend. Each item is detailed in its own subsection below.
+
+- **[Operating-system components](#operating-system-components-iis-sql-server-git)** — IIS (**version 10 or newer**), SQL Server, and, optionally, Git.
+- **[IIS modules](#iis-modules)** — the URL Rewrite Module and an httpPlatform handler.
+- **[Database](#database)** — SQL Server (default) or PostgreSQL.
+- **[Node.js](#nodejs)** — the major version pinned in the Admin App's `package.json` (currently `>=22`).
+- **[Identity provider](../../configuration/identity-provider.md)** — an OIDC provider; this guide uses a local Keycloak example.
+- **[TLS certificate](#tls-and-certificates)** — a CA-issued certificate, or a self-signed one for local use.
+- **[Yopass](../../configuration/yopass-administrators-guide/readme.md)** (optional) — for one-time credential links.
 
 ### Operating system components (IIS, SQL Server, Git)
-
-_Automated by `setup-vm-prereqs.ps1` (scans first, installs only what is missing)._
 
 - **IIS**: Enable the IIS web server role and management tools. From an elevated PowerShell:
 
@@ -103,13 +34,11 @@ _Automated by `setup-vm-prereqs.ps1` (scans first, installs only what is missing
 
 ### IIS modules and configuration (URL Rewrite + httpPlatform handler) {#iis-modules}
 
-_Automated by `01-prereqs-iis.ps1` (assumes the IIS role above is already installed)._
-
 IIS hosts the Node.js API through the **httpPlatform handler**: IIS acts as a reverse proxy, launching the Node process (`main.js`) and forwarding requests to a loopback port it assigns via the `HTTP_PLATFORM_PORT` environment variable.
 
 1. Install the [IIS URL Rewrite Module](https://www.iis.net/downloads/microsoft/url-rewrite). It is used for the HTTP→HTTPS redirect and the frontend's SPA fallback.
 2. Install an httpPlatform handler. Two are compatible, and both register the same `httpPlatformHandler` module name:
-   - **HttpBridge** — the [LeXtudio fork](https://github.com/lextudio/httpbridge) (MIT, actively maintained). This is the scripts' default.
+   - **HttpBridge** — the [LeXtudio fork](https://github.com/lextudio/httpbridge) (MIT, actively maintained).
    - **Microsoft HttpPlatformHandler** — the [original v1.2](https://www.iis.net/downloads/microsoft/httpplatformhandler) (signed, stable, frozen since ~2016).
 3. **Unlock the handlers configuration section** so the application's `web.config` can register the handler. From an elevated PowerShell:
 
@@ -123,9 +52,7 @@ Without unlocking the `handlers` section, requests to the API return **HTTP 500.
 
 ### Database
 
-_Automated by `02-prereqs-sql.ps1` (SQL Server path)._
-
-The Admin App supports PostgreSQL 16+ and SQL Server 2017+, and needs only one. This guide uses **SQL Server** by default on Windows; PostgreSQL is available via Docker (`install-all.ps1 -DbEngine pgsql`; requires Docker Desktop in Linux-container mode).
+The Admin App supports PostgreSQL 16+ and SQL Server 2017+, and needs only one. This guide uses **SQL Server** by default on Windows; PostgreSQL is available via Docker (requires Docker Desktop in Linux-container mode).
 
 For SQL Server:
 
@@ -148,19 +75,15 @@ For SQL Server:
 Installing the Admin App database in its own SQL Server instance, separate from the ODS/API databases (`EdFi_Admin`, `EdFi_Security`), is recommended.
 :::
 
-For PostgreSQL, see [Configuring the Admin App](../configuration/configuring-admin-app.md); the automated PostgreSQL path runs through `install-all.ps1 -DbEngine pgsql`.
+For PostgreSQL, see [Configuring the Admin App](../../configuration/configuring-admin-app.md).
 
 ### Node.js
 
-_Automated by `03-prereqs-node.ps1` (upgrades a too-old version via nvm-windows)._
-
-Install the Node.js major version pinned in the Admin App's `package.json` (`engines.node`, currently `>=22`) from [nodejs.org](https://nodejs.org/). `03-prereqs-node.ps1` reads `engines.node` at runtime and remediates a too-old Node via nvm-windows.
+Install the Node.js major version pinned in the Admin App's `package.json` (`engines.node`, currently `>=22`) from [nodejs.org](https://nodejs.org/).
 
 ### Identity provider
 
-_Automated by `idp-keycloak-setup.ps1`._
-
-This guide uses **Keycloak**, running locally, as the example OIDC identity provider. `idp-keycloak-setup.ps1` installs a JDK, downloads and starts Keycloak, and provisions the `edfi` realm, the `edfiadminapp` confidential client, and a test user. To do it manually: install a supported LTS JDK — Keycloak 26 supports OpenJDK 17, 21, or 25 (the setup script installs OpenJDK 21) — download and start [Keycloak](https://www.keycloak.org/), then create the realm, a confidential client, and a user.
+This guide uses **Keycloak**, running locally, as the example OIDC identity provider. Install a supported LTS JDK — Keycloak 26.6 supports OpenJDK 17, 21, or 25 — then download and start [Keycloak](https://www.keycloak.org/) and create the `edfi` realm, the `edfiadminapp` confidential client, and a test user.
 
 :::note
 Register these in the Keycloak client (HTTPS, matching the default ports):
@@ -169,26 +92,18 @@ Register these in the Keycloak client (HTTPS, matching the default ports):
 - Post-logout redirect URI: `https://localhost:3443/api/auth/post-logout`
 - Web origin: `https://localhost:4443`
 
-`<oidc-id>` is the id of the row in the `oidc` database table; `install-all.ps1` resolves it and prints the exact callback URI to register (it is not always `1`). A user must exist in Keycloak whose email/username claim matches the Admin App admin user (`-AdminUsername`, default `admin@example.com`). Java is required **only** for the local Keycloak example.
+`<oidc-id>` is the id of the row in the `oidc` database table (it is not always `1`; resolve it from that table). A user must exist in Keycloak whose email/username claim matches the Admin App admin user (default `admin@example.com`). Java is required **only** for the local Keycloak example.
 :::
 
-For more detail, see [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md).
+For more detail, see [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md).
 
 ### Yopass (optional)
 
-_Automated by `yopass-docker.ps1`._
-
-Yopass lets the Admin App share newly created API client credentials as one-time, self-destructing links instead of showing them inline. Stand up a local Yopass via Docker, point the app at an existing Yopass, or leave it disabled (credentials are then shown inline, a supported configuration). See the [Yopass Administrator Guide](../configuration/yopass-administrators-guide/readme.md).
+Yopass lets the Admin App share newly created API client credentials as one-time, self-destructing links instead of showing them inline. Stand up a local Yopass via Docker, point the app at an existing Yopass, or leave it disabled (credentials are then shown inline, a supported configuration). See the [Yopass Administrator Guide](../../configuration/yopass-administrators-guide/readme.md).
 
 ### TLS and certificates
 
-_Automated by the deploy scripts: `05-deploy-api.ps1` / `06-deploy-fe.ps1` bind the certificate (a supplied `-CertificateThumbprint` / `-CertificatePfxPath`, or a generated self-signed one); `install-all.ps1` forwards the same parameters._
-
-Both IIS sites are served over HTTPS (API `:3443`, frontend `:4443`). Each also keeps an HTTP binding (`:3333` / `:4200`) that returns a 301 redirect to its HTTPS URL. The certificate is resolved in this order:
-
-1. **`-CertificateThumbprint`** — bind an existing certificate already in `LocalMachine\My`.
-2. **`-CertificatePfxPath`** + **`-CertificatePassword`** — import and bind a PFX you supply.
-3. **None supplied** — a **self-signed** certificate (CN/SAN `localhost` plus the machine name) is generated, bound, and added to `LocalMachine\Root` so local browsers trust it. Opt out of the trust step with `-SkipSelfSignedTrust`.
+Both IIS sites are served over HTTPS (API `:3443`, frontend `:4443`). Each also keeps an HTTP binding (`:3333` / `:4200`) that returns a 301 redirect to its HTTPS URL. Use a CA-issued certificate where you can; for local use, a self-signed certificate (CN/SAN `localhost` plus the machine name) is sufficient. Place the certificate in `LocalMachine\My` and bind it to each site's HTTPS binding.
 
 :::warning
 A self-signed certificate is auto-trusted **only on this machine**; other machines browsing to it still see a trust warning. Supply a real certificate (thumbprint or PFX) for anything beyond this host.
@@ -205,26 +120,16 @@ Then add an HTTPS binding to each IIS site (in IIS Manager, or with `New-WebBind
 
 ### Verify prerequisites
 
-Run the read-only diagnostic before continuing:
-
-```powershell
-.\00-check-prereqs.ps1
-```
-
-It reports IIS (and that it is version 10 or newer), the database, Node.js, build artifacts, and whether ports 3333, 4200, 3443, and 4443 are free. It does not check the identity provider.
+Before deploying, confirm the prerequisites above are in place and that the four ports the two sites use — **3333**, **4200**, **3443**, and **4443** — are free.
 
 ## Backend API Installation
-
-:::tip Automation shortcut
-The build (step 1) is automated by `04-build.ps1`; the deploy (steps 2-8) by `05-deploy-api.ps1`. Or follow the manual steps.
-:::
 
 The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP binding on port 3333 and an HTTPS binding on port 3443; the HTTP binding only 301-redirects to HTTPS. IIS hosts the Node.js process through the **httpPlatform handler** (reverse proxy), which comes from [IIS modules and configuration](#iis-modules).
 
 1. **Build the application**:
 
    :::note
-   Always install from a **stable release tag**, not the default `main` branch (which reflects active development). Use the **latest stable release tag** — the same release the automated `install-all.ps1` path resolves for you. Find it on the [Releases page](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-AdminApp/releases), then use it below.
+   Always install from a **stable release tag**, not the default `main` branch (which reflects active development). Find the **latest stable release tag** on the [Releases page](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-AdminApp/releases), then use it below.
    :::
 
    ```powershell
@@ -394,7 +299,7 @@ The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP 
 
 8. **Set the App-Pool npm cache (if npm runs under the pool)**:
 
-   `05-deploy-api.ps1` sets `NPM_CONFIG_CACHE` on the `EdFi-AdminApp-API` App Pool's environment (an IIS 10+ feature) and grants that identity write access, so npm has a writable cache scoped to the pool. If you configure manually and npm fails to write its cache, set that environment variable on the pool to a writable folder such as `C:\npm-cache`.
+   If npm runs under the App Pool and fails to write its cache, set `NPM_CONFIG_CACHE` on the `EdFi-AdminApp-API` App Pool's environment (an IIS 10+ feature) to a writable folder such as `C:\npm-cache`, and grant that identity write access.
 
 ### Critical success factors
 
@@ -403,13 +308,9 @@ The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP 
 - **`API_PORT` must read `HTTP_PLATFORM_PORT`.** httpPlatform assigns the loopback port at runtime; a hard-coded port makes IIS and Node disagree and the site returns 502.
 - **The HTTPS binding needs a certificate.** Without one bound to port 3443, the site cannot start over HTTPS. See [TLS and certificates](#tls-and-certificates).
 
-See the [Troubleshooting](../troubleshooting.md#backend-troubleshooting) section if you hit errors.
+See the [Troubleshooting](../../troubleshooting.md#backend-troubleshooting) section if you hit errors.
 
 ## Frontend Installation
-
-:::tip Automation shortcut
-The `.env` and build (steps 1-2) are automated by `04-build.ps1`; the deploy (steps 3-6) by `06-deploy-fe.ps1`. Or follow the manual steps.
-:::
 
 The frontend is a Vite single-page application, deployed as a second standalone IIS site, `EdFi-AdminApp-FE`, with an HTTP binding on port 4200 and an HTTPS binding on port 4443; the HTTP binding only 301-redirects to HTTPS.
 
@@ -514,10 +415,10 @@ The frontend is a Vite single-page application, deployed as a second standalone 
    :::
 
    :::note
-   If your web fonts fail to load (HTTP 404 for `.woff2` files), your IIS may be missing that MIME type. See [Troubleshooting](../troubleshooting.md#frontend-troubleshooting).
+   If your web fonts fail to load (HTTP 404 for `.woff2` files), your IIS may be missing that MIME type. See [Troubleshooting](../../troubleshooting.md#frontend-troubleshooting).
    :::
 
-See the [Troubleshooting](../troubleshooting.md#frontend-troubleshooting) section if you hit errors.
+See the [Troubleshooting](../../troubleshooting.md#frontend-troubleshooting) section if you hit errors.
 
 ## Security headers
 
@@ -532,7 +433,7 @@ The API additionally sets `X-Content-Type-Options` and `X-Frame-Options` in appl
 
 The default install is suitable for a local or trusted-network deployment. Before exposing the Admin App more broadly:
 
-- **Use a CA-issued certificate.** The default self-signed certificate is trusted only on the install host. Bind a real certificate (`-CertificateThumbprint` or `-CertificatePfxPath`) so other machines trust the sites without warnings.
+- **Use a CA-issued certificate.** The default self-signed certificate is trusted only on the install host. Bind a CA-issued certificate (see [TLS and certificates](#tls-and-certificates)) so other machines trust the sites without warnings.
 - **Do not run the example Keycloak in production.** The local Keycloak example runs in `start-dev` (HTTP, embedded H2 database, hostname strictness off) and is for local development only. For production, run `kc.bat start` with `--hostname`, a real database, and TLS — or use your own OIDC provider.
 - **Keep upstream TLS verification on.** `SSL_VERIFICATION` defaults to `true`, so the API verifies the certificate of the ODS/API and Admin API it calls. If an upstream presents a self-signed or dev certificate, make Node trust it rather than disabling verification:
   1. Export the upstream's certificate (or its issuing CA) to a PEM file (`.crt`/`.pem`).
@@ -540,29 +441,33 @@ The default install is suitable for a local or trusted-network deployment. Befor
   3. Restart the API site so Node re-reads the value.
 
   On Node 22.15+ you can instead set `NODE_OPTIONS=--use-system-ca`, which honors the Windows certificate store.
-- **Review secrets handling.** A manual install keeps credentials in `production.js`; a scripted `install-all.ps1` run keeps them in the API App Pool's environment and writes the generated encryption key to an ACL-restricted `install-summary.txt`. Protect or rotate them wherever they live, per your policy.
+- **Review secrets handling.** A manual install keeps credentials in `production.js`. Protect or rotate them per your policy.
 - **Harden the database and App Pool identities.** This guide already connects as a least-privilege SQL login (`edfi_adminapp`, not `sa`); keep that separation in production.
 
 ## Uninstall
 
-This works the same whether you installed with the scripts or by hand, as long as you used the site names, paths, and database name from this guide.
+To remove a manual install, reverse the steps:
 
-- `uninstall.ps1` removes the generic Admin App install: the `EdFi-AdminApp-API` and `EdFi-AdminApp-FE` sites, the App Pool, the deployed directories, the `sbaa` database, the dockerized PostgreSQL/Yopass stacks (if used), and the npm cache folder. It leaves Node.js, SQL Server, and IIS in place. It prompts for confirmation; pass `-Force` for a non-interactive run, and `-SaPassword` to drop the SQL Server database over SQL authentication.
-- `uninstall-keycloak.ps1` tears down the local Keycloak example: it stops the Keycloak process, deletes the Keycloak install directory, and unsets the machine `JAVA_HOME`. The JDK itself is left installed.
+- In IIS Manager, remove the `EdFi-AdminApp-API` and `EdFi-AdminApp-FE` sites and their App Pool.
+- Delete the deployed folders (for example `C:\inetpub\EdFi-AdminApp-API` and `C:\inetpub\EdFi-AdminApp-FE`), and the npm cache folder if you created one.
+- Drop the `sbaa` database and the `edfi_adminapp` login.
+- If you set up the local Keycloak example, stop its process, delete its install directory, and unset the machine `JAVA_HOME` (the JDK can stay installed).
+
+Node.js, SQL Server, and IIS can remain in place.
 
 ## Next steps
 
 The Admin App is now running, but it manages **Ed-Fi ODS/API** instances that run separately — this guide does not install an ODS/API. To start using the Admin App, sign in and connect a running ODS/API environment (ODS/API 6.x or 7.x) by its Discovery API URL.
 
 :::note First sign-in
-Open the frontend at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the seeded user — email `admin@example.com` (the `-AdminUsername` / `-TestUserEmail` default) and the password you passed as `-TestUserPassword`. This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
+Open the frontend at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the Keycloak user you created — its email must match `ADMIN_USERNAME` in `production.js` (default `admin@example.com`). This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
 :::
 
 :::note
 If the ODS/API or Admin API presents a self-signed or dev certificate — common for a local ODS/API — adding an Environment fails with a certificate error (`DEPTH_ZERO_SELF_SIGNED_CERT`) in the API log (`logs\node-stdout.log`). Make Node trust the upstream certificate via `NODE_EXTRA_CA_CERTS`; see [Production considerations](#production-considerations).
 :::
 
-- [Configuring Ed-Fi Admin App](../configuration/configuring-admin-app.md)
-- [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
-- [Security Considerations](../configuration/security-considerations.md)
-- [Global Administration Tasks](../configuration/global-administration-tasks.md)
+- [Configuring Ed-Fi Admin App](../../configuration/configuring-admin-app.md)
+- [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md)
+- [Security Considerations](../../configuration/security-considerations.md)
+- [Global Administration Tasks](../../configuration/global-administration-tasks.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -14,9 +14,9 @@ Prepare the following on the Windows host before deploying the API and Web Appli
 - **[IIS modules](#iis-modules)** — the URL Rewrite Module and an httpPlatform handler.
 - **[Database](#database)** — SQL Server (default) or PostgreSQL.
 - **[Node.js](#nodejs)** — the major version pinned in the Admin App's `package.json` (currently `>=22`).
-- **[Identity provider](../../configuration/identity-provider.md)** — an OIDC provider; this guide uses a local Keycloak example.
+- **[Identity provider](#identity-provider)** — an OIDC provider; this guide uses a local Keycloak example.
 - **[TLS certificate](#tls-and-certificates)** — a CA-issued certificate, or a self-signed one for local use.
-- **[Yopass](../../configuration/yopass-administrators-guide/readme.md)** (optional) — for one-time credential links.
+- **[Yopass](#yopass-optional)** (optional) — for one-time credential links.
 
 ### Operating system components (IIS, SQL Server, Git)
 
@@ -95,10 +95,24 @@ Register these in the Keycloak client (HTTPS, matching the default ports):
 - Post-logout redirect URI: `https://localhost:3443/api/auth/post-logout`
 - Web origin: `https://localhost:4443`
 
-`<oidc-id>` is the id of the row in the `oidc` database table (it is not always `1`; resolve it from that table). A user must exist in Keycloak whose email/username claim matches the Admin App admin user (default `admin@example.com`). Java is required **only** for the local Keycloak example.
+`<oidc-id>` is the `id` of the row in the Admin App's `oidc` table. That row does not exist yet — the API creates it on its first start from `SAMPLE_OIDC_CONFIG` in `production.js`, and only if the table is empty. On a clean install the id is `1`, so register `1` here. After the API is running, confirm it with `SELECT id FROM oidc;`; if it differs, update this redirect URI and `VITE_OIDC_ID`, which requires rebuilding the Web Application.
+
+A user must exist in Keycloak whose email/username claim matches the Admin App admin user (default `admin@example.com`). Java is required **only** for the local Keycloak example.
 :::
 
 For more detail, see [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md).
+
+:::warning Keycloak does not survive a restart on its own
+A locally installed Keycloak does not come back when the host restarts. The API needs Keycloak already running when the API starts, so it has to start **after** Keycloak is accepting requests. If the API starts first, sign-in fails until the API is recycled.
+
+On a manual install, arrange both after every restart:
+
+1. Start Keycloak.
+2. Wait until its OIDC discovery endpoint responds.
+3. Recycle the `EdFi-AdminApp-API` App Pool.
+
+The [Automated](./automated.md#after-a-restart-the-keycloak-startup-task) and [Semi-automated](./semi-automated.md) paths register a startup scheduled task that performs these three steps, which is the simplest way to cover it. This applies only to a local Keycloak: an external identity provider needs nothing started on this host.
+:::
 
 ### Yopass (optional)
 
@@ -112,14 +126,14 @@ Both IIS sites are served over HTTPS (API `:3443`, Web Application `:4443`). Eac
 A self-signed certificate is auto-trusted **only on this machine**; other machines browsing to it still see a trust warning. Supply a real certificate (thumbprint or PFX) for anything beyond this host.
 :::
 
-To configure TLS manually, generate or obtain a certificate and place it in `LocalMachine\My`. For a self-signed certificate (local use), from an elevated PowerShell:
+To create a self-signed certificate for local use, from an elevated PowerShell:
 
 ```powershell
 New-SelfSignedCertificate -DnsName 'localhost', $env:COMPUTERNAME `
   -CertStoreLocation Cert:\LocalMachine\My -FriendlyName 'Ed-Fi Admin App'
 ```
 
-Then add an HTTPS binding to each IIS site (in IIS Manager, or with `New-WebBinding` + `New-Item IIS:\SslBindings`), selecting that certificate.
+Then add an HTTPS binding to each IIS site in IIS Manager, selecting that certificate.
 
 ### Verify prerequisites
 
@@ -334,7 +348,7 @@ The Web Application is a Vite single-page application, deployed as a second stan
 
    **Environment variable descriptions:**
    - `VITE_API_URL`: Backend API endpoint (the API site's HTTPS URL, `https://localhost:3443`).
-   - `VITE_OIDC_ID`: OpenID Connect configuration ID from the database (the id of the `oidc` row; must match the redirect-URI callback id).
+   - `VITE_OIDC_ID`: OpenID Connect configuration ID from the database — the `id` of the `oidc` row, which must match the id in the Keycloak redirect URI. See [Identity provider](#identity-provider) for how that row is created and how to confirm the id.
    - `VITE_BASE_PATH`: URL path the app is served from. Keep it `"/"`: the Web Application is served from the root of its own site.
    - `VITE_HELP_GUIDE`: URL to general help documentation.
    - `VITE_STARTING_GUIDE`: URL to the getting-started / system administrator guide.
@@ -432,6 +446,10 @@ Both IIS sites emit a baseline set of response headers (shown in each site's `we
 
 The API additionally sets `X-Content-Type-Options` and `X-Frame-Options` in application code. Adjust these headers if you place the sites behind a reverse proxy that sets its own.
 
+## First sign-in
+
+Open the Web Application at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the Keycloak user you created — its email must match `ADMIN_USERNAME` in `production.js` (default `admin@example.com`). This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
+
 ## Production considerations
 
 The default install is suitable for a local or trusted-network deployment. Before exposing the Admin App more broadly:
@@ -461,10 +479,6 @@ Node.js, SQL Server, and IIS can remain in place.
 ## Next steps
 
 The Admin App is now running, but it manages **Ed-Fi ODS/API** instances that run separately — this guide does not install an ODS/API. To start using the Admin App, sign in and connect a running ODS/API environment (ODS/API 6.x or 7.x) by its Discovery API URL.
-
-:::note First sign-in
-Open the Web Application at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the Keycloak user you created — its email must match `ADMIN_USERNAME` in `production.js` (default `admin@example.com`). This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
-:::
 
 :::note
 If the ODS/API or Admin API presents a self-signed or dev certificate — common for a local ODS/API — adding an Environment fails with a certificate error (`DEPTH_ZERO_SELF_SIGNED_CERT`) in the API log (`logs\node-stdout.log`). Make Node trust the upstream certificate via `NODE_EXTRA_CA_CERTS`; see [Production considerations](#production-considerations).

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -54,13 +54,12 @@ Without unlocking the `handlers` section, requests to the API return **HTTP 500.
 
 The Admin App supports PostgreSQL 16+ and SQL Server 2017+, and needs only one. This guide uses **SQL Server** by default on Windows; PostgreSQL is available via Docker (requires Docker Desktop in Linux-container mode).
 
-For SQL Server:
+For SQL Server, run these steps as a Windows account that is a SQL Server sysadmin (Windows Authentication); the `sa` login is not required:
 
 1. Enable **Mixed Mode (SQL Server and Windows) authentication** (the Node `mssql` driver connects with SQL authentication).
 2. Enable the **TCP/IP** protocol and confirm it listens on port **1433** (the driver requires TCP).
-3. Enable the **`sa`** login and set a password. `sa` is used **only for setup** (enabling Mixed Mode and creating the database and app login); the Admin App itself does not connect as `sa`.
-4. Create an empty database. This guide uses the name **`sbaa`**.
-5. Create a dedicated least-privilege login for the Admin App to connect as. It is `db_owner` on the Admin App database **only** and holds no server-level role (it is not a sysadmin like `sa`). `db_owner` — rather than just `db_datareader`/`db_datawriter` — is required because the app creates and migrates its own schema on startup.
+3. Create an empty database. This guide uses the name **`sbaa`**.
+4. Create a dedicated least-privilege login for the Admin App to connect as. It is `db_owner` on the Admin App database **only** and holds no server-level role (it is not a sysadmin like `sa`). `db_owner` — rather than just `db_datareader`/`db_datawriter` — is required because the app creates and migrates its own schema on startup.
 
    ```sql
    CREATE LOGIN [edfi_adminapp] WITH PASSWORD = N'YourStrong!AppPassw0rd', CHECK_POLICY = ON;

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -8,7 +8,7 @@ This page documents the full manual Windows/IIS installation — every prerequis
 
 ## Windows Prerequisites
 
-Prepare the following on the Windows host before deploying the API and frontend. Each item is detailed in its own subsection below.
+Prepare the following on the Windows host before deploying the API and Web Application. Each item is detailed in its own subsection below.
 
 - **[Operating-system components](#operating-system-components-iis-sql-server-git)** — IIS (**version 10 or newer**), SQL Server, and, optionally, Git.
 - **[IIS modules](#iis-modules)** — the URL Rewrite Module and an httpPlatform handler.
@@ -36,7 +36,7 @@ Prepare the following on the Windows host before deploying the API and frontend.
 
 IIS hosts the Node.js API through the **httpPlatform handler**: IIS acts as a reverse proxy, launching the Node process (`main.js`) and forwarding requests to a loopback port it assigns via the `HTTP_PLATFORM_PORT` environment variable.
 
-1. Install the [IIS URL Rewrite Module](https://www.iis.net/downloads/microsoft/url-rewrite). It is used for the HTTP→HTTPS redirect and the frontend's SPA fallback.
+1. Install the [IIS URL Rewrite Module](https://www.iis.net/downloads/microsoft/url-rewrite). It is used for the HTTP→HTTPS redirect and the Web Application's SPA fallback.
 2. Install an httpPlatform handler. Two are compatible, and both register the same `httpPlatformHandler` module name:
    - **HttpBridge** — the [LeXtudio fork](https://github.com/lextudio/httpbridge) (MIT, actively maintained).
    - **Microsoft HttpPlatformHandler** — the [original v1.2](https://www.iis.net/downloads/microsoft/httpplatformhandler) (signed, stable, frozen since ~2016).
@@ -106,7 +106,7 @@ Yopass lets the Admin App share newly created API client credentials as one-time
 
 ### TLS and certificates
 
-Both IIS sites are served over HTTPS (API `:3443`, frontend `:4443`). Each also keeps an HTTP binding (`:3333` / `:4200`) that returns a 301 redirect to its HTTPS URL. Use a CA-issued certificate where you can; for local use, a self-signed certificate (CN/SAN `localhost` plus the machine name) is sufficient. Place the certificate in `LocalMachine\My` and bind it to each site's HTTPS binding.
+Both IIS sites are served over HTTPS (API `:3443`, Web Application `:4443`). Each also keeps an HTTP binding (`:3333` / `:4200`) that returns a 301 redirect to its HTTPS URL. Use a CA-issued certificate where you can; for local use, a self-signed certificate (CN/SAN `localhost` plus the machine name) is sufficient. Place the certificate in `LocalMachine\My` and bind it to each site's HTTPS binding.
 
 :::warning
 A self-signed certificate is auto-trusted **only on this machine**; other machines browsing to it still see a trust warning. Supply a real certificate (thumbprint or PFX) for anything beyond this host.
@@ -224,7 +224,7 @@ The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP 
    Copy `production.js-edfi` to `production.js` in `packages/api/config`, then set the values. The example below is a local SQL Server install with the local Keycloak example identity provider.
 
    ```javascript
-   // Frontend URL from the 'Frontend Installation' section (HTTPS).
+   // Web Application URL from the 'Web Application Installation' section (HTTPS).
    const FE_URL = 'https://localhost:4443';
 
    module.exports = {
@@ -270,7 +270,7 @@ The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP 
        scope: 'openid email profile',
      },
      USE_PKCE: true,
-     ADMIN_USERNAME: 'admin@example.com', // must match a user in your IdP
+     ADMIN_USERNAME: 'admin@example.com', // must match a user in your identity provider
 
      FE_URL: FE_URL,
      MY_URL: 'https://localhost:3443', // the API site's HTTPS URL
@@ -313,9 +313,9 @@ The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP 
 
 See the [Troubleshooting](../../troubleshooting.md#backend-troubleshooting) section if you hit errors.
 
-## Frontend Installation
+## Web Application Installation
 
-The frontend is a Vite single-page application, deployed as a second standalone IIS site, `EdFi-AdminApp-FE`, with an HTTP binding on port 4200 and an HTTPS binding on port 4443; the HTTP binding only 301-redirects to HTTPS.
+The Web Application is a Vite single-page application, deployed as a second standalone IIS site, `EdFi-AdminApp-FE`, with an HTTP binding on port 4200 and an HTTPS binding on port 4443; the HTTP binding only 301-redirects to HTTPS.
 
 1. **Configure the build-time environment (`.env`)**:
 
@@ -335,7 +335,7 @@ The frontend is a Vite single-page application, deployed as a second standalone 
    **Environment variable descriptions:**
    - `VITE_API_URL`: Backend API endpoint (the API site's HTTPS URL, `https://localhost:3443`).
    - `VITE_OIDC_ID`: OpenID Connect configuration ID from the database (the id of the `oidc` row; must match the redirect-URI callback id).
-   - `VITE_BASE_PATH`: URL path the app is served from. Keep it `"/"`: the frontend is served from the root of its own site.
+   - `VITE_BASE_PATH`: URL path the app is served from. Keep it `"/"`: the Web Application is served from the root of its own site.
    - `VITE_HELP_GUIDE`: URL to general help documentation.
    - `VITE_STARTING_GUIDE`: URL to the getting-started / system administrator guide.
    - `VITE_CONTACT`: URL to a community support or contact page.
@@ -346,7 +346,7 @@ The frontend is a Vite single-page application, deployed as a second standalone 
    These values are baked into the bundle at build time, so set `.env` **before** building (step 2); changing it afterward has no effect. For the local Keycloak example, `VITE_IDP_ACCOUNT_URL` is the account-management interface (`/realms/{realm-name}/account/`), not the admin console.
    :::
 
-2. **Build the frontend**:
+2. **Build the Web Application**:
 
    ```powershell
    # From the cloned repository
@@ -373,7 +373,7 @@ The frontend is a Vite single-page application, deployed as a second standalone 
 
 6. **Configure `web.config`**:
 
-   Create a `web.config` in the site folder. It redirects HTTP to HTTPS, falls back client-side routes to `index.html`, and sets the frontend's security headers.
+   Create a `web.config` in the site folder. It redirects HTTP to HTTPS, falls back client-side routes to `index.html`, and sets the Web Application's security headers.
 
    ```xml
    <?xml version="1.0" encoding="utf-8"?>
@@ -414,7 +414,7 @@ The frontend is a Vite single-page application, deployed as a second standalone 
    ```
 
    :::note
-   The `connect-src` in the Content-Security-Policy must name the exact API origin the bundle calls (`VITE_API_URL`), or the browser blocks the frontend's API requests. Here it is `https://localhost:3443`.
+   The `connect-src` in the Content-Security-Policy must name the exact API origin the bundle calls (`VITE_API_URL`), or the browser blocks the Web Application's API requests. Here it is `https://localhost:3443`.
    :::
 
    :::note
@@ -428,7 +428,7 @@ See the [Troubleshooting](../../troubleshooting.md#frontend-troubleshooting) sec
 Both IIS sites emit a baseline set of response headers (shown in each site's `web.config` above) and remove `X-Powered-By`. Both send `Strict-Transport-Security` (HSTS) and `Referrer-Policy`, and each carries an **enforcing** `Content-Security-Policy`:
 
 - **API** — `default-src 'none'`, since it serves only JSON in production (Swagger UI is disabled there).
-- **Frontend** — allows its own origin plus the API origin in `connect-src`; `style-src` allows `'unsafe-inline'` because the UI framework injects styles at runtime.
+- **Web Application** — allows its own origin plus the API origin in `connect-src`; `style-src` allows `'unsafe-inline'` because the UI framework injects styles at runtime.
 
 The API additionally sets `X-Content-Type-Options` and `X-Frame-Options` in application code. Adjust these headers if you place the sites behind a reverse proxy that sets its own.
 
@@ -463,7 +463,7 @@ Node.js, SQL Server, and IIS can remain in place.
 The Admin App is now running, but it manages **Ed-Fi ODS/API** instances that run separately — this guide does not install an ODS/API. To start using the Admin App, sign in and connect a running ODS/API environment (ODS/API 6.x or 7.x) by its Discovery API URL.
 
 :::note First sign-in
-Open the frontend at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the Keycloak user you created — its email must match `ADMIN_USERNAME` in `production.js` (default `admin@example.com`). This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
+Open the Web Application at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the Keycloak user you created — its email must match `ADMIN_USERNAME` in `production.js` (default `admin@example.com`). This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
 :::
 
 :::note

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -71,6 +71,10 @@ For SQL Server:
 
    This login and its password become `MSSQL_DB_USERNAME` / `MSSQL_DB_PASSWORD` in `production.js`. `CHECK_POLICY = ON` enforces the Windows password policy, so use a strong password (length ≥ 8 and at least 3 of: uppercase, lowercase, digit, symbol).
 
+:::warning
+Some special characters are not currently supported in the Admin App database username or password. Use only letters, digits, and these symbols: `! $ ( ) * , - . _ ~`. A value that includes other characters (for example `@ : / ? # % & = ;`, `"`, `< >`, `|`, or a space) can stop the API from connecting to the database at startup.
+:::
+
 :::note
 Installing the Admin App database in its own SQL Server instance, separate from the ODS/API databases (`EdFi_Admin`, `EdFi_Security`), is recommended.
 :::

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
@@ -1,0 +1,29 @@
+---
+sidebar_position: 1
+---
+
+# Windows IIS Installation
+
+This page describes how to install the Ed-Fi Admin App on Windows using Internet Information Services (IIS). It covers the backend API and the frontend single-page application, deployed as two standalone IIS sites over HTTPS.
+
+:::note
+This is one of three alternative installation paths. If you instead want to run the Admin App in containers or on a Unix-like server, see [Docker Compose Installation](../docker-installation.md) or [Unix-like Systems Installation](../unix-installation.md).
+:::
+
+## Before you start: decide three things
+
+1. **Database engine** — SQL Server (default) or PostgreSQL. You need only one.
+2. **Identity provider (IdP)** — the Admin App authenticates against an OIDC provider. This guide sets up **Keycloak**, running locally, as the example identity provider. The Admin App's auth engine uses generic OIDC discovery, but Keycloak is the identity provider documented for this release. See [Configuring an Identity Provider](../../configuration/identity-provider.md).
+3. **How much to automate** — pick one of the three installation paths below.
+
+:::info
+Both IIS sites are served over **HTTPS by default** — API on port **3443** and frontend on port **4443**. Each also keeps an HTTP binding (**3333** / **4200**) that returns a 301 redirect to its HTTPS URL. When no certificate is supplied, a self-signed certificate is generated and trusted on the local machine; supply a real certificate for anything beyond this host (see [TLS and certificates](./manual.md#tls-and-certificates)). **IIS 10 or newer is required.**
+:::
+
+## Installation paths
+
+Choose the path that fits how much you want to automate. All three produce the same two IIS sites.
+
+- **[Automated](./automated.md)** — the whole stack in one command (`setup-vm-prereqs.ps1`, then `install-all.ps1`). Best for a fresh machine or a quick stand-up.
+- **[Semi-automated](./semi-automated.md)** — automate some sections and hand-configure others, using the script-to-section map.
+- **[Manual](./manual.md)** — every step by hand, with the exact `web.config` and `production.js`. The authoritative reference for what gets configured.

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Windows IIS Installation
 
-This page describes how to install the Ed-Fi Admin App on Windows using Internet Information Services (IIS). It covers the backend API and the frontend single-page application, deployed as two standalone IIS sites over HTTPS.
+This page describes how to install the Ed-Fi Admin App on Windows using Internet Information Services (IIS). It covers the backend API and the Web Application, deployed as two standalone IIS sites over HTTPS.
 
 :::note
 This is one of three alternative installation paths. If you instead want to run the Admin App in containers or on a Unix-like server, see [Docker Compose Installation](../docker-installation.md) or [Unix-like Systems Installation](../unix-installation.md).
@@ -13,11 +13,11 @@ This is one of three alternative installation paths. If you instead want to run 
 ## Before you start: decide three things
 
 1. **Database engine** — SQL Server (default) or PostgreSQL. You need only one.
-2. **Identity provider (IdP)** — the Admin App authenticates against an OIDC provider. This guide sets up **Keycloak**, running locally, as the example identity provider. The Admin App's auth engine uses generic OIDC discovery, but Keycloak is the identity provider documented for this release. See [Configuring an Identity Provider](../../configuration/identity-provider.md).
+2. **Identity provider** — the Admin App authenticates against an OIDC provider. This guide sets up **Keycloak**, running locally, as the example identity provider. The Admin App's auth engine uses generic OIDC discovery, but Keycloak is the identity provider documented for this release. See [Configuring an Identity Provider](../../configuration/identity-provider.md).
 3. **How much to automate** — pick one of the three installation paths below.
 
 :::info
-Both IIS sites are served over **HTTPS by default** — API on port **3443** and frontend on port **4443**. Each also keeps an HTTP binding (**3333** / **4200**) that returns a 301 redirect to its HTTPS URL. When no certificate is supplied, a self-signed certificate is generated and trusted on the local machine; supply a real certificate for anything beyond this host (see [TLS and certificates](./manual.md#tls-and-certificates)). **IIS 10 or newer is required.**
+Both IIS sites are served over **HTTPS by default** — API on port **3443** and Web Application on port **4443**. Each also keeps an HTTP binding (**3333** / **4200**) that returns a 301 redirect to its HTTPS URL. When no certificate is supplied, a self-signed certificate is generated and trusted on the local machine; supply a real certificate for anything beyond this host (see [TLS and certificates](./manual.md#tls-and-certificates)). **IIS 10 or newer is required.**
 :::
 
 ## Installation paths

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Windows IIS Installation

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
@@ -17,7 +17,11 @@ This is one of three alternative installation paths. If you instead want to run 
 3. **How much to automate** — pick one of the three installation paths below.
 
 :::info
-Both IIS sites are served over **HTTPS by default** — API on port **3443** and Web Application on port **4443**. Each also keeps an HTTP binding (**3333** / **4200**) that returns a 301 redirect to its HTTPS URL. When no certificate is supplied, a self-signed certificate is generated and trusted on the local machine; supply a real certificate for anything beyond this host (see [TLS and certificates](./manual.md#tls-and-certificates)). **IIS 10 or newer is required.**
+Both IIS sites are served over **HTTPS by default** — API on port **3443** and Web Application on port **4443**. Each also keeps an HTTP binding (**3333** / **4200**) that returns a 301 redirect to its HTTPS URL. When no certificate is supplied, a self-signed certificate is generated and trusted on the local machine; supply a real certificate for anything beyond this host (see [TLS and certificates](./manual.md#tls-and-certificates)).
+:::
+
+:::info IIS version
+**IIS 10 or newer is required.** Windows Server 2019 and 2022, and Windows 10 and 11, all ship IIS 10. The API's configuration is passed to Node through environment variables set on its IIS App Pool, and App Pool environment variables are an IIS 10 feature. `00-check-prereqs.ps1` reports the IIS version it detects.
 :::
 
 ## Installation paths

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 3
+---
+
+# Semi-automated
+
+Automate some sections and hand-configure others — for example, script the prerequisites and the build, then deploy against an existing IIS setup by hand. Each script below automates one section; any script can be skipped in favor of the matching [Manual](./manual.md) steps.
+
+First clone the scripts (see [Automated](./automated.md#get-the-scripts)), then run the ones you want from an elevated PowerShell in `windows-install/`, in the order below.
+
+| Order | Script | What it automates | Manual section |
+| --- | --- | --- | --- |
+| 0 (fresh VM) | `setup-vm-prereqs.ps1` | OS-level installs: IIS feature set, SQL Server Developer, Git. Scans first, installs only what is missing; also sets the execution policy and unblocks the scripts. | [Windows Prerequisites](./manual.md#windows-prerequisites) |
+| 1 | `01-prereqs-iis.ps1` | URL Rewrite Module + the httpPlatform handler (HttpBridge by default, or Microsoft HttpPlatformHandler); unlocks the `handlers` configuration section. | [Windows Prerequisites](./manual.md#iis-modules) |
+| 2 | `02-prereqs-sql.ps1` | SQL Server Mixed Mode + TCP/IP + `sa`; creates the `sbaa` database and a dedicated least-privilege login (`edfi_adminapp`) the app connects as. | [Database](./manual.md#database) |
+| 3 | `03-prereqs-node.ps1` | Installs Node.js (the major version pinned in `engines.node`); remediates a too-old Node via nvm-windows. | [Node.js](./manual.md#nodejs) |
+| 4 | `04-build.ps1` | `npm ci` + build API + build frontend. Seeds the frontend `.env` before building. | [Backend API](./manual.md#backend-api-installation) / [Frontend](./manual.md#frontend-installation) |
+| 5 | `05-deploy-api.ps1` | Deploys the API as standalone site `EdFi-AdminApp-API` (HTTPS :3443; HTTP :3333 redirects): web.config, App Pool, `production.js`, App-Pool-scoped npm cache. | [Backend API](./manual.md#backend-api-installation) |
+| 6 | `06-deploy-fe.ps1` | Deploys the frontend as standalone site `EdFi-AdminApp-FE` (HTTPS :4443; HTTP :4200 redirects). | [Frontend](./manual.md#frontend-installation) |
+| verify | `00-check-prereqs.ps1` | Read-only diagnostic: IIS (and version), database, Node, build artifacts, and whether ports 3333/4200/3443/4443 are free. | [Verify prerequisites](./manual.md#verify-prerequisites) |
+| optional | `idp-keycloak-setup.ps1` | Installs a JDK, downloads and starts a local Keycloak, provisions realm `edfi`, client `edfiadminapp`, and a test user. | [Identity provider](./manual.md#identity-provider) |
+| optional | `idp-keycloak-start.ps1` | Restarts the local Keycloak (e.g. after a reboot). | [Identity provider](./manual.md#identity-provider) |
+| optional | `yopass-docker.ps1` | Stands up a local Yopass via Docker. | [Yopass](./manual.md#yopass-optional) |
+| optional | `install-all.ps1` | Runs the whole sequence end to end (see [Automated](./automated.md)). | (whole install) |
+
+To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and unsets `JAVA_HOME`; leaves the JDK installed).

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
@@ -14,16 +14,16 @@ On **Windows Server 2019/2022**, install the Windows Package Manager (`winget`) 
 
 | Order | Script | What it automates | Manual section |
 | --- | --- | --- | --- |
-| 0 (fresh VM) | `setup-vm-prereqs.ps1` | OS-level installs: IIS feature set, SQL Server Developer, Git. Scans first, installs only what is missing; also sets the execution policy and unblocks the scripts. | [Windows Prerequisites](./manual.md#windows-prerequisites) |
+| 0 (fresh virtual machine) | `setup-vm-prereqs.ps1` | Operating-system-level installs: IIS feature set, SQL Server Developer, Git. Scans first, installs only what is missing; also sets the execution policy and unblocks the scripts. | [Windows Prerequisites](./manual.md#windows-prerequisites) |
 | 1 | `01-prereqs-iis.ps1` | URL Rewrite Module + the httpPlatform handler (HttpBridge by default, or Microsoft HttpPlatformHandler); unlocks the `handlers` configuration section. | [Windows Prerequisites](./manual.md#iis-modules) |
 | 2 | `02-prereqs-sql.ps1` | SQL Server Mixed Mode + TCP/IP; creates the `sbaa` database and a dedicated least-privilege login (`edfi_adminapp`) the app connects as. Server setup uses Windows Authentication, not `sa`. | [Database](./manual.md#database) |
 | 3 | `03-prereqs-node.ps1` | Installs Node.js (the major version pinned in `engines.node`); remediates a too-old Node via nvm-windows. | [Node.js](./manual.md#nodejs) |
-| 4 | `04-build.ps1` | `npm ci` + build API + build frontend. Seeds the frontend `.env` before building. | [Backend API](./manual.md#backend-api-installation) / [Frontend](./manual.md#frontend-installation) |
+| 4 | `04-build.ps1` | `npm ci` + build API + build Web Application. Seeds the Web Application `.env` before building. | [Backend API](./manual.md#backend-api-installation) / [Web Application](./manual.md#web-application-installation) |
 | 5 | `05-deploy-api.ps1` | Deploys the API as standalone site `EdFi-AdminApp-API` (HTTPS :3443; HTTP :3333 redirects): web.config, App Pool, `production.js`, App-Pool-scoped npm cache. | [Backend API](./manual.md#backend-api-installation) |
-| 6 | `06-deploy-fe.ps1` | Deploys the frontend as standalone site `EdFi-AdminApp-FE` (HTTPS :4443; HTTP :4200 redirects). | [Frontend](./manual.md#frontend-installation) |
+| 6 | `06-deploy-fe.ps1` | Deploys the Web Application as standalone site `EdFi-AdminApp-FE` (HTTPS :4443; HTTP :4200 redirects). | [Web Application](./manual.md#web-application-installation) |
 | verify | `00-check-prereqs.ps1` | Read-only diagnostic: IIS (and version), database, Node, build artifacts, and whether ports 3333/4200/3443/4443 are free. | [Verify prerequisites](./manual.md#verify-prerequisites) |
 | optional | `idp-keycloak-setup.ps1` | Installs a JDK, downloads and starts a local Keycloak, provisions realm `edfi`, client `edfiadminapp`, and a test user. | [Identity provider](./manual.md#identity-provider) |
-| optional | `idp-keycloak-start.ps1` | Restarts the local Keycloak (e.g. after a reboot). | [Identity provider](./manual.md#identity-provider) |
+| optional | `idp-keycloak-start.ps1` | Restarts the local Keycloak (for example, after a reboot). | [Identity provider](./manual.md#identity-provider) |
 | optional | `yopass-docker.ps1` | Stands up a local Yopass via Docker. | [Yopass](./manual.md#yopass-optional) |
 | optional | `install-all.ps1` | Runs the whole sequence end to end (see [Automated](./automated.md)). | (whole install) |
 

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
@@ -8,6 +8,10 @@ Automate some sections and hand-configure others — for example, script the pre
 
 First clone the scripts (see [Automated](./automated.md#get-the-scripts)), then run the ones you want from an elevated PowerShell in `windows-install/`, in the order below.
 
+:::note
+On **Windows Server 2019/2022**, install the Windows Package Manager (`winget`) before running `setup-vm-prereqs.ps1` (it ships only on Windows 10/11). See [Automated → Windows Server prerequisite: install winget](./automated.md#windows-server-prerequisite-install-winget).
+:::
+
 | Order | Script | What it automates | Manual section |
 | --- | --- | --- | --- |
 | 0 (fresh VM) | `setup-vm-prereqs.ps1` | OS-level installs: IIS feature set, SQL Server Developer, Git. Scans first, installs only what is missing; also sets the execution policy and unblocks the scripts. | [Windows Prerequisites](./manual.md#windows-prerequisites) |

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
@@ -15,16 +15,16 @@ On **Windows Server 2019/2022**, install the Windows Package Manager (`winget`) 
 | Order | Script | What it automates | Manual section |
 | --- | --- | --- | --- |
 | 0 (fresh virtual machine) | `setup-vm-prereqs.ps1` | Operating-system-level installs: IIS feature set, SQL Server Developer, Git. Scans first, installs only what is missing; also sets the execution policy and unblocks the scripts. | [Windows Prerequisites](./manual.md#windows-prerequisites) |
-| 1 | `01-prereqs-iis.ps1` | URL Rewrite Module + the httpPlatform handler (HttpBridge by default, or Microsoft HttpPlatformHandler); unlocks the `handlers` configuration section. | [Windows Prerequisites](./manual.md#iis-modules) |
+| 1 | `01-prereqs-iis.ps1` | URL Rewrite Module + the httpPlatform handler (HttpBridge by default, or Microsoft HttpPlatformHandler); unlocks the `handlers` configuration section. | [IIS modules](./manual.md#iis-modules) |
 | 2 | `02-prereqs-sql.ps1` | SQL Server Mixed Mode + TCP/IP; creates the `sbaa` database and a dedicated least-privilege login (`edfi_adminapp`) the app connects as. Server setup uses Windows Authentication, not `sa`. | [Database](./manual.md#database) |
 | 3 | `03-prereqs-node.ps1` | Installs Node.js (the major version pinned in `engines.node`); remediates a too-old Node via nvm-windows. | [Node.js](./manual.md#nodejs) |
 | 4 | `04-build.ps1` | `npm ci` + build API + build Web Application. Seeds the Web Application `.env` before building. | [Backend API](./manual.md#backend-api-installation) / [Web Application](./manual.md#web-application-installation) |
 | 5 | `05-deploy-api.ps1` | Deploys the API as standalone site `EdFi-AdminApp-API` (HTTPS :3443; HTTP :3333 redirects): web.config, App Pool, `production.js`, App-Pool-scoped npm cache. | [Backend API](./manual.md#backend-api-installation) |
 | 6 | `06-deploy-fe.ps1` | Deploys the Web Application as standalone site `EdFi-AdminApp-FE` (HTTPS :4443; HTTP :4200 redirects). | [Web Application](./manual.md#web-application-installation) |
 | verify | `00-check-prereqs.ps1` | Read-only diagnostic: IIS (and version), database, Node, build artifacts, and whether ports 3333/4200/3443/4443 are free. | [Verify prerequisites](./manual.md#verify-prerequisites) |
-| optional | `idp-keycloak-setup.ps1` | Installs a JDK, downloads and starts a local Keycloak, provisions realm `edfi`, client `edfiadminapp`, and a test user. | [Identity provider](./manual.md#identity-provider) |
-| optional | `idp-keycloak-start.ps1` | Restarts the local Keycloak (for example, after a reboot). | [Identity provider](./manual.md#identity-provider) |
+| optional | `idp-keycloak-setup.ps1` | Installs a JDK, downloads and starts a local Keycloak, provisions realm `edfi`, client `edfiadminapp`, and a test user. Also registers the `Ed-Fi Admin App Keycloak` startup task (see [Automated → After a restart](./automated.md#after-a-restart-the-keycloak-startup-task)). | [Identity provider](./manual.md#identity-provider) |
+| optional | `idp-keycloak-start.ps1` | Starts the local Keycloak again without restarting the host. After a host restart the startup task does this automatically. | [Identity provider](./manual.md#identity-provider) |
 | optional | `yopass-docker.ps1` | Stands up a local Yopass via Docker. | [Yopass](./manual.md#yopass-optional) |
 | optional | `install-all.ps1` | Runs the whole sequence end to end (see [Automated](./automated.md)). | (whole install) |
 
-To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and unsets `JAVA_HOME`; leaves the JDK installed).
+To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and its startup task, and unsets `JAVA_HOME`; leaves the JDK installed).

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
@@ -12,7 +12,7 @@ First clone the scripts (see [Automated](./automated.md#get-the-scripts)), then 
 | --- | --- | --- | --- |
 | 0 (fresh VM) | `setup-vm-prereqs.ps1` | OS-level installs: IIS feature set, SQL Server Developer, Git. Scans first, installs only what is missing; also sets the execution policy and unblocks the scripts. | [Windows Prerequisites](./manual.md#windows-prerequisites) |
 | 1 | `01-prereqs-iis.ps1` | URL Rewrite Module + the httpPlatform handler (HttpBridge by default, or Microsoft HttpPlatformHandler); unlocks the `handlers` configuration section. | [Windows Prerequisites](./manual.md#iis-modules) |
-| 2 | `02-prereqs-sql.ps1` | SQL Server Mixed Mode + TCP/IP + `sa`; creates the `sbaa` database and a dedicated least-privilege login (`edfi_adminapp`) the app connects as. | [Database](./manual.md#database) |
+| 2 | `02-prereqs-sql.ps1` | SQL Server Mixed Mode + TCP/IP; creates the `sbaa` database and a dedicated least-privilege login (`edfi_adminapp`) the app connects as. Server setup uses Windows Authentication, not `sa`. | [Database](./manual.md#database) |
 | 3 | `03-prereqs-node.ps1` | Installs Node.js (the major version pinned in `engines.node`); remediates a too-old Node via nvm-windows. | [Node.js](./manual.md#nodejs) |
 | 4 | `04-build.ps1` | `npm ci` + build API + build frontend. Seeds the frontend `.env` before building. | [Backend API](./manual.md#backend-api-installation) / [Frontend](./manual.md#frontend-installation) |
 | 5 | `05-deploy-api.ps1` | Deploys the API as standalone site `EdFi-AdminApp-API` (HTTPS :3443; HTTP :3333 redirects): web.config, App Pool, `production.js`, App-Pool-scoped npm cache. | [Backend API](./manual.md#backend-api-installation) |

--- a/docs/reference/5-admin-app/maintenance.md
+++ b/docs/reference/5-admin-app/maintenance.md
@@ -76,7 +76,10 @@ The application provides health check endpoints:
    
    # Update code
    cd /opt/edfiadminapp
-   git pull origin main
+   # Check out the latest stable release tag (not main, which is active development).
+   # See the Releases page: https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-AdminApp/releases
+   git fetch --tags
+   git checkout v4.0.1  # replace with the latest release tag
    npm ci
    npm run build:api
    npm run build:fe

--- a/docs/reference/5-admin-app/readme.md
+++ b/docs/reference/5-admin-app/readme.md
@@ -10,8 +10,11 @@ and API health across diverse user roles and deployment models.
 
 Documentation for the Ed-Fi Admin App is viewable online:
 
-* [What's New](./whats-new.md)
-* [Getting Started](./getting-started/readme.md)
+- [What's New](./whats-new.md)
+- [Getting Started](./getting-started/readme.md)
+- [Configuration](./configuration/configuring-admin-app.md)
+- [Troubleshooting](./troubleshooting.md)
+- [Maintenance](./maintenance.md)
 
 ## Target Audiences
 
@@ -22,5 +25,5 @@ to delegate some maintenance tasks to local education agency staff.
 
 Accordingly, there are two perspectives to the application documentation:
 
-* [Getting Started](./getting-started/readme.md)
-* [User's Guide](./user-guide/readme.md)
+- [Getting Started](./getting-started/readme.md)
+- [User's Guide](./user-guide/readme.md)

--- a/docs/reference/5-admin-app/troubleshooting.md
+++ b/docs/reference/5-admin-app/troubleshooting.md
@@ -6,232 +6,86 @@ sidebar_position: 6
 
 ## Backend Troubleshooting
 
-**Common Issues and Solutions:**
+The API is hosted in IIS through the **httpPlatform handler**: IIS launches the
+Node process (`main.js`) and forwards requests to a loopback port it assigns via
+`HTTP_PLATFORM_PORT`. Most backend failures surface in the Node stdout log at
+`logs\node-stdout.log` under the API site folder (for example
+`C:\inetpub\EdFi-AdminApp-API\logs\`). Start there.
 
-**Node.js Executable Not Found:**
+**HTTP 500.19 — configuration locked:**
 
-- **Error**: "The iisnode module is unable to start the node.exe process..."
-- **Cause**: IIS cannot find the Node.js executable
-- **Solution**:
-  1. **Find your Node.js installation path**:
+- **Cause**: the `system.webServer/handlers` section is locked at the server
+  level, so the `httpPlatformHandler` mapping in the site's `web.config` cannot
+  be applied.
+- **Solution**: unlock it from an elevated PowerShell, then retry:
 
-     ```powershell
-     # Check where Node.js is installed
-     where node
-     
-     # Or check the version and default location
-     node --version
-     # Default locations:
-     # C:\Program Files\nodejs\node.exe (standard installation)
-     # C:\Program Files (x86)\nodejs\node.exe (32-bit installation)
-     ```
-  
-  2. **Update the `nodeProcessCommandLine` in web.config**:
-
-     ```xml
-     <!-- For standard Node.js installation -->
-     nodeProcessCommandLine="C:\Program Files\nodejs\node.exe"
-     
-     <!-- For NVM (Node Version Manager) installation -->
-     nodeProcessCommandLine="%APPDATA%\nvm\v18.17.0\node.exe"
-     <!-- Replace v18.17.0 with your actual Node.js version -->
-     ```
-  
-  3. **For NVM (Node Version Manager) users**:
-
-     **Find your current Node.js version and path:**
-
-     ```powershell
-     # Check your current Node.js version
-     node --version
-     
-     # Check nvm list to see installed versions
-     nvm list
-     
-     # Check the exact path
-     where node
-     ```
-
-     **Common NVM paths:**
-     - `%APPDATA%\nvm\v{version}\node.exe` (nvm-windows)
-     - `C:\Users\{username}\AppData\Roaming\nvm\v{version}\node.exe` (full path)
-     - `%NVM_HOME%\v{version}\node.exe` (if NVM_HOME is set)
-
-     **Example for Node.js v18.17.0:**
-
-     ```xml
-     nodeProcessCommandLine="%APPDATA%\nvm\v18.17.0\node.exe"
-     ```
-
-     **Alternative approach for NVM - Use symlink:**
-
-     ```xml
-     <!-- If nvm creates a symlink (some nvm versions do this) -->
-     nodeProcessCommandLine="%APPDATA%\nvm\nodejs\node.exe"
-     ```
-
-  4. **Alternative locations to check**:
-     - `C:\Program Files\nodejs\node.exe` (standard installation)
-     - `C:\Program Files (x86)\nodejs\node.exe` (32-bit)
-     - `%APPDATA%\nvm\v{version}\node.exe` (nvm-windows)
-     - `%APPDATA%\npm\node.exe` (npm global installations)
-     - Custom installation directory
-
-**Duplicate MIME Type Error:**
-
-- **Error**: "Cannot add duplicate collection entry of type 'mimeMap' with unique key attribute 'fileExtension' set to '.json'"
-- **Cause**: IIS already has a MIME type mapping for `.json` files
-- **Solution**: Use the `<remove>` element before adding the MIME type:
-
-  ```xml
-  <staticContent>
-    <!-- Remove existing .json mapping if it exists, then add our own -->
-    <remove fileExtension=".json" />
-    <mimeMap fileExtension=".json" mimeType="application/json" />
-  </staticContent>
+  ```powershell
+  & "$env:SystemRoot\System32\inetsrv\appcmd.exe" unlock config -section:system.webServer/handlers
   ```
 
-**HTTP Error 403.14 - Forbidden:**
+  See [IIS modules and configuration](./getting-started/windows-iis-installation.md#iis-modules).
 
-- **Cause**: IIS cannot find the default document or directory browsing is disabled
-- **Solution**:
-  1. Ensure `web.config` is in the same directory as `main.js`
-  2. Verify the `<defaultDocument>` section includes `main.js`
-  3. Check that the physical path in IIS points to the directory containing `main.js`
-  4. Verify iisnode is properly installed and the handler is registered
+**HTTP 502.5 — process failure (Node not machine-wide):**
 
-**HTTP Error 404.0 - Not Found for `/api` routes:**
+- **Cause**: `processPath` points at a `node.exe` under a user profile (an
+  nvm-windows default). The App Pool virtual account (`IIS APPPOOL\EdFi-AdminApp-API`)
+  cannot execute it.
+- **Solution**: install Node.js machine-wide (`C:\Program Files\nodejs\node.exe`)
+  and set `processPath` to that path in `web.config`.
 
-- **Cause**: Requests aren't being routed through the Node.js application
-- **Solution**:
-  1. The updated `web.config` above includes rewrite rules to handle this
-  2. Ensure the `<rewrite>` section is present (this is different from URL Rewrite module)
-  3. Verify that all API requests go through `main.js`
+**HTTP 502 — IIS and Node disagree on the port:**
 
-**Testing Your Deployment:**
+- **Cause**: `API_PORT` is hard-coded instead of reading the port httpPlatform assigns.
+- **Solution**: set `API_PORT: process.env.HTTP_PLATFORM_PORT || 3333` in `production.js`.
 
-1. **Test the root endpoint**: `http://localhost:3333/` should return your Node.js application response
-2. **Test API endpoints**: `http://localhost:3333/api/` should work for API routes
-3. **Test Swagger**: `http://localhost:3333/api/` should show the Swagger documentation if enabled
-4. **Check iisnode logs**: Look in the `iisnode` folder for detailed error logs
+**Site will not start over HTTPS:**
 
-**Debugging Steps:**
+- **Cause**: no certificate is bound to the HTTPS port (3443 API, 4443 frontend).
+- **Solution**: bind a certificate to the site's HTTPS binding (a self-signed one
+  is fine for local use). See [TLS and certificates](./getting-started/windows-iis-installation.md#tls-and-certificates).
 
-1. **Enable detailed errors** in the `web.config` (already enabled in the config above):
+**Adding an Environment fails with a certificate error:**
 
-   ```xml
-   debuggingEnabled="true"
-   devErrorsEnabled="true"
-   ```
+- **Error**: `DEPTH_ZERO_SELF_SIGNED_CERT` (or a similar TLS error) in
+  `logs\node-stdout.log` when connecting an ODS/API or Admin API.
+- **Cause**: `SSL_VERIFICATION` is on (the secure default) and the upstream
+  presents a self-signed or dev certificate Node does not trust.
+- **Solution**: make Node trust the upstream certificate via `NODE_EXTRA_CA_CERTS`
+  rather than disabling verification. See [Production considerations](./getting-started/windows-iis-installation.md#production-considerations).
 
-2. **Check Windows Event Viewer**: Look for IIS and iisnode related errors
+**"NODE_ENV value of 'production' did not match any deployment config file names":**
 
-3. **Verify file permissions**: Ensure IIS has read access to your application files
+- **Cause**: the app runs with `NODE_ENV=production` but no `production.js` exists
+  in `packages/api/config`.
+- **Solution**: create `production.js` from the `production.js-edfi` template. The
+  `web.config` sets `NODE_ENV=production` through httpPlatform's `environmentVariables`.
 
-4. **Test Node.js directly**: Before deploying to IIS, test that `node main.js` works locally
+**Database password error ("client password must be a string"):**
 
-**Configuration Issues:**
-
-**NODE_ENV Configuration Warning:**
-
-- **Warning**: "NODE_ENV value of 'production' did not match any deployment config file names"
-- **Cause**: Application running in production mode but no production.js config file exists
-- **Solutions**:
-  1. **Use development mode** in web.config:
-
-     ```xml
-     node_env="development"
-     ```
-
-  2. **Create production.js** config file in the config directory with production settings
-  3. **Add promoteServerVars** to ensure environment variables are passed:
-
-     ```xml
-     promoteServerVars="NODE_ENV"
-     ```
-
-**Database Password Error:**
-
-- **Error**: "SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string"
-- **Cause**: PostgreSQL password not being passed as a proper string
-- **Solution**: Ensure all database credentials in config are strings:
+- **Error**: `SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string` (PostgreSQL).
+- **Cause**: a database credential is not a string.
+- **Solution**: ensure every value in `DB_SECRET_VALUE` is a string:
 
   ```javascript
   DB_SECRET_VALUE: {
     DB_HOST: 'localhost',
     DB_PORT: 5432,
-    DB_USERNAME: 'postgres',
+    DB_USERNAME: 'edfiadminapp',
     DB_DATABASE: 'sbaa',
-    DB_PASSWORD: 'postgres',  // Ensure this is a string
+    DB_PASSWORD: 'your_secure_password', // must be a string
   }
   ```
 
-### Proven Working Configuration
+**Testing the deployment:**
 
-The following configuration has been **tested and verified** to work successfully:
-
-**Essential Components:**
-
-1. **iisnode** installed and registered as an IIS module
-2. **Handler mapping** configured in IIS Manager (not web.config) with path `*`
-3. **URL Rewrite rules** in web.config for proper request routing
-4. **Proper permissions** for IIS App Pool user on application directory
-
-**This minimal web.config configuration is known to work:**
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <system.webServer>
-    <!-- URL Rewrite rules - THE KEY TO SUCCESS -->
-    <rewrite>
-      <rules>
-        <rule name="NodeJS" stopProcessing="true">
-          <match url=".*"/>
-          <conditions logicalGrouping="MatchAll">
-            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true"/>
-            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true"/>
-          </conditions>
-          <action type="Rewrite" url="main.js"/>
-        </rule>
-      </rules>
-    </rewrite>
-    
-    <iisnode 
-      nodeProcessCommandLine="node.exe"
-      loggingEnabled="true"
-      debuggingEnabled="true"
-      devErrorsEnabled="true"
-      node_env="development" />
-      
-    <defaultDocument>
-      <files>
-        <add value="main.js"/>
-      </files>
-    </defaultDocument>
-    
-    <httpErrors errorMode="Detailed"/>
-  </system.webServer>
-</configuration>
-```
-
-### Advantages of Direct IIS Deployment
-
-- **Direct integration**: Node.js runs directly within IIS worker process
-- **Better error handling**: iisnode provides detailed error logging
-- **Process management**: IIS handles process recycling and monitoring
-- **Native Windows integration**: Works seamlessly with Windows authentication and security
-
-### Considerations
-
-- **URL Rewrite dependency**: Requires URL Rewrite rules for proper routing (not the URL Rewrite module)
-- **Handler configuration**: Must be done via IIS Manager due to security restrictions
-- **Port binding**: The application uses the port configured in IIS, accessed via `process.env.PORT`
-- **Logging**: iisnode provides its own logging mechanism in addition to your application logs
+- Browse to `https://localhost:3443/api/healthcheck`; it should return a healthy
+  response. The HTTP binding (`http://localhost:3333`) should 301-redirect to HTTPS.
+- Check `logs\node-stdout.log` first for any startup error.
 
 ### Build errors
 
-Check configuration file `production.js` or `local.js` variables are set correctly. Sometimes you need to execute `nx reset` in order to get a new build without caching files. You can include the command in yout `package.json` as `cache: nx reset` and then use it `npm run cache`
+Check that the `production.js` (or `local.js`) values are set correctly. If a
+stale build cache causes problems, run `nx reset` to clear it before rebuilding.
 
 ## Frontend Troubleshooting
 
@@ -241,7 +95,7 @@ Check configuration file `production.js` or `local.js` variables are set correct
 
 - **Error**: "Cannot add duplicate collection entry of type 'mimeMap' with unique key attribute 'fileExtension' set to '.json'"
 - **Cause**: IIS already has MIME type mappings for certain file extensions
-- **Solution**: Use `<remove>` elements before `<mimeMap>` elements as shown in the web.config above
+- **Solution**: Use `<remove>` elements before `<mimeMap>` elements (see the `.woff2` example below)
 
 **React Router 404 Errors:**
 
@@ -249,11 +103,20 @@ Check configuration file `production.js` or `local.js` variables are set correct
 - **Cause**: IIS tries to serve routes as static files instead of letting React Router handle them
 - **Solution**: Ensure the URL Rewrite rule for React Routes is properly configured
 
-**Static Asset Loading Issues:**
+**Static Asset Loading Issues (fonts / `.woff2` return 404):**
 
-- **Symptom**: CSS, JS, or font files return 404 or MIME type errors
-- **Cause**: Missing or incorrect MIME type mappings
-- **Solution**: Add proper MIME type mappings in the `<staticContent>` section
+- **Symptom**: CSS, JS, or font files (commonly `.woff2`) return 404 or a wrong MIME type
+- **Cause**: The IIS install is missing a MIME type mapping for the extension. Some IIS versions do not register `.woff2` by default
+- **Solution**: Add the missing MIME types to the frontend site's `web.config`, inside `<system.webServer>`. Use `<remove>` before each `<mimeMap>` to avoid a duplicate-entry error (HTTP 500.19) if IIS already defines it:
+
+  ```xml
+  <staticContent>
+    <remove fileExtension=".woff" />
+    <remove fileExtension=".woff2" />
+    <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+    <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+  </staticContent>
+  ```
 
 **API Communication Errors:**
 

--- a/docs/reference/5-admin-app/troubleshooting.md
+++ b/docs/reference/5-admin-app/troubleshooting.md
@@ -23,7 +23,7 @@ Node process (`main.js`) and forwards requests to a loopback port it assigns via
   & "$env:SystemRoot\System32\inetsrv\appcmd.exe" unlock config -section:system.webServer/handlers
   ```
 
-  See [IIS modules and configuration](./getting-started/windows-iis-installation.md#iis-modules).
+  See [IIS modules and configuration](./getting-started/windows-iis-installation/manual.md#iis-modules).
 
 **HTTP 502.5 — process failure (Node not machine-wide):**
 
@@ -42,7 +42,7 @@ Node process (`main.js`) and forwards requests to a loopback port it assigns via
 
 - **Cause**: no certificate is bound to the HTTPS port (3443 API, 4443 frontend).
 - **Solution**: bind a certificate to the site's HTTPS binding (a self-signed one
-  is fine for local use). See [TLS and certificates](./getting-started/windows-iis-installation.md#tls-and-certificates).
+  is fine for local use). See [TLS and certificates](./getting-started/windows-iis-installation/manual.md#tls-and-certificates).
 
 **Adding an Environment fails with a certificate error:**
 
@@ -51,7 +51,7 @@ Node process (`main.js`) and forwards requests to a loopback port it assigns via
 - **Cause**: `SSL_VERIFICATION` is on (the secure default) and the upstream
   presents a self-signed or dev certificate Node does not trust.
 - **Solution**: make Node trust the upstream certificate via `NODE_EXTRA_CA_CERTS`
-  rather than disabling verification. See [Production considerations](./getting-started/windows-iis-installation.md#production-considerations).
+  rather than disabling verification. See [Production considerations](./getting-started/windows-iis-installation/manual.md#production-considerations).
 
 **"NODE_ENV value of 'production' did not match any deployment config file names":**
 


### PR DESCRIPTION
## Summary

Rewrites the Windows IIS installation guide to match the current Admin App v4 install scripts and aligns the surrounding reference docs with what the scripts actually deploy (HTTPS by default, httpPlatform hosting, least-privilege DB login, enforcing security headers). Also clarifies which database engine each installation path supports.

## Tickets

- [[EDFI-2779](https://edfi.atlassian.net/browse/EDFI-2779)] Windows Server Installation Guide
- [[EDFI-2791](https://edfi.atlassian.net/browse/EDFI-2791)] Clarify database support for each OS

## What changed

**Windows IIS guide (EDFI-2779)** — rewritten to match the scripts:
- Two IIS sites over **HTTPS** (API `:3443`, FE `:4443`), HTTP bindings redirect; **httpPlatform handler** (HttpBridge) replacing iisnode.
- New `web.config` for both sites, `production.js`/`.env` aligned (`edfi_adminapp` least-privilege login, `API_PORT` from `HTTP_PLATFORM_PORT`, `SSL_VERIFICATION`).
- TLS-by-default with a self-signed fallback; enforcing security-headers section.
- Scripted and manual paths documented side by side; a runnable `install-all.ps1` example (SecureString passwords, `-AppDbPassword`) and a first sign-in note.
- Identity provider scoped to the Keycloak example for this release.

**Reference-doc alignment (EDFI-2779)** — brought in line with the v4 scripts:
- Troubleshooting rewritten from iisnode to the httpPlatform hosting model.
- `configuring-admin-app`: fixed the `ENABLE_OPEN_API` key, corrected DB encryption key length (64 hex chars), de-duplicated frontend build-time variables, fixed the OIDC config table name (`oidc`).
- OIDC callback URIs use the configured provider id.
- Security "Built-in Protections" made installer-neutral; maintenance now updates via a release tag, not `git pull origin main`.

**Database engine support per path (EDFI-2791):**
- Docker Compose: both engines (PostgreSQL default; SQL Server via `DB_ENGINE=mssql` + `-MSSQL`).
- Unix-like: PostgreSQL.
- Windows IIS: SQL Server (default) and PostgreSQL via Docker.


<img width="1599" height="806" alt="image" src="https://github.com/user-attachments/assets/51398e8a-581e-4b20-8aa1-e296dbb49c1f" />


## Validation

- `markdownlint` clean; Docusaurus build passes (no broken internal links).
- The companion install scripts were validated end-to-end on Windows/IIS.

## Related

- Install scripts PR: Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts#2

## Out of scope / follow-ups

- Microsoft Entra ID and Google Workspace provider docs → [EDFI-2794](https://edfi.atlassian.net/browse/EDFI-2794) (after the Admin App v4.1 release, when those providers are officially supported).

[EDFI-2779]: https://edfi.atlassian.net/browse/EDFI-2779
[EDFI-2791]: https://edfi.atlassian.net/browse/EDFI-2791
[EDFI-2794]: https://edfi.atlassian.net/browse/EDFI-2794