### PR TITLE
[DMS-1280] Restore bearer auth in claims-management how-to (API 8.0)

### DIFF
--- a/odsApi_versioned_docs/version-8.0/how-to-guides/how-to-create-and-manage-api-security-metadata.mdx
+++ b/odsApi_versioned_docs/version-8.0/how-to-guides/how-to-create-and-manage-api-security-metadata.mdx
@@ -470,14 +470,12 @@ array uses the same JSON array format described in [The Security Metadata
 Format](#the-security-metadata-format). Any new claim set referenced in the
 hierarchy must also appear in `claimSets`.
 
-These management endpoints are not authenticated — they are gated solely by
-`DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING` (another reason to
-keep it disabled outside local development), so no bearer token is required.
-
 **Retrieve the current claims** to use as a starting point:
 
 ```powershell
-Invoke-RestMethod -Uri "http://localhost:8081/management/current-claims" |
+$headers = @{ Authorization = "Bearer $($token.access_token)" }
+
+Invoke-RestMethod -Uri "http://localhost:8081/management/current-claims" -Headers $headers |
   ConvertTo-Json -Depth 100 |
   Set-Content claims.json
 ```
@@ -495,6 +493,7 @@ $body = @{ claims = $claims } | ConvertTo-Json -Depth 100
 
 Invoke-RestMethod -Method Post `
   -Uri "http://localhost:8081/management/upload-claims" `
+  -Headers @{ Authorization = "Bearer $($token.access_token)" } `
   -ContentType "application/json" `
   -Body $body
 ```


### PR DESCRIPTION
## Summary

Reverts the recent change to the API 8.0 "how to create and manage API security metadata" guide that stated the DMS Configuration Service claims-management endpoints (`/management/current-claims`, `/management/upload-claims`, `/management/reload-claims`) are unauthenticated, and that removed their bearer `Authorization` headers.

Those endpoints **do** require a valid CMS bearer token as of DMS-1280 — they were the only CMS management routes missing `RequireAuthorization`, and that gap is being closed in Data-Management-Service PR #1108. This restores the docs to match the enforced behavior:

- Remove the "these management endpoints are not authenticated … no bearer token is required" paragraph.
- Restore `$headers = @{ Authorization = "Bearer $($token.access_token)" }` and `-Headers $headers` on the current-claims example.
- Restore `-Headers @{ Authorization = "Bearer $($token.access_token)" }` on the upload-claims example.

No other content changed.

Related: `Ed-Fi-Alliance-OSS/Data-Management-Service#1108` (DMS-1280).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
