### PR TITLE
[CERT-260] Fix SEORA v5 scenario description and example table

### DIFF
--- a/docs/partners/2-certification/available-certifications/sis-v5/test-scenarios/student-ed-org-responsibility-association-scenarios.md
+++ b/docs/partners/2-certification/available-certifications/sis-v5/test-scenarios/student-ed-org-responsibility-association-scenarios.md
@@ -19,21 +19,23 @@ relationship with an EducationOrganization. Enrollment relationship semantics ar
 
 ## Scenarios
 
-1. Create a second Student EdOrg Responsibility Association for an elementary Student at Grand Bend
-   School District.
-2. Update the responsibility descriptor on the student.
+1. Create a first Student EdOrg Responsibility Association for an elementary Student at Grand Bend
+   Elementary School District.
+2. Create a second Student EdOrg Responsibility Association for the same elementary Student at Grand
+   Bend High School District.
+3. Update the endDate on the Grand Bend High School District association.
 
 ### Additional Notes
 
 * A SEORA is written when the responsibility for a student is a different education organization than the enrollment school in the SSA.
 * The BeginDate and EndDate of the SEORA should be informed by the EntryDate and ExitWithdrawDate of a student’s SSA(s). There may be circumstances when they may be legitimately different.
 
-| Resource                                                           | Property Name                           | Is Collection | Data Type                             | Required    | Scenario 1: POST                         | Scenario 2: POST                         |
-| ------------------------------------------------------------------ | --------------------------------------- | ------------- | ------------------------------------- | ----------- | ---------------------------------------- | ---------------------------------------- |
-| StudentEducationOrganizationResponsibilityAssociations             | educationOrganizationReference          | FALSE         | educationOrganizationReference        | REQUIRED    |                                          |                                          |
-| educationOrganizationReference                                     | educationOrganizationId                 | FALSE         | integer                               | REQUIRED    | 255901                                   | 255901                                   |
-| StudentEducationOrganizationResponsibilityAssociations             | studentReference                        | FALSE         | studentReference                      | REQUIRED    |                                          |                                          |
-| studentReference                                                   | studentUniqueId                         | FALSE         | string                                | REQUIRED    | 111111                                   | 222222                                   |
-| StudentEducationOrganizationResponsibilityAssociations             | beginDate                               | FALSE         | string                                | REQUIRED    | [current school year]-08-23              | [current school year]-08-23              |
-| StudentEducationOrganizationResponsibilityAssociations             | responsibilityDescriptor                | FALSE         | string                                | REQUIRED    | Residency                                | Individualized Education Program         |
-| StudentEducationOrganizationResponsibilityAssociations             | endDate                                 | FALSE         | string                                | REQUIRED    | [current school year]-06-01              | [current school year]-06-01              |
+| Resource                                                           | Property Name                           | Is Collection | Data Type                             | Required    | Scenario 1: POST                         | Scenario 2: POST                         | Scenario 3: PUT                          |
+| ------------------------------------------------------------------ | --------------------------------------- | ------------- | ------------------------------------- | ----------- | ---------------------------------------- | ---------------------------------------- | ---------------------------------------- |
+| StudentEducationOrganizationResponsibilityAssociations             | educationOrganizationReference          | FALSE         | educationOrganizationReference        | REQUIRED    |                                          |                                          |                                          |
+| educationOrganizationReference                                     | educationOrganizationId                 | FALSE         | integer                               | REQUIRED    | 255901107                                | 255901001                                | 255901001                                |
+| StudentEducationOrganizationResponsibilityAssociations             | studentReference                        | FALSE         | studentReference                      | REQUIRED    |                                          |                                          |                                          |
+| studentReference                                                   | studentUniqueId                         | FALSE         | string                                | REQUIRED    | 111111                                   | 111111                                   | 111111                                   |
+| StudentEducationOrganizationResponsibilityAssociations             | beginDate                               | FALSE         | string                                | REQUIRED    | [current school year]-08-23              | [current school year]-08-23              | [current school year]-08-23              |
+| StudentEducationOrganizationResponsibilityAssociations             | responsibilityDescriptor                | FALSE         | string                                | REQUIRED    | Residency                                | Individualized Education Program         | Individualized Education Program         |
+| StudentEducationOrganizationResponsibilityAssociations             | endDate                                 | FALSE         | string                                | REQUIRED    | [current school year]-06-01              | [current school year]-06-01              | [current school year]-10-01              |


### PR DESCRIPTION
## Summary
- Fixes the v5 `StudentEdOrgResponsibilityAssociation` (SEORA) scenario doc, which incorrectly described updating `responsibilityDescriptor` (a primary key field that cannot be updated via PUT).
- Scenario steps now describe creating two SEORAs for the same student at different education organizations (Grand Bend Elementary vs. Grand Bend High School District), then updating `endDate` on the second.
- Added a third `Scenario 3: PUT` column to the example table, using the values proposed in CERT-260.

## Test plan
- [x] `npm run lint:folder` on the affected directory — no new lint errors introduced.
- [x] Reviewer to confirm the example table values (educationOrganizationId, dates, descriptors) match the intended scenarios — see PR comment.

Jira: https://edfi.atlassian.net/browse/CERT-260