### PR TITLE
EDFI-2781 Claimset Scripts

### DIFF
--- a/docs/reference/5-admin-app/user-guide/global-admin-quick-start/machine-user-setup.md
+++ b/docs/reference/5-admin-app/user-guide/global-admin-quick-start/machine-user-setup.md
@@ -19,11 +19,10 @@ by hand.
 
 :::
 
-
 ## Setup Keycloak machine account (manually)
 
 If you prefer to configure Keycloak manually instead of running the
-[bootstrap script](#the-bootstrap-script), follow the steps below.
+[bootstrap script](run-the-quick-start), follow the steps below.
 
 :::info
 

--- a/docs/reference/5-admin-app/user-guide/global-admin-quick-start/quick-start-appendix.md
+++ b/docs/reference/5-admin-app/user-guide/global-admin-quick-start/quick-start-appendix.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 ## Environment Variable Reference
 
-The `.env` file in the repository's `quick-start/` folder configures all three
+The `.env` file in the repository's `quick-start/` folder configures all the
 scripts. Copy
 [`.env.example`](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts/blob/main/quick-start/.env.example)
 to `.env` and edit as needed before running `run.ps1`. The defaults match the
@@ -59,8 +59,25 @@ Used by `bootstrap.ps1` to seed the machine user and by `cleanup.ps1`.
 | `ADMIN_API_URL` | `https://localhost/AdminApi` | ODS Admin API URL |
 | `ODS_API_DISCOVERY_URL` | `https://localhost/WebApi` | ODS/API discovery URL |
 | `TENANT_NAME` | `default` | Ed-Fi tenant to create under the environment |
-| `ODSS_JSON` | _(two sample instances)_ | JSON array of ODS instances to attach; ids must match `EdFi_Admin.dbo.OdsInstances` on the target ODS/API |
+| `ODSS_JSON` | _(two sample instances)_ | JSON array of ODS instances to attach; ids **and names** must match existing rows in `EdFi_Admin.dbo.OdsInstances` on the target ODS/API — the scripts do not create or correct them (see [Set Up the ODS Instances](run-the-quick-start#set-up-the-ods-instances-odss_json)) |
 | `SKIP_CERTIFICATE_CHECK` | `true` | `true`: skip TLS validation (local self-signed certificates) |
+
+### Claim set copies (EdFi_Security)
+
+Used by `copy-claimsets.ps1` to copy the built-in claim sets in the ODS/API's
+`EdFi_Security` database. The connection reuses `DB_ENGINE`, `SA_PASSWORD`, and
+the `POSTGRES_*` values above; only the settings below are specific to this
+step.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `COPY_CLAIMSETS` | `true` | `false`: skip the claim set copy step entirely |
+| `CLAIMSET_NAMES` | _(empty = every built-in claim set)_ | Claim sets to copy, semicolon-separated; blank copies all built-ins except internal-use ones (e.g. `Bootstrap Descriptors and EdOrgs`) |
+| `CLAIMSET_PREFIX` | `"AA "` | Prefix for the copies; quote it to keep the trailing space |
+| `SECURITY_DATABASE_NAME` | `EdFi_Security` | Security database name |
+| `SECURITY_SQL_SERVER` | `tcp:localhost,1433` | SQL Server hosting `EdFi_Security` |
+| `SECURITY_USE_INTEGRATED_SECURITY` | `false` | `true`: Windows integrated authentication (`SA_PASSWORD` not needed) |
+| `SECURITY_POSTGRES_CONTAINER` | `ed-fi-db-admin` | With `USE_POSTGRES_DOCKER=true`: the ODS stack's admin/security db container |
 
 ## Finding your token endpoint
 
@@ -84,7 +101,8 @@ $disco.token_endpoint                          # use this as TOKEN_URL
 | Option | Purpose |
 | --- | --- |
 | `-EnvFile <path>` | Use a different env file (default: `./.env`) |
-| `-SkipBootstrap` | Skip `bootstrap.ps1` (IdP client + machine-user seed) and only run `quick-start.ps1` |
+| `-SkipBootstrap` | Skip `bootstrap.ps1` (IdP client + machine-user seed) |
+| `-SkipClaimsets` | Skip `copy-claimsets.ps1` (built-in claim set copies in `EdFi_Security`) |
 
 ### cleanup.ps1
 
@@ -95,23 +113,27 @@ parameter passed explicitly overrides the `.env` value.
 | --- | --- |
 | `-Force` | Skip the confirmation prompt (automation) |
 | `-EnvFile <path>` | Use a different env file (default: `./.env`) |
-| `-EnvironmentName` / `-TeamName` / `-MachineUsername` | Override the names to delete |
-| `-DbEngine`, `-DatabaseName`, `-SaPassword`, `-PostgresAppPassword`, … | Override the database connection |
+| `-SkipClaimsets` | Leave the claim set copies in `EdFi_Security` (e.g. an application still uses one) |
+| `-EnvironmentName` / `-TeamName` / `-MachineUsername` / `-ClaimSetNames` | Override the names to delete |
+| `-DbEngine`, `-DatabaseName`, `-SaPassword`, `-PostgresAppPassword`, … | Override the Admin App database connection |
+| `-SecuritySqlServer` | Override the SQL Server hosting `EdFi_Security` (everything else reuses the database values above and the `SECURITY_*` `.env` settings) |
 
 ### Running the scripts directly
 
-`bootstrap.ps1` and `quick-start.ps1` are plain parameter-driven scripts —
-`run.ps1` only maps `.env` values onto their parameters. To run either one
-directly (for example, to provision a second environment with different
-values), see its comment-based help:
+`bootstrap.ps1`, `quick-start.ps1`, and `copy-claimsets.ps1` are plain
+parameter-driven scripts — `run.ps1` only maps `.env` values onto their
+parameters. To run one directly (for example, to provision a second
+environment with different values, or to copy additional claim sets), see its
+comment-based help:
 
 ```powershell
 Get-Help ./bootstrap.ps1 -Full
 Get-Help ./quick-start.ps1 -Full
+Get-Help ./copy-claimsets.ps1 -Full
 ```
 
-Both scripts are idempotent: re-runs update or reuse existing resources instead
-of duplicating them.
+All the scripts are idempotent: re-runs update, reuse, or skip existing
+resources instead of duplicating them.
 
 ## Troubleshooting
 
@@ -130,7 +152,18 @@ of duplicating them.
   membership automatically) or `PUT` the membership's `roleId` to 6.
 - **Empty ODS instances list.** The ids in `ODSS_JSON` must exist in
   `EdFi_Admin.dbo.OdsInstances` on the target ODS/API; otherwise the sync finds
-  nothing to attach.
+  nothing to attach. Query the table and use its real `OdsInstanceId` values —
+  see
+  [Set Up the ODS Instances](run-the-quick-start#set-up-the-ods-instances-odss_json).
+- **`ODS instance "<name>" does not exist in Admin API` when creating an
+  application.** The Admin App matches the environment's ODS against the Admin
+  API's `GET /v2/odsInstances` list **by name**, and that list comes from
+  `EdFi_Admin.dbo.OdsInstances`. The named instance is missing from that table,
+  or its `Name` differs from the `name` in `ODSS_JSON`. Check with
+  `SELECT OdsInstanceId, Name FROM dbo.OdsInstances` against `EdFi_Admin`; if
+  the row is missing, create it (see
+  [Set Up the ODS Instances](run-the-quick-start#set-up-the-ods-instances-odss_json)),
+  restart the ODS/API, and make sure `ODSS_JSON` uses the exact same name.
 - **`/auth/me` returns 401 with `"Token claim validation failed"`.** The token's
   `iss` does not equal the Admin App's configured `AUTH0_CONFIG_SECRET.ISSUER`,
   or its `aud` does not include `MACHINE_AUDIENCE`. Mint the token from the

--- a/docs/reference/5-admin-app/user-guide/global-admin-quick-start/readme.md
+++ b/docs/reference/5-admin-app/user-guide/global-admin-quick-start/readme.md
@@ -27,6 +27,13 @@ Admin App API, running as the authenticated service-account (machine) user):
 - **Ownership** of both the environment and the tenant by the team (**Full
   ownership**, role id 5)
 
+In addition, in the ODS/API's **EdFi_Security** database (by direct SQL):
+
+- A copy of every built-in **claim set** (`SIS Vendor`, `Ed-Fi Sandbox`,
+  `Assessment Vendor`, … — excluding internal-use ones) under an `AA` prefix —
+  the Admin App hides built-in claim sets from the application claim set
+  dropdown, so only the copies can be assigned when creating client credentials
+
 ## Prerequisites
 
 | Requirement | Notes |
@@ -36,12 +43,16 @@ Admin App API, running as the authenticated service-account (machine) user):
 | Ed-Fi ODS/API and ODS Admin API | Installed and reachable at the URLs configured in `.env` (defaults assume the local stack at `https://localhost`) |
 | Ed-Fi Admin App | Deployed with its database migrated (migrations seed the built-in roles the scripts reference — `Global admin`, `Tenant admin`, `Full ownership`) |
 | Identity provider (OIDC) | Configured for the Admin App, with a bootstrap global-admin user you can sign in as — see [Configuring an Identity Provider for Ed-Fi Admin App](/reference/admin-app/configuration/identity-provider) |
+| ODS instances registered in `EdFi_Admin` | Every instance listed in `ODSS_JSON` must exist in `EdFi_Admin.dbo.OdsInstances` on the target ODS/API — the scripts do not create them; see [Set Up the ODS Instances](run-the-quick-start#set-up-the-ods-instances-odss_json) |
 
 :::info
 
-The ODS instance ids in `ODSS_JSON` must match real rows in
+The ODS instance ids **and names** in `ODSS_JSON` must match real rows in
 `EdFi_Admin.dbo.OdsInstances` on the target ODS/API — otherwise the sync will
 not find them and the ODS lists will be empty.
+[Set Up the ODS Instances](run-the-quick-start#set-up-the-ods-instances-odss_json)
+covers how to check the table and create missing rows before running the
+scripts.
 
 :::
 

--- a/docs/reference/5-admin-app/user-guide/global-admin-quick-start/run-the-quick-start.md
+++ b/docs/reference/5-admin-app/user-guide/global-admin-quick-start/run-the-quick-start.md
@@ -33,10 +33,61 @@ review:
 | `DB_ENGINE`, `SA_PASSWORD` / `POSTGRES_APP_PASSWORD` | Admin App database engine and credentials, used to seed the machine user |
 | `TOKEN_URL` | Your issuer's token endpoint (the default is the Docker-stack Keycloak) |
 | `API_BASE_URL`, `ADMIN_API_URL`, `ODS_API_DISCOVERY_URL` | Where the Admin App API, ODS Admin API, and ODS/API are reachable |
-| `ODSS_JSON` | JSON array of ODS instances to attach; ids must match `EdFi_Admin.dbo.OdsInstances` on the target ODS/API |
+| `ODSS_JSON` | JSON array of ODS instances to attach; ids **and names** must match existing rows in `EdFi_Admin.dbo.OdsInstances` on the target ODS/API (see below) |
+| `SECURITY_*` | Where the ODS/API's `EdFi_Security` database lives (server, database name, container), used to copy the built-in claim sets — credentials reuse `SA_PASSWORD` / `POSTGRES_*` |
 
 See the [Appendix](quick-start-appendix) for the full environment variable
 reference.
+
+### Set Up the ODS Instances (`ODSS_JSON`)
+
+The scripts do **not** create ODS instances. Every entry in `ODSS_JSON` must
+match a real row in the `dbo.OdsInstances` table of the **`EdFi_Admin`**
+database on the target ODS/API — by `id` **and** by `name` — because when an
+application is created, the Admin App looks the instance up in the Admin API
+**by name**, and that list comes straight from this table. Set the table up
+before running the scripts:
+
+**If the ODS instances already exist** (the usual case — the ODS/API
+deployment registers its databases here), query the table and copy the exact
+values into `ODSS_JSON` — `OdsInstanceId` as `id` and `Name` as `name`:
+
+```sql
+-- against the EdFi_Admin database
+SELECT OdsInstanceId, Name, InstanceType FROM dbo.OdsInstances;
+```
+
+For example, if the query returns `OdsInstanceId` 1 for `EdFi_Ods_2026` and 2
+for `EdFi_Ods_2027`, the matching `ODSS_JSON` is:
+
+```json
+[
+  { "id": 1, "name": "EdFi_Ods_2026", "dbName": "EdFi_Ods_2026", "allowedEdOrgs": "255901" },
+  { "id": 2, "name": "EdFi_Ods_2027", "dbName": "EdFi_Ods_2027", "allowedEdOrgs": "255902" }
+]
+```
+
+(In the `.env` file the array goes on a single line:
+`ODSS_JSON=[{"id":1,"name":"EdFi_Ods_2026",...},{"id":2,...}]`.)
+
+**If an ODS instance is missing** (or the table is empty), create the row —
+and, for year-specific routing, its `schoolYearFromRoute` context — with the
+SQL in
+[Creating Applications (Admin API v2 Mode)](/reference/admin-app/configuration/global-administration-tasks#creating-applications-admin-api-v2-mode),
+then re-run the query above to get the generated `OdsInstanceId` for
+`ODSS_JSON` (`OdsInstanceId` is an identity column, so ids cannot be chosen up
+front).
+
+:::warning
+
+The ODS/API reads `dbo.OdsInstances` at startup — after creating a row,
+**restart the ODS/API** before calling it with the new instance.
+
+:::
+
+If an entry's `name` has no matching `Name` in the table, creating an
+application later fails with
+`ODS instance "<name>" does not exist in Admin API`.
 
 ## Step 3 — Run the Scripts
 
@@ -44,48 +95,85 @@ reference.
 ./run.ps1
 ```
 
-`run.ps1` runs two scripts in order:
+`run.ps1` runs three scripts in order:
 
 1. **`bootstrap.ps1`** — provisions the machine (service-account) client in the
    identity provider and seeds the matching machine user in the Admin App
    database. See [Machine User Setup](machine-user-setup) for what it does and
    how to do it manually instead.
 2. **`quick-start.ps1`** — provisions the team, environment, tenant, ODS
-   instances, and ownerships through the Admin App API.
+   instances, and ownerships through the Admin App API. The ODS instances in
+   `ODSS_JSON` must already exist in `EdFi_Admin.dbo.OdsInstances` — see
+   [Set Up the ODS Instances](#set-up-the-ods-instances-odss_json).
+3. **`copy-claimsets.ps1`** — copies every built-in claim set under an `AA`
+   prefix — `SIS Vendor` becomes `AA SIS Vendor` — directly in the ODS/API's
+   `EdFi_Security` database (internal-use claim sets such as
+   `Bootstrap Descriptors and EdOrgs` are excluded; set `CLAIMSET_NAMES` to
+   copy a specific list instead). The Admin App hides built-in (Ed-Fi preset)
+   claim sets from the application claim set dropdown, so credentials cannot
+   be created against them; the copies are selectable. The connection reuses
+   the `SA_PASSWORD` / `POSTGRES_*` values; only the server, database name,
+   and container come from the `SECURITY_*` variables.
 
-Both scripts are idempotent, so re-running `run.ps1` is safe. If the machine
-client and machine user are already in place (e.g. the Docker stack), run only
-the provisioning half:
+All the scripts are idempotent, so re-running `run.ps1` is safe. If the
+machine client and machine user are already in place (e.g. the Docker stack),
+run only the provisioning half:
 
 ```powershell
 ./run.ps1 -SkipBootstrap
 ```
+
+If the ODS/API's `EdFi_Security` database is not reachable from this machine,
+skip the claim set copies with `-SkipClaimsets` (or `COPY_CLAIMSETS=false`).
+
+:::info
+
+The claim set copies are snapshots: an ODS/API upgrade that changes a built-in
+claim set does not propagate to the `AA` copies. Delete and re-create them to
+pick up the new definition.
+
+:::
 
 ## Step 4 — Verify
 
 Sign in to the Admin App UI as the bootstrap user. The `Ed-Fi ODS/API v7.3`
 environment should appear, list its ODS instances and education organizations,
 and — because this path registers working credentials — the **Applications** and
-**Profiles** pages should load without a 403.
+**Profiles** pages should load without a 403. When creating an application, the
+`AA`-prefixed claim set copies (e.g. `AA SIS Vendor`) appear in the claim set
+dropdown.
 
 ## Cleaning Up
 
 To tear down the environment and everything attached to it (ownership, ODS
-instances, Ed-Orgs, tenant), plus the team, its membership, and the machine user
-seeded by `bootstrap.ps1` (`quick-start-machine`), run `cleanup.ps1` from the
-same folder. The bootstrap human user (`admin@example.org`) is left in place.
+instances, Ed-Orgs, tenant), plus the team, its membership, the machine user
+seeded by `bootstrap.ps1` (`quick-start-machine`), and the claim set copies
+made by `copy-claimsets.ps1`, run `cleanup.ps1` from the same folder. The
+bootstrap human user (`admin@example.org`) is left in place.
 
 ```powershell
-./cleanup.ps1          # shows what will be deleted and prompts for confirmation
-./cleanup.ps1 -Force   # no prompt (automation)
+./cleanup.ps1                  # shows what will be deleted and prompts for confirmation
+./cleanup.ps1 -Force           # no prompt (automation)
+./cleanup.ps1 -SkipClaimsets   # leave the claim set copies in EdFi_Security
 ```
 
 :::note
 
 The script runs against the **Admin App application database** (default `sbaa`)
-— not `EdFi_Admin` or an ODS database. It reads the database engine and
-connection values, plus the names to delete (`ENVIRONMENT_NAME`, `TEAM_NAME`,
-`MACHINE_USERNAME`), from the same `.env` file; any parameter passed explicitly
-overrides the `.env` value. Both SQL Server and PostgreSQL are supported.
+— not `EdFi_Admin` or an ODS database — plus, for the claim set copies, the
+ODS/API's `EdFi_Security` database (via the `SECURITY_*` values). It reads the
+database engine and connection values, plus the names to delete
+(`ENVIRONMENT_NAME`, `TEAM_NAME`, `MACHINE_USERNAME`, `CLAIMSET_NAMES`), from
+the same `.env` file; any parameter passed explicitly overrides the `.env`
+value. Both SQL Server and PostgreSQL are supported.
+
+:::
+
+:::warning
+
+Deleting a claim set that an application still uses leaves that application's
+credentials without resource access. Delete the application first, or pass
+`-SkipClaimsets`. Only the copies are ever removed — the built-in claim sets
+are never touched.
 
 :::

--- a/docs/reference/5-admin-app/user-guide/global-admin-quick-start/run-the-quick-start.md
+++ b/docs/reference/5-admin-app/user-guide/global-admin-quick-start/run-the-quick-start.md
@@ -41,11 +41,11 @@ reference.
 
 ### Set Up the ODS Instances (`ODSS_JSON`)
 
-The scripts do **not** create ODS instances. Every entry in `ODSS_JSON` must
-match a real row in the `dbo.OdsInstances` table of the **`EdFi_Admin`**
-database on the target ODS/API — by `id` **and** by `name` — because when an
-application is created, the Admin App looks the instance up in the Admin API
-**by name**, and that list comes straight from this table. Set the table up
+The scripts do **not** create or register ODS instances in the ODS/API's
+**`EdFi_Admin`** database. Every entry in `ODSS_JSON` must match an existing row
+in `dbo.OdsInstances` — by `id` **and** by `name` — because when an application
+is created, the Admin App looks the instance up in the Admin API **by name**,
+and that list comes straight from this table. Set the table up
 before running the scripts:
 
 **If the ODS instances already exist** (the usual case — the ODS/API


### PR DESCRIPTION
### Summary
Builds on the EDFI-2780 quick-start guides. Updates the Global Admin Quick Start docs to match the claim set scripts added to Admin-App-Installation-Scripts and to make ODS instance setup an explicit manual prerequisite.

Claim set copies (new copy-claimsets.ps1 step)

- The Admin App hides built-in (Ed-Fi preset) claim sets from the application claim set dropdown, so credentials cannot be created against them. The quick start now ends by copying every built-in claim set under an AA prefix (e.g. SIS Vendor -> AA SIS Vendor) directly in the ODS/API's EdFi_Security database.
- Documented the step in the flow (run.ps1 script list), the new .env variables (COPY_CLAIMSETS, CLAIMSET_NAMES, CLAIMSET_PREFIX, SECURITY_*), the -SkipClaimsets option, the snapshot caveat (ODS/API upgrades don't propagate to the copies), and cleanup behavior (cleanup.ps1 removes the copies; only non-preset copies are ever touched).

ODS instances are now a documented manual prerequisite
  - Instances already exist: query SELECT OdsInstanceId, Name, InstanceType FROM dbo.OdsInstances and use those exact values as id/name in ODSS_JSON (with a worked JSON example).
  - Instances missing: create them with the SQL in Creating Applications (Admin API v2 Mode) (including the schoolYearFromRoute context), restart the ODS/API, then re-query for the generated ids.

_Verification: npm run lint:folder 0 errors; npm run build passes (internal links and the new #set-up-the-ods-instances-odss_json anchor validated)._
