### PR TITLE
[DRAFT] EDFI-2794 Document Entra ID and Google Workspace for Windows, Docker and Unix

### DIFF
--- a/docs/reference/5-admin-app/configuration/configuring-admin-app.md
+++ b/docs/reference/5-admin-app/configuration/configuring-admin-app.md
@@ -44,7 +44,7 @@ module.exports = {
       issuer: 'https://your-keycloak-server/auth/realms/edfi',
       clientId: 'edfiadminapp',
       clientSecret: 'your-client-secret',
-      scope: '',
+      scope: 'openid email profile',
   },
   //this should match with a user in your Idp
   ADMIN_USERNAME: 'admin@example.com',
@@ -284,7 +284,7 @@ The OIDC configuration is stored in the application database. Insert configurati
 
 ```sql
 INSERT INTO oidc (issuer, "clientId", "clientSecret", scope) VALUES
-('https://your-domain.com/auth/realms/edfi', 'edfiadminapp', 'your-client-secret', '');
+('https://your-domain.com/auth/realms/edfi', 'edfiadminapp', 'your-client-secret', 'openid email profile');
 ```
 
 For more details on configuring an identity provider, see [Configuring an Identity Provider for Ed-Fi Admin App](./identity-provider/readme.md).

--- a/docs/reference/5-admin-app/configuration/configuring-admin-app.md
+++ b/docs/reference/5-admin-app/configuration/configuring-admin-app.md
@@ -154,12 +154,11 @@ VITE_IDP_ACCOUNT_URL=https://your-domain.com/auth/realms/edfi/account/
 - `VITE_IDP_ACCOUNT_URL`: URL to the identity provider's account management page where users can manage their profile and authentication settings
 
 :::note
-**Important:** The `VITE_IDP_ACCOUNT_URL` value may differ from your Keycloak admin console URL.
-This should point to the **account management interface** (`/auth/realms/{realm-name}/account/`), not the admin console.
+**Important:** `VITE_IDP_ACCOUNT_URL` should point to your identity provider's **end-user account-management page**, not its admin console. It is provider-specific:
 
-- Local development: `https://localhost/auth/realms/edfi/account/`
-- Production: `https://auth.yourdomain.com/auth/realms/production/account/`
-- Custom realm: `https://keycloak.example.org/auth/realms/school-district/account/`
+- Keycloak: `https://<host>/auth/realms/{realm}/account/`
+- Microsoft Entra ID: `https://myaccount.microsoft.com/`
+- Google Workspace: `https://myaccount.google.com/`
 
 :::
 
@@ -235,9 +234,9 @@ npm run migrations:revert
 
 ## Authentication Configuration
 
-The Admin App uses OpenID Connect (OIDC) for authentication. Keycloak is the recommended provider.
+The Admin App uses OpenID Connect (OIDC) for authentication. It works with any OIDC-compatible provider; Keycloak is the bundled default example, and Microsoft Entra ID and Google Workspace are also validated. See [Configuring an Identity Provider for Ed-Fi Admin App](./identity-provider/readme.md) for provider-specific guides.
 
-### Keycloak Configuration
+### Example: Keycloak
 
 1. **Create Realm**: Create a new realm called `edfi`
 
@@ -288,7 +287,7 @@ INSERT INTO oidc (issuer, "clientId", "clientSecret", scope) VALUES
 ('https://your-domain.com/auth/realms/edfi', 'edfiadminapp', 'your-client-secret', '');
 ```
 
-For more details on configuring an identity provider, see [Configuring an Identity Provider for Ed-Fi Admin App](./identity-provider.md).
+For more details on configuring an identity provider, see [Configuring an Identity Provider for Ed-Fi Admin App](./identity-provider/readme.md).
 
 ## Next Steps
 

--- a/docs/reference/5-admin-app/configuration/configuring-admin-app.md
+++ b/docs/reference/5-admin-app/configuration/configuring-admin-app.md
@@ -234,7 +234,7 @@ npm run migrations:revert
 
 ## Authentication Configuration
 
-The Admin App uses OpenID Connect (OIDC) for authentication. It works with any OIDC-compatible provider; Keycloak is the bundled default example, and Microsoft Entra ID and Google Workspace are also validated. See [Configuring an Identity Provider for Ed-Fi Admin App](./identity-provider/readme.md) for provider-specific guides.
+The Admin App uses OpenID Connect (OIDC) for authentication. It works with any OIDC-compatible provider; Keycloak is the bundled default example, and Microsoft Entra ID, Google Workspace, and Auth0 are also validated. See [Configuring an Identity Provider for Ed-Fi Admin App](./identity-provider/readme.md) for provider-specific guides.
 
 ### Example: Keycloak
 

--- a/docs/reference/5-admin-app/configuration/identity-provider/auth0.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/auth0.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 5
+---
+
+# Auth0
+
+:::info
+
+Scope: native Windows/IIS installation with SQL Server, a single OIDC provider, and a fresh install. Human login is validated end-to-end on Windows/IIS. This section covers only what is Auth0-specific; follow the [Windows IIS installation guide](../../getting-started/windows-iis-installation/readme.md) for the install itself and [Configuring Ed-Fi Admin App](../configuring-admin-app.md) for the non-OIDC configuration.
+
+:::
+
+Create the Auth0 application **first** — its domain (issuer), client id, and secret go into the Admin App configuration during installation.
+
+## Prerequisites
+
+- A Windows/IIS server with SQL Server prepared per the [Windows IIS installation guide](../../getting-started/windows-iis-installation/readme.md).
+- An Auth0 tenant where you can create Applications (and, for machine-to-machine access, APIs).
+- The host where the Admin App **API** is served — used in the callback URL. In the two-site Windows/IIS layout this is the API site, for example `https://localhost:3443`.
+- The **email of the first admin user** — it must equal the `email` claim Auth0 sends for that person. It is set as `ADMIN_USERNAME` during installation, so decide it beforehand.
+
+:::tip Automated install
+
+The [automated Windows install](../../getting-started/windows-iis-installation/automated.md) supports Auth0 natively: `install-all.ps1 -IdpProvider auth0` validates discovery, writes the configuration (normalizing the issuer into the forms each setting expects, whichever slash form you pass), and prints the exact URLs to register in the Auth0 dashboard. Only Part A below remains manual — no script can provision the Auth0 tenant.
+
+:::
+
+## Part A — Create the application in Auth0
+
+### A1. Create a Single Page Web Application
+
+1. Auth0 Dashboard → **Applications** → **Applications** → **Create Application**.
+2. **Name:** for example, `Ed-Fi Admin App v4`; **type: Single Page Web Application** → **Create**.
+
+   ![Auth0 Create application dialog](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/auth0/create-application.png)
+
+3. From the application's **Settings** tab, copy the **Domain** (e.g. `your-tenant.us.auth0.com` — as a URL this is the issuer, `https://your-tenant.us.auth0.com`), the **Client ID**, and the **Client Secret**.
+
+   ![Auth0 application Settings showing Domain, Client ID, and Client Secret](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/auth0/basic-info.png)
+
+### A2. Register the application URLs
+
+Still on the application's **Settings** tab, set — Auth0 enforces these strictly, and mismatch errors surface as an Auth0 error page naming the offending URL:
+
+| Auth0 field | Value (two-site Windows/IIS layout) |
+| --- | --- |
+| Allowed Callback URLs | `https://<api-host>/api/auth/callback/<oidc-id>` (e.g. `https://localhost:3443/api/auth/callback/1`) |
+| Allowed Logout URLs | `https://<api-host>/api/auth/post-logout` |
+| Allowed Web Origins | the frontend site (e.g. `https://localhost:4443`) |
+
+![Auth0 Application URIs with callback, logout, and web-origin URLs registered](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/auth0/application-uris.png)
+
+:::note
+
+The callback URL points at the **API** site, not the frontend. `<oidc-id>` is the `oidc` table row id; on a fresh single-provider install it is `1`.
+
+:::
+
+### A3. Users need an email address
+
+Every person who will log in must exist as an Auth0 user **with an email address** — the Admin App requires an `email` claim from the IdP and rejects login with `Invalid email from IdP` when it is missing. The `email` scope in Part B is what makes Auth0 emit the claim; database-connection users created with an email need nothing further. Create users under **User Management** → **Users** → **Create User**:
+
+![Auth0 Create user dialog under User Management](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/auth0/create-user.png)
+
+## Part B — Configure the API (`production.js`)
+
+Set the OIDC block in `packages/api/config/production.js`; the API seeds it into the `oidc` table on first startup. See [Configuring Ed-Fi Admin App](../configuring-admin-app.md) for the full file (database, encryption key, Yopass, and so on).
+
+```javascript
+SAMPLE_OIDC_CONFIG: {
+  issuer:       'https://your-tenant.us.auth0.com',   // NO trailing slash
+  clientId:     '<application-client-id>',
+  clientSecret: '<application-client-secret>',
+  scope:        'openid profile email',
+},
+USE_PKCE: true,
+// First admin: must match the email Auth0 sends for this person.
+ADMIN_USERNAME: '<admin-email>',
+```
+
+Differences from the Keycloak example:
+
+- `issuer` → the tenant URL (the application's **Domain** with `https://`), not a Keycloak realm URL — and **without a trailing slash** (a trailing slash breaks OIDC discovery; see the troubleshooting table in Part D).
+- `scope` → `openid profile email` is required: without the `email` scope Auth0 omits the claim and login is rejected with `Invalid email from IdP`.
+- `clientId` / `clientSecret` → the Single Page Application values from Part A.
+
+:::note
+
+A successful sign-in still fails with `USER_NOT_FOUND` unless a user with that email exists with a role. On a fresh install, startup seeding creates the admin from `ADMIN_USERNAME` with roleId `2` (Global admin) when the `user` table is empty. Roles for reference: 1 = Tenant user global, **2 = Global admin**, 3 = Global viewer, 6 = Tenant admin, 7 = Tenant viewer, 8 = Standard tenant access.
+
+:::
+
+## Part C — Configure the frontend
+
+Set the frontend build-time variables in `packages/fe/.env` (see [Configuring Ed-Fi Admin App](../configuring-admin-app.md) for the full set). Only two are provider-specific for Auth0:
+
+- `VITE_OIDC_ID=1` — the `oidc` row the login button targets (`1` on a single-provider fresh install; the shipped default).
+- `VITE_IDP_ACCOUNT_URL=https://your-tenant.us.auth0.com/` — drives the Account → Account Management self-service link. Auth0 has **no hosted end-user account page** by default, so the tenant URL is a placeholder; point it at your own profile page if you have one.
+
+:::warning
+
+These are build-time variables, so set them before `npm run build:fe`.
+
+:::
+
+## Part D — Validate end-to-end
+
+1. Start the API so it reads the `oidc` table and registers the Auth0 strategy (look for `Registering OIDC provider https://your-tenant.us.auth0.com with id 1` in the API log).
+2. Open the Admin App in a clean browser at the frontend site, for example `https://localhost:4443`.
+3. Login redirects to Auth0 Universal Login, then back through `/api/auth/callback/<oidc-id>` into the app.
+4. Confirm you land authenticated (no `Invalid email from IdP`, no `USER_NOT_FOUND`).
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Invalid email from IdP` (in the API log; the browser shows only a generic login-failure message) | `email` claim empty | Give the Auth0 user an email address; confirm `scope` includes `email` |
+| `USER_NOT_FOUND` | admin not seeded with that email | Set `ADMIN_USERNAME` (Part B) |
+| `NO_ROLE` | user exists without a role | Assign a role (for example, roleId 2) |
+| Auth0 error page: "Callback URL mismatch" | Allowed Callback URLs does not match what the app sends | Register `https://<api-host>/api/auth/callback/<oidc-id>` exactly (A2) |
+| `Error registering OIDC provider ...` at API startup + `Unknown authentication strategy "oidc-1"` on login | trailing slash on the `oidc` row's issuer (discovery URL 404s) | Remove the trailing slash from `SAMPLE_OIDC_CONFIG.issuer` / the `oidc` row |
+
+## Machine-to-machine (M2M) access
+
+Bearer-token access to the Admin App API (used by the [Global Admin Quick Start](../../user-guide/global-admin-quick-start/readme.md) and other automation) needs three Auth0-specific things beyond the human-login setup:
+
+1. **An Auth0 API** (Dashboard → **Applications** → **APIs** → **Create API**) whose **Identifier** equals the Admin App's configured `MACHINE_AUDIENCE` (default `edfiadminapp-api`), with a **`login:app`** permission defined. Leave the **JSON Web Token (JWT) Profile** at **RFC 9068** (the default for new APIs): only that profile puts a `client_id` claim in client-credentials access tokens, and the Admin App keys the machine user on that claim — with the legacy **Auth0** profile the token carries `azp` instead and authentication fails.
+
+   ![Auth0 Create Custom API with the Identifier and JWT profile settings](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/auth0/create-api.png)
+
+   ![Auth0 API Permissions tab defining the login:app permission](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/auth0/login-app-permision.png)
+
+2. **A Machine to Machine application**, authorized for that API with the `login:app` permission granted. Its **Client ID** is what the machine user in the Admin App is keyed on.
+
+   ![Auth0 Machine to Machine application Settings showing the Client ID and Client Secret](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/auth0/edfiadminapp-api.png)
+
+   ![Auth0 Machine to Machine application granted the login:app permission on the API](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/auth0/grant-access-api.png)
+
+3. **Token requests need an explicit audience**: calls to `https://your-tenant.us.auth0.com/oauth/token` must pass an `audience` parameter equal to the API identifier — Auth0 requires it for the client-credentials grant, and without it the token does not carry the expected `aud`. (The automated installer writes `AUTH0_CONFIG_SECRET_VALUE.ISSUER` for you; if configuring it by hand, it must equal the token's `iss` claim exactly — see the checklist below.)
+
+If a bearer call returns 401, decode the token (for example at jwt.io) and check, in order: `iss` equals the configured `ISSUER` exactly (including the trailing slash), `aud` equals `MACHINE_AUDIENCE`, `client_id` is present and matches a machine user in the Admin App, and `scope` includes `login:app`. The Admin App identifies the machine client by the `client_id` claim only — `azp` is not used as a fallback. A token that carries `azp` but no `client_id` means the API is on the legacy **Auth0** JWT profile; switch it to **RFC 9068** (step 1 above). The quick start's `bootstrap.ps1 -Provider auth0` (from the [Admin App Installation Scripts repository](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts)) automates these checks against a real token, and the [Quick Start appendix](../../user-guide/global-admin-quick-start/quick-start-appendix.md) covers the general M2M troubleshooting flow.

--- a/docs/reference/5-admin-app/configuration/identity-provider/google-workspace.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/google-workspace.md
@@ -117,7 +117,7 @@ ADMIN_USERNAME: '<admin-email>',
 Differences from the Keycloak example:
 
 - `issuer` → `https://accounts.google.com` (its discovery document is at `https://accounts.google.com/.well-known/openid-configuration`).
-- `scope` → `openid profile email`; the `email` scope supplies the username claim. The Keycloak example ships `scope: ''`, which would omit the email claim here.
+- `scope` → `openid profile email`; the `email` scope supplies the username claim. Keycloak returns `email` through its default client scopes even without an explicit scope, but Google requires the `email` scope to be requested.
 - `clientId` / `clientSecret` → the OAuth client values from Part A.
 
 A successful sign-in still fails with `USER_NOT_FOUND` unless a user with that email exists with a role. On a fresh install, startup seeding creates the admin from `ADMIN_USERNAME` with roleId `2` (Global admin) when the `user` table is empty. Set `ADMIN_USERNAME` to the admin's Google Workspace email — it must exactly match the email Google sends for that person.

--- a/docs/reference/5-admin-app/configuration/identity-provider/google-workspace.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/google-workspace.md
@@ -1,0 +1,152 @@
+---
+sidebar_position: 4
+---
+
+# Google Workspace
+
+:::info
+
+Scope: native Windows/IIS installation with SQL Server, a single OIDC provider, and a fresh install. Validated end-to-end on Windows/IIS. This section covers only what is Google-specific; follow the [Windows IIS installation guide](../../getting-started/windows-iis-installation/readme.md) and [Configuring Ed-Fi Admin App](../configuring-admin-app.md) for the rest.
+
+:::
+
+Google returns the `email` claim by default when the `email` scope is requested, so there is **no optional-claim step**. Create the OAuth client **first** — its client id and secret go into the Admin App configuration during installation.
+
+## Prerequisites
+
+- A Windows/IIS server with SQL Server prepared per the [Windows IIS installation guide](../../getting-started/windows-iis-installation/readme.md).
+- **Google Workspace admin access** to create the project under your organization and set the OAuth consent screen to **Internal**. The project must belong to your Workspace organization for the **Internal** audience to be available.
+- The host where the Admin App **API** is served — used in the redirect URI, for example `https://localhost:3443`.
+- The **email of the first admin user** — a user in your Workspace domain; it must equal the email Google sends. Set as `ADMIN_USERNAME` during installation.
+
+## Part A — Create OAuth credentials in Google Cloud Console
+
+:::note
+
+Navigate via the left-hand menu (**APIs & Services** → **Credentials**); a direct link to the credentials page may not load reliably.
+
+:::
+
+### A1. Create or select a project
+
+1. Sign in to the [Google Cloud Console](https://console.cloud.google.com).
+2. Create a new project **inside your Google Workspace organization** (or select one that already belongs to it). Org ownership is required so the **Internal** audience is available in the next step.
+
+![Google Cloud Console create project](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/google/01-create-project-1.png)
+
+![Google Cloud Console new project details](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/google/02-create-project-2.png)
+
+### A2. Configure the OAuth consent screen
+
+1. Go to **APIs & Services** → **OAuth consent screen**.
+2. Fill in **App name** and **User support email**.
+
+   ![Google OAuth consent screen app information](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/google/03-consent-app-info.png)
+
+3. **Audience: Internal** — limits sign-in to your Workspace domain.
+
+   ![Google OAuth consent screen audience set to Internal](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/google/04-audience-internal.png)
+
+4. Provide the **Contact information** email (used only for Google notifications about the project; not shown to end users).
+
+   ![Google OAuth consent screen contact information](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/google/05-contact-information.png)
+
+5. Accept the Google API Services policies and **Finish**.
+
+![Google OAuth consent screen accept and finish](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/google/06-accept-finish.png)
+
+:::warning
+
+If only **External** appears, the project is not under your Workspace organization or your account is not a Workspace admin. External widens sign-in to any Google account and adds a verification/publishing flow — resolve the org/admin placement before continuing.
+
+:::
+
+### A3. Create the OAuth client ID
+
+1. Go to **APIs & Services** → **Credentials** → **Create Credentials** → **OAuth client ID**.
+
+   ![Google Cloud Console create OAuth client ID](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/google/07-create-credentials-oauth-client.png)
+
+2. **Application type: Web application**.
+3. **Name:** for example, `Ed-Fi Admin App v4`.
+4. **Authorized redirect URIs** → add `https://<api-host>/api/auth/callback/<oidc-id>`. For the two-site Windows/IIS layout, for example `https://localhost:3443/api/auth/callback/1`.
+5. **Authorized JavaScript origins:** leave **empty** — the app uses the server-side Authorization Code flow.
+6. **Create.**
+
+![Google OAuth client ID web application with redirect URI](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/google/08-oauth-client-web.png)
+
+:::note
+
+The redirect URI must match **exactly** (scheme, host, path, no extra trailing slash) or Google returns `redirect_uri_mismatch`. Google permits `https://localhost` as a redirect URI. `<oidc-id>` is `1` on a fresh single-provider install.
+
+:::
+
+### A4. Record the Client ID and Client Secret
+
+Google shows the **Client ID** and **Client Secret** on creation and offers a JSON download; capture both (the JSON holds both under the `web` key). The secret can be retrieved again later from the client's detail page.
+
+![Google OAuth client ID and secret](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/google/09-client-id-secret.png)
+
+:::warning
+
+Treat the client secret as sensitive: keep it out of source control, tickets, and docs (use the placeholder `<clientSecret>` in shared material). For production, Google may require domain verification of the redirect URI domain (**APIs & Services** → **Domain verification**); this is not required for a `localhost` test.
+
+:::
+
+| Admin App field | Google value |
+| --- | --- |
+| `issuer` | `https://accounts.google.com` |
+| `clientId` | Client ID from the OAuth Credentials page |
+| `clientSecret` | Client secret from the OAuth Credentials page |
+| `scope` | `openid profile email` |
+
+## Part B — Configure the API (`production.js`)
+
+```javascript
+SAMPLE_OIDC_CONFIG: {
+  issuer:       'https://accounts.google.com',
+  clientId:     '<googleClientId>',
+  clientSecret: '<googleClientSecret>',
+  scope:        'openid profile email',
+},
+USE_PKCE: true,
+// First admin: must match the email Google sends for this person.
+ADMIN_USERNAME: '<admin-email>',
+```
+
+Differences from the Keycloak example:
+
+- `issuer` → `https://accounts.google.com` (its discovery document is at `https://accounts.google.com/.well-known/openid-configuration`).
+- `scope` → `openid profile email`; the `email` scope supplies the username claim. The Keycloak example ships `scope: ''`, which would omit the email claim here.
+- `clientId` / `clientSecret` → the OAuth client values from Part A.
+
+A successful sign-in still fails with `USER_NOT_FOUND` unless a user with that email exists with a role. On a fresh install, startup seeding creates the admin from `ADMIN_USERNAME` with roleId `2` (Global admin) when the `user` table is empty. Set `ADMIN_USERNAME` to the admin's Google Workspace email — it must exactly match the email Google sends for that person.
+
+## Part C — Configure the frontend
+
+Provider-specific frontend variables for Google (see [Configuring Ed-Fi Admin App](../configuring-admin-app.md) for the full set):
+
+- `VITE_OIDC_ID=1` — the `oidc` row the login button targets.
+- `VITE_IDP_ACCOUNT_URL=https://myaccount.google.com/` — the Account Management self-service link.
+
+:::warning
+
+Do not point `VITE_IDP_ACCOUNT_URL` at `admin.google.com` or `console.cloud.google.com` — those are admin consoles, not end-user self-service.
+
+:::
+
+## Part D — Validate end-to-end
+
+1. Start the API so it registers the Google strategy.
+2. Open the Admin App at the frontend site, for example `https://localhost:4443`, in a clean browser.
+3. Login redirects to Google sign-in (consent for `openid profile email`), then back through `/api/auth/callback/<oidc-id>`.
+4. Confirm you land authenticated; the `email` claim arrives populated with no optional-claim configuration needed.
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Invalid email from IdP` | `email` claim empty | Confirm `scope` includes `email`; sign in with a real Workspace account |
+| `USER_NOT_FOUND` | admin not seeded with that email | Set `ADMIN_USERNAME` (Part B) |
+| `NO_ROLE` | user exists without a role | Assign a role (for example, roleId 2) |
+| `redirect_uri_mismatch` (from Google) | Google redirect URI does not match the callback | Make them match exactly (scheme, host, path) |
+| Only **External** audience available | project not under the Workspace org, or not an admin | Create the project under the org with an admin account (A2) |
+| Discovery error at API startup | wrong issuer | Confirm `https://accounts.google.com` |

--- a/docs/reference/5-admin-app/configuration/identity-provider/keycloak.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/keycloak.md
@@ -1,81 +1,13 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
-# Configuring an Identity Provider for Ed-Fi Admin App
-
-The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing user accounts. Keycloak is the only fully supported provider in this release; Microsoft Entra ID and Google Workspace have been tested and gain full support in Admin App v4.1. The guidance below uses Keycloak as the example.
-
-## General IdP Guidance and Configuration
-
-### Backend Configuration Settings
-
-The Ed-Fi Admin App backend requires specific configuration settings to connect to your OIDC-compatible Identity Provider. These settings are typically configured in the application's environment variables or configuration files.
-
-Key configuration parameters include:
-
-- **Authority URL**: The base URL of your IdP (e.g., `https://your-keycloak-server/realms/edfi`)
-- **Client ID**: The client identifier registered in your IdP (e.g., `edfiadminapp`)
-- **Client Secret**: The confidential secret associated with the client
-- **Redirect URI**: The callback URL where the IdP sends authentication responses (e.g., `https://your-admin-app-api-url/api/auth/callback/<oidc-id>`, where `<oidc-id>` is the id of the `oidc` table row)
-- **Post Logout Redirect URI**: Where users are redirected after logging out (e.g., `https://your-admin-app-url/api/auth/post-logout`)
-- **Response Type**: Typically set to `code` for authorization code flow
-- **Scope**: The OIDC scopes requested, typically `openid profile email`
-
-These settings must match the configuration in your IdP to ensure proper authentication flow.
-
-### Bootstrap User Concept
-
-The Ed-Fi Admin App uses a **bootstrap user** mechanism to initialize the system with its first administrative user. This is necessary because:
-
-1. The application requires at least one user with administrative privileges to configure the system
-2. User permissions and roles are managed within the Admin App itself, separate from the IdP
-3. The bootstrap user provides the initial entry point to set up additional users and permissions
-
-**How it works:**
-
-- When the Admin App starts for the first time (or when the database is empty), it looks for a configured bootstrap user
-- This user's email address or username is specified in the application configuration
-- When this user first authenticates through the IdP, they are automatically granted administrative privileges in the Admin App
-- Subsequent users who authenticate must be granted permissions by an existing administrator
-
-:::tip
-Configure the bootstrap user email/username before deploying the application to production. This ensures you can immediately access the system after initial deployment.
-:::
-
-### Authentication and Authorization Architecture
-
-The Ed-Fi Admin App implements a two-layer security model:
-
-**Authentication (IdP Layer):**
-
-- The Identity Provider handles user authentication and session management
-- Users log in through the IdP interface (e.g., Keycloak login page)
-- The IdP validates credentials and issues authentication tokens
-- The application uses cookie-based authentication to maintain user sessions
-
-**Authorization (Admin App Layer):**
-
-- The Admin App maintains its own authorization system independent of the IdP
-- User permissions, roles, and access controls are managed within the Admin App database
-- The IdP does not need to provide special claims, scopes, or role information
-- Users only need a valid IdP account; all authorization decisions are made by the Admin App
-
-**What this means for IdP configuration:**
-
-- You do not need to configure custom claims or scopes in your IdP
-- You do not need to map roles or permissions from the IdP to the Admin App
-- Users simply need a valid account in the IdP with basic profile information (username, email, name)
-- All permission management happens within the Admin App after successful authentication
-
-This separation of concerns allows for flexible user management while maintaining security and simplifying IdP setup.
-
-## Using Keycloak
+# Keycloak
 
 This guide walks you through setting up Keycloak as the identity provider for the Ed-Fi Admin App. Keycloak is used for OpenID Connect (OIDC) authentication, managing user sessions, and providing secure authentication for both the web interface and machine-to-machine (M2M) clients.
 More info in the [Official Keycloak Website](https://www.keycloak.org/guides)
 
-### Prerequisites
+## Prerequisites
 
 Before starting, ensure you have:
 
@@ -85,14 +17,14 @@ Before starting, ensure you have:
 - The Ed-Fi Admin App repository cloned
 - Basic familiarity with Keycloak concepts (realms, clients, users)
 
-### Create the Ed-Fi Realm
+## Create the Ed-Fi Realm
 
 1. In the Keycloak admin console, click the realm dropdown (top-left)
 2. Click "Create Realm"
 3. Enter realm name: `edfi`
 4. Click "Create"
 
-#### Configure Realm Settings
+### Configure Realm Settings
 
 Navigate to **Realm Settings** → **General**:
 
@@ -100,7 +32,7 @@ Navigate to **Realm Settings** → **General**:
 - **Display Name**: `Ed-Fi`
 - **HTML Display Name**: `Ed-Fi Technology Suite`
 
-#### Configure Session Timeouts
+### Configure Session Timeouts
 
 Navigate to **Realm Settings** → **Sessions**:
 
@@ -119,7 +51,7 @@ These settings should align with your Admin App's express session timeout config
 
 Click **Save**.
 
-### Client Configuration
+## Client Configuration
 
 If you need to create the client manually:
 
@@ -153,9 +85,9 @@ If you need to create the client manually:
    - **Web origins**: `https://your-admin-app-api-url`
    - Click **Save**
 
-### User Creation
+## User Creation
 
-#### 1. Create Your First Admin User
+### 1. Create Your First Admin User
 
 1. In the Keycloak admin console, select the `edfi` realm
 2. Go to **Users** in the left sidebar
@@ -168,7 +100,7 @@ If you need to create the client manually:
    - **Email Verified**: ON (toggle this to avoid verification emails)
 5. Click **Create**
 
-#### 2. Set User Password
+### 2. Set User Password
 
 After creating the user:
 
@@ -179,7 +111,7 @@ After creating the user:
 5. Click **Save**
 6. Confirm by clicking **Set password** in the dialog
 
-### HTTP Security for Keycloak
+## HTTP Security for Keycloak
 
 :::warning
 
@@ -237,7 +169,7 @@ X-Xss-Protection: 1; mode=block
 
 :::
 
-### Key Rotation in Keycloak
+## Key Rotation in Keycloak
 
 The Ed-Fi Admin App has its own client credentials (aka "key and secret") for
 connecting to the OAuth provider, such as Keycloak. As a best practice, many
@@ -249,7 +181,7 @@ rotation is available as a preview feature; it is disabled by default. To enable
 secret rotation, administrators need to manually configure and activate this
 feature within Keycloak settings.
 
-#### Enable client secret rotation feature on docker
+### Enable client secret rotation feature on docker
 
 To enable client secret rotation in Keycloak when running in Docker, add this
 under environment in your docker-compose.yml
@@ -259,7 +191,7 @@ under environment in your docker-compose.yml
       KC_FEATURES: client-secret-rotation
 ```
 
-#### Create a Client Profile with Secret Rotation Executor
+### Create a Client Profile with Secret Rotation Executor
 
 - Navigate to Realm Settings > Client Policies > Profiles.
 - Click on Create client profile and provide a name and description.
@@ -271,7 +203,7 @@ under environment in your docker-compose.yml
   3. Remain Expiration Time: Time window (in seconds) before secret expiration
      during which updates trigger rotation.
 
-#### Create a Client Policy
+### Create a Client Policy
 
 - Still under Client Policies, navigate to the Policies tab.
 - Click on Create client policy and provide a name and description.
@@ -279,7 +211,7 @@ under environment in your docker-compose.yml
   with a specific access type or role).
 - Associate the previously created client profile with this policy.
 
-#### Apply the Policy to Existing Clients
+### Apply the Policy to Existing Clients
 
 - During the creation of new clients, if the client secret rotation policy is
   active, the behavior will be applied automatically.

--- a/docs/reference/5-admin-app/configuration/identity-provider/microsoft-entra-id.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/microsoft-entra-id.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 3
+---
+
+# Microsoft Entra ID
+
+:::info
+
+Scope: native Windows/IIS installation with SQL Server, a single OIDC provider, and a fresh install. Validated end-to-end on Windows/IIS. This section covers only what is Entra-specific; follow the [Windows IIS installation guide](../../getting-started/windows-iis-installation/readme.md) for the install itself and [Configuring Ed-Fi Admin App](../configuring-admin-app.md) for the non-OIDC configuration.
+
+:::
+
+Register the Entra application **first** — its issuer, client id, and secret go into the Admin App configuration during installation. Do not install the Admin App before completing Part A.
+
+## Prerequisites
+
+- A Windows/IIS server with SQL Server prepared per the [Windows IIS installation guide](../../getting-started/windows-iis-installation/readme.md).
+- Access to the Microsoft Entra admin center with permission to create App Registrations and grant admin consent (for example, Cloud Application Administrator).
+- The host where the Admin App **API** is served — used in the redirect URI. In the two-site Windows/IIS layout this is the API site, for example `https://localhost:3443`.
+- Your Entra **Tenant ID**.
+- The **email of the first admin user** — it must equal the email Entra sends for that person. It is set as `ADMIN_USERNAME` during installation, so decide it beforehand.
+
+## Part A — Register the application in Microsoft Entra ID
+
+### A1. Create the App Registration
+
+1. Azure portal → **Microsoft Entra ID** → **App registrations** → **New registration**.
+
+   ![Entra ID new App registration screen](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/entra/01-new-registration.png)
+
+2. **Name:** for example, `Ed-Fi Admin App v4`.
+3. **Supported account types:** _Accounts in this organizational directory only (single tenant)_.
+4. **Redirect URI:** platform **Web**, value `https://<api-host>/api/auth/callback/<oidc-id>`. For the two-site Windows/IIS layout the API host is the `:3443` site, for example `https://localhost:3443/api/auth/callback/1`.
+5. **Register**, then from **Overview** copy the **Application (client) ID** and **Directory (tenant) ID**.
+
+![Entra ID Overview showing client and tenant IDs](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/entra/02-overview-ids.png)
+
+:::note
+
+The redirect URI points at the **API** site, not the frontend. `<oidc-id>` is the `oidc` table row id; on a fresh single-provider install it is `1`.
+
+:::
+
+### A2. Create a client secret
+
+1. **Certificates & secrets** → **Client secrets** → **New client secret** → set a description and expiry → **Add**.
+2. Copy the secret **Value** immediately (shown only once) — this is the `clientSecret`. (Ignore "Secret ID".)
+
+![Entra ID client secret creation](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/entra/03-client-secret.png)
+
+### A3. API permissions
+
+1. **API permissions** → **Add a permission** → **Microsoft Graph** → **Delegated permissions** → add `openid` and `email`.
+2. **Grant admin consent** for your directory; confirm the status shows "Granted".
+
+![Entra ID API permissions with admin consent granted](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/entra/04-api-permissions.png)
+
+### A4. Add the `email` optional claim (required)
+
+Entra v2.0 does not emit the `email` claim by default, and the auth strategy rejects login with `Invalid email from IdP` when it is empty.
+
+1. **Token configuration** → **Add optional claim** → **Token type: ID** → check `email` → **Add**.
+2. If prompted to enable the associated Microsoft Graph permission, accept.
+
+![Entra ID optional email claim in Token configuration](https://edfidocs.blob.core.windows.net/$web/img/reference/admin-app/configuration/identity-provider/entra/05-optional-claim-email.png)
+
+:::warning
+
+Even with the optional claim, a directory user whose profile has no email may still send an empty `email`. Use an account with a real email address, or set the user's Email attribute in Entra.
+
+:::
+
+### Single-tenant vs. multitenant
+
+This section uses **single-tenant**, the recommended model for on-premise deployments where each Implementation Partner runs its own Admin App against its own directory. The issuer is `https://login.microsoftonline.com/<tenantId>/v2.0` and token validation is straightforward.
+
+Multitenant is **not supported out of the box**: it uses the `common` endpoint, whose discovery document declares a templated issuer while tokens carry each user's real tenant id — which Admin App's strict issuer validation would reject. It also widens the sign-in surface to any Microsoft organization. A safe multitenant setup would need pattern-based issuer validation plus a tenant allowlist and `tid` validation, none of which exist today.
+
+## Part B — Configure the API (`production.js`)
+
+Set the OIDC block in `packages/api/config/production.js`; the API seeds it into the `oidc` table on first startup. See [Configuring Ed-Fi Admin App](../configuring-admin-app.md) for the full file (database, encryption key, Yopass, and so on).
+
+```javascript
+SAMPLE_OIDC_CONFIG: {
+  issuer:       'https://login.microsoftonline.com/<tenantId>/v2.0',
+  clientId:     '<appClientId>',
+  clientSecret: '<clientSecret>',
+  scope:        'openid profile email',
+},
+USE_PKCE: true,
+// First admin: must match the email Entra sends for this person.
+ADMIN_USERNAME: '<admin-email>',
+```
+
+Differences from the Keycloak example:
+
+- `issuer` → the Entra v2.0 issuer, not a Keycloak realm URL.
+- `scope` → `openid profile email`. The Keycloak example ships `scope: ''`, which fails for Entra: without the `email` scope the `email` claim is absent and login is rejected with `Invalid email from IdP`.
+- `clientId` / `clientSecret` → the App Registration values from Part A.
+
+:::note
+
+A successful sign-in still fails with `USER_NOT_FOUND` unless a user with that email exists with a role. On a fresh install, startup seeding creates the admin from `ADMIN_USERNAME` with roleId `2` (Global admin) when the `user` table is empty. Roles for reference: 1 = Tenant user global, **2 = Global admin**, 3 = Global viewer, 6 = Tenant admin, 7 = Tenant viewer, 8 = Standard tenant access.
+
+:::
+
+## Part C — Configure the frontend
+
+Set the frontend build-time variables in `packages/fe/.env` (see [Configuring Ed-Fi Admin App](../configuring-admin-app.md) for the full set). Only two are provider-specific for Entra:
+
+- `VITE_OIDC_ID=1` — the `oidc` row the login button targets (`1` on a single-provider fresh install; the shipped default).
+- `VITE_IDP_ACCOUNT_URL=https://myaccount.microsoft.com/` — drives the Account → Account Management self-service link.
+
+:::warning
+
+Do not point `VITE_IDP_ACCOUNT_URL` at `portal.azure.com` or `entra.microsoft.com` — those are admin consoles, not end-user self-service. These are build-time variables, so set them before `npm run build:fe`.
+
+:::
+
+## Part D — Validate end-to-end
+
+1. Start the API so it reads the `oidc` table and registers the Entra strategy.
+2. Open the Admin App in a clean browser at the frontend site, for example `https://localhost:4443`.
+3. Login redirects to Microsoft sign-in, then back through `/api/auth/callback/<oidc-id>` into the app.
+4. Confirm you land authenticated (no `Invalid email from IdP`, no `USER_NOT_FOUND`).
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Invalid email from IdP` | `email` claim empty | Re-check A4 and that `scope` includes `email`; use an account with a real email |
+| `USER_NOT_FOUND` | admin not seeded with that email | Set `ADMIN_USERNAME` (Part B) |
+| `NO_ROLE` | user exists without a role | Assign a role (for example, roleId 2) |
+| `redirect_uri` mismatch (from Microsoft) | Entra redirect URI does not match the callback | Make them match exactly |
+| Discovery error at API startup | wrong issuer | Confirm `https://login.microsoftonline.com/<tenantId>/v2.0` |

--- a/docs/reference/5-admin-app/configuration/identity-provider/microsoft-entra-id.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/microsoft-entra-id.md
@@ -15,12 +15,27 @@ Register the Entra application **first** — its issuer, client id, and secret g
 ## Prerequisites
 
 - A Windows/IIS server with SQL Server prepared per the [Windows IIS installation guide](../../getting-started/windows-iis-installation/readme.md).
-- Access to the Microsoft Entra admin center with permission to create App Registrations and grant admin consent (for example, Cloud Application Administrator).
+- Sufficient Microsoft Entra directory roles: **Cloud Application Administrator** (or higher) to create the App Registration, and **Privileged Role Administrator** or **Global Administrator** to grant admin consent in step A3. Cloud Application Administrator alone can create the app but cannot grant tenant-wide admin consent; if your account lacks that privilege, have a Global Administrator grant consent afterward.
 - The host where the Admin App **API** is served — used in the redirect URI. In the two-site Windows/IIS layout this is the API site, for example `https://localhost:3443`.
 - Your Entra **Tenant ID**.
 - The **email of the first admin user** — it must equal the email Entra sends for that person. It is set as `ADMIN_USERNAME` during installation, so decide it beforehand.
 
 ## Part A — Register the application in Microsoft Entra ID
+
+:::tip Automate Part A with a script
+
+Instead of the manual steps below, you can script this entire section with `idp-entra-setup.ps1` from the [Admin App Installation Scripts repository](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts) (`windows-install` folder). Using the Microsoft Graph PowerShell SDK, it creates a single-tenant App Registration with the Web redirect URI, the `email` ID-token optional claim, the delegated `openid`/`email` permissions, and a client secret, and grants tenant-wide admin consent (or prints the exact manual consent URL when your account lacks the privilege). It outputs the client id, issuer, and redirect URI, and writes the secret to an ACL-restricted file — the values you need for Part B or the [automated install](../../getting-started/windows-iis-installation/automated.md).
+
+It needs the same Entra roles as the manual path (see [Prerequisites](#prerequisites)) plus the Microsoft Graph `Application.ReadWrite.All` scope, and does not require an elevated session.
+
+```powershell
+# From the windows-install folder:
+$r = .\idp-entra-setup.ps1 -DisplayName 'Ed-Fi Admin App' -TenantId '<tenant-id>'
+```
+
+By default the redirect URI targets `https://localhost:3443/api/auth/callback/1`; pass `-ApiBaseUrl` for a different API host, or `-RedirectCallbackId <id>` if the install reports an `oidc` row id other than `1`. Run `Get-Help .\idp-entra-setup.ps1 -Full` for all parameters.
+
+:::
 
 ### A1. Create the App Registration
 

--- a/docs/reference/5-admin-app/configuration/identity-provider/microsoft-entra-id.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/microsoft-entra-id.md
@@ -95,7 +95,7 @@ ADMIN_USERNAME: '<admin-email>',
 Differences from the Keycloak example:
 
 - `issuer` → the Entra v2.0 issuer, not a Keycloak realm URL.
-- `scope` → `openid profile email`. The Keycloak example ships `scope: ''`, which fails for Entra: without the `email` scope the `email` claim is absent and login is rejected with `Invalid email from IdP`.
+- `scope` → `openid profile email`. Keycloak returns the `email` claim through its default client scopes even without an explicit scope, but Entra does not: without the `email` scope the claim is absent and login is rejected with `Invalid email from IdP`.
 - `clientId` / `clientSecret` → the App Registration values from Part A.
 
 :::note

--- a/docs/reference/5-admin-app/configuration/identity-provider/readme.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/readme.md
@@ -5,7 +5,7 @@ sidebar_label: Configuring an Identity Provider
 
 # Configuring an Identity Provider for Ed-Fi Admin App
 
-The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing user accounts. In theory any OIDC-compatible IdP will suffice. The Ed-Fi Alliance has validated three providers end-to-end on the native Windows/IIS deployment: [Keycloak](./keycloak.md) (the default example), [Microsoft Entra ID](./microsoft-entra-id.md), and [Google Workspace](./google-workspace.md). Each has its own guide, linked below. Another development team has used Auth0.
+The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing user accounts. In theory any OIDC-compatible IdP will suffice. The Ed-Fi Alliance has validated three providers end-to-end on the native Windows/IIS deployment: [Keycloak](./keycloak.md) (the default example), [Microsoft Entra ID](./microsoft-entra-id.md), and [Google Workspace](./google-workspace.md). Each has its own guide, linked below.
 
 ## General IdP Guidance and Configuration
 

--- a/docs/reference/5-admin-app/configuration/identity-provider/readme.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/readme.md
@@ -59,12 +59,13 @@ The Ed-Fi Admin App implements a two-layer security model:
 
 - The Admin App maintains its own authorization system independent of the IdP
 - User permissions, roles, and access controls are managed within the Admin App database
-- The IdP does not need to provide special claims, scopes, or role information
+- The IdP does not need to provide Admin App roles or permissions; those are managed within the Admin App database
+- The Admin App does require a populated `email` claim for each user (typically via the `email` scope; some providers require enabling the claim)
 - Users only need a valid IdP account; all authorization decisions are made by the Admin App
 
 **What this means for IdP configuration:**
 
-- You do not need to configure custom claims or scopes in your IdP
+- Ensure your IdP issues the `email` claim for users (Entra requires adding `email` as an optional claim)
 - You do not need to map roles or permissions from the IdP to the Admin App
 - Users simply need a valid account in the IdP with basic profile information (username, email, name)
 - All permission management happens within the Admin App after successful authentication

--- a/docs/reference/5-admin-app/configuration/identity-provider/readme.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/readme.md
@@ -1,0 +1,88 @@
+---
+sidebar_position: 1
+sidebar_label: Configuring an Identity Provider
+---
+
+# Configuring an Identity Provider for Ed-Fi Admin App
+
+The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing user accounts. In theory any OIDC-compatible IdP will suffice. The Ed-Fi Alliance has validated three providers end-to-end on the native Windows/IIS deployment: [Keycloak](./keycloak.md) (the default example), [Microsoft Entra ID](./microsoft-entra-id.md), and [Google Workspace](./google-workspace.md). Each has its own guide, linked below. Another development team has used Auth0.
+
+## General IdP Guidance and Configuration
+
+### Backend Configuration Settings
+
+The Ed-Fi Admin App backend requires specific configuration settings to connect to your OIDC-compatible Identity Provider. These settings are typically configured in the application's environment variables or configuration files.
+
+Key configuration parameters include:
+
+- **Authority URL**: The base URL of your IdP (e.g., `https://your-keycloak-server/realms/edfi`)
+- **Client ID**: The client identifier registered in your IdP (e.g., `edfiadminapp`)
+- **Client Secret**: The confidential secret associated with the client
+- **Redirect URI**: The callback URL where the IdP sends authentication responses (e.g., `https://your-admin-app-api-url/api/auth/callback/<oidc-id>`, where `<oidc-id>` is the id of the `oidc` table row)
+- **Post Logout Redirect URI**: Where users are redirected after logging out (e.g., `https://your-admin-app-url/api/auth/post-logout`)
+- **Response Type**: Typically set to `code` for authorization code flow
+- **Scope**: The OIDC scopes requested, typically `openid profile email`
+
+These settings must match the configuration in your IdP to ensure proper authentication flow.
+
+### Bootstrap User Concept
+
+The Ed-Fi Admin App uses a **bootstrap user** mechanism to initialize the system with its first administrative user. This is necessary because:
+
+1. The application requires at least one user with administrative privileges to configure the system
+2. User permissions and roles are managed within the Admin App itself, separate from the IdP
+3. The bootstrap user provides the initial entry point to set up additional users and permissions
+
+**How it works:**
+
+- When the Admin App starts for the first time (or when the database is empty), it looks for a configured bootstrap user
+- This user's email address or username is specified in the application configuration
+- When this user first authenticates through the IdP, they are automatically granted administrative privileges in the Admin App
+- Subsequent users who authenticate must be granted permissions by an existing administrator
+
+:::tip
+Configure the bootstrap user email/username before deploying the application to production. This ensures you can immediately access the system after initial deployment.
+:::
+
+### Authentication and Authorization Architecture
+
+The Ed-Fi Admin App implements a two-layer security model:
+
+**Authentication (IdP Layer):**
+
+- The Identity Provider handles user authentication and session management
+- Users log in through the IdP interface (e.g., Keycloak login page)
+- The IdP validates credentials and issues authentication tokens
+- The application uses cookie-based authentication to maintain user sessions
+
+**Authorization (Admin App Layer):**
+
+- The Admin App maintains its own authorization system independent of the IdP
+- User permissions, roles, and access controls are managed within the Admin App database
+- The IdP does not need to provide special claims, scopes, or role information
+- Users only need a valid IdP account; all authorization decisions are made by the Admin App
+
+**What this means for IdP configuration:**
+
+- You do not need to configure custom claims or scopes in your IdP
+- You do not need to map roles or permissions from the IdP to the Admin App
+- Users simply need a valid account in the IdP with basic profile information (username, email, name)
+- All permission management happens within the Admin App after successful authentication
+
+This separation of concerns allows for flexible user management while maintaining security and simplifying IdP setup.
+
+### How Provider Settings Are Loaded
+
+Admin App's OIDC integration is generic and table-driven. On startup the API reads the `oidc` table and registers one authentication strategy per provider, discovering each provider's endpoints automatically from `{issuer}/.well-known/openid-configuration`. Provider values reach that table through the API config file `packages/api/config/production.js` (the `SAMPLE_OIDC_CONFIG` block), which the API seeds into the `oidc` table on first startup when the table is empty.
+
+Configuring any provider therefore follows the same five steps: (1) register an application with the provider, (2) put its values in `production.js` (`SAMPLE_OIDC_CONFIG`), (3) set the first admin's email (`ADMIN_USERNAME`), (4) set the frontend variables, and (5) sign in. No application code changes are required. The app uses the `email` claim as the username and matches it to a user that must already exist with a role.
+
+On a fresh, single-provider install the `oidc` table starts empty, so the provider you configure lands at row id `1` — the frontend's default (`VITE_OIDC_ID=1`).
+
+## Provider Guides
+
+Step-by-step guides for the three validated providers:
+
+- [Keycloak](./keycloak.md) — the bundled default example.
+- [Microsoft Entra ID](./microsoft-entra-id.md)
+- [Google Workspace](./google-workspace.md)

--- a/docs/reference/5-admin-app/configuration/identity-provider/readme.md
+++ b/docs/reference/5-admin-app/configuration/identity-provider/readme.md
@@ -5,7 +5,7 @@ sidebar_label: Configuring an Identity Provider
 
 # Configuring an Identity Provider for Ed-Fi Admin App
 
-The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing user accounts. In theory any OIDC-compatible IdP will suffice. The Ed-Fi Alliance has validated three providers end-to-end on the native Windows/IIS deployment: [Keycloak](./keycloak.md) (the default example), [Microsoft Entra ID](./microsoft-entra-id.md), and [Google Workspace](./google-workspace.md). Each has its own guide, linked below.
+The Ed-Fi Admin App uses an Open ID Connect (OIDC) compatible Identity Provider (IdP) for managing user accounts. In theory any OIDC-compatible IdP will suffice. The Ed-Fi Alliance has validated four providers end-to-end on the native Windows/IIS deployment: [Keycloak](./keycloak.md) (the default example), [Microsoft Entra ID](./microsoft-entra-id.md), [Google Workspace](./google-workspace.md), and [Auth0](./auth0.md). Each has its own guide, linked below.
 
 ## General IdP Guidance and Configuration
 
@@ -82,8 +82,9 @@ On a fresh, single-provider install the `oidc` table starts empty, so the provid
 
 ## Provider Guides
 
-Step-by-step guides for the three validated providers:
+Step-by-step guides for the four validated providers:
 
 - [Keycloak](./keycloak.md) — the bundled default example.
 - [Microsoft Entra ID](./microsoft-entra-id.md)
 - [Google Workspace](./google-workspace.md)
+- [Auth0](./auth0.md)

--- a/docs/reference/5-admin-app/getting-started/docker-installation.md
+++ b/docs/reference/5-admin-app/getting-started/docker-installation.md
@@ -153,11 +153,11 @@ Some special characters are not currently supported in the database password (fo
 :::
 
 :::note
-**Important:** `VITE_IDP_ACCOUNT_URL` should point to your identity provider's **end-user account-management page**, not its admin console. It is provider-specific: Keycloak `https://<host>/auth/realms/{realm}/account/`, Microsoft Entra ID `https://myaccount.microsoft.com/`, Google Workspace `https://myaccount.google.com/`.
+**Important:** `VITE_IDP_ACCOUNT_URL` should point to your identity provider's **end-user account-management page**, not its admin console. It is provider-specific: Keycloak `https://<host>/auth/realms/{realm}/account/`, Microsoft Entra ID `https://myaccount.microsoft.com/`, Google Workspace `https://myaccount.google.com/`, Auth0 has no hosted account page (use the tenant URL as a placeholder or your own profile page).
 :::
 
 :::note
-The bundled stack ships **Keycloak** as the example OIDC provider. Because the Admin App uses generic OIDC discovery, [Microsoft Entra ID](../configuration/identity-provider/microsoft-entra-id.md) and [Google Workspace](../configuration/identity-provider/google-workspace.md) also work: set the provider values (`issuer`, `clientId`, `clientSecret`, `scope`) in `packages/api/config/production.js-edfi` (baked into the API image as `production.js`), rebuild with `./start-services.ps1 -Rebuild`, and select it from the frontend with `VITE_OIDC_ID`.
+The bundled stack ships **Keycloak** as the example OIDC provider. Because the Admin App uses generic OIDC discovery, [Microsoft Entra ID](../configuration/identity-provider/microsoft-entra-id.md), [Google Workspace](../configuration/identity-provider/google-workspace.md), and [Auth0](../configuration/identity-provider/auth0.md) also work: set the provider values (`issuer`, `clientId`, `clientSecret`, `scope`) in `packages/api/config/production.js-edfi` (baked into the API image as `production.js`), rebuild with `./start-services.ps1 -Rebuild`, and select it from the frontend with `VITE_OIDC_ID`.
 :::
 
 :::note

--- a/docs/reference/5-admin-app/getting-started/docker-installation.md
+++ b/docs/reference/5-admin-app/getting-started/docker-installation.md
@@ -141,6 +141,11 @@ VITE_STARTING_GUIDE=https://docs.ed-fi.org/reference/admin-app/configuration/glo
 VITE_CONTACT=https://community.ed-fi.org/
 VITE_APPLICATION_NAME="Ed-Fi Admin App"
 VITE_IDP_ACCOUNT_URL=https://yourdomain.com/auth/realms/edfi/account/
+
+# OIDC provider selector: the id of the `oidc` table row to sign in with
+# (must match the redirect-URI callback id). On a fresh single-provider
+# install this is 1.
+VITE_OIDC_ID=1
 ```
 
 :::warning
@@ -149,6 +154,14 @@ Some special characters are not currently supported in the database password (fo
 
 :::note
 **Important:** `VITE_IDP_ACCOUNT_URL` should point to your identity provider's **end-user account-management page**, not its admin console. It is provider-specific: Keycloak `https://<host>/auth/realms/{realm}/account/`, Microsoft Entra ID `https://myaccount.microsoft.com/`, Google Workspace `https://myaccount.google.com/`.
+:::
+
+:::note
+The bundled stack ships **Keycloak** as the example OIDC provider. Because the Admin App uses generic OIDC discovery, [Microsoft Entra ID](../configuration/identity-provider/microsoft-entra-id.md) and [Google Workspace](../configuration/identity-provider/google-workspace.md) also work: set the provider values (`issuer`, `clientId`, `clientSecret`, `scope`) in `packages/api/config/production.js-edfi` (baked into the API image as `production.js`), rebuild with `./start-services.ps1 -Rebuild`, and select it from the frontend with `VITE_OIDC_ID`.
+:::
+
+:::note
+For an external provider, the redirect/callback URI is `<MY_URL>/api/auth/callback/<oidc-id>` — with the Compose stack's default NGiNX proxy (all services served from `https://localhost`), that is `https://localhost/adminapp-api/api/auth/callback/1`.
 :::
 
 - **SSL Certificates:** Replace self-signed certificates with production certificates in a live environment.

--- a/docs/reference/5-admin-app/getting-started/docker-installation.md
+++ b/docs/reference/5-admin-app/getting-started/docker-installation.md
@@ -148,9 +148,7 @@ Some special characters are not currently supported in the database password (fo
 :::
 
 :::note
-**Important:** The `VITE_IDP_ACCOUNT_URL` value may differ from your Keycloak admin console URL.
-This should point to the **account management interface** (`/auth/realms/{realm-name}/account/`), not the admin console.
-Ensure this matches your actual Keycloak realm configuration and domain.
+**Important:** `VITE_IDP_ACCOUNT_URL` should point to your identity provider's **end-user account-management page**, not its admin console. It is provider-specific: Keycloak `https://<host>/auth/realms/{realm}/account/`, Microsoft Entra ID `https://myaccount.microsoft.com/`, Google Workspace `https://myaccount.google.com/`.
 :::
 
 - **SSL Certificates:** Replace self-signed certificates with production certificates in a live environment.
@@ -162,6 +160,6 @@ A fresh install has no users, teams, or environments yet. The Global Admin Quick
 
 - [Global Admin Quick Start](../user-guide/global-admin-quick-start/readme.md)
 - [Configuring Ed-Fi Admin App](../configuration/configuring-admin-app.md)
-- [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
+- [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md)
 - [Security Considerations](../configuration/security-considerations.md)
 - [Global Administration Tasks](../configuration/global-administration-tasks.md)

--- a/docs/reference/5-admin-app/getting-started/readme.md
+++ b/docs/reference/5-admin-app/getting-started/readme.md
@@ -23,7 +23,7 @@ deployments. It consists of:
 
 - **PostgreSQL or SQL Server Database** (Required) — an empty database created
   for the Admin App (the examples use the name `sbaa`)
-- **OIDC Provider** (Required) - Keycloak, Microsoft Entra ID, or Google Workspace; see
+- **OIDC Provider** (Required) - Keycloak, Microsoft Entra ID, Google Workspace, or Auth0; see
   - [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md)
 - **Reverse Proxy** (Recommended for production) - Nginx, IIS, or similar
   - Provides a single public entry point for the Web Application and API (this avoids cross-origin/CORS between the two sites), plus caching, load balancing, and a place to enforce edge security (for example, a web application firewall).
@@ -32,8 +32,8 @@ deployments. It consists of:
 :::tip
 
 This application runs with any Open ID Connect provider. The Ed-Fi Alliance has
-validated three end-to-end on the Windows/IIS deployment: Keycloak (the bundled
-example), Microsoft Entra ID, and Google Workspace. See
+validated four end-to-end on the Windows/IIS deployment: Keycloak (the bundled
+example), Microsoft Entra ID, Google Workspace, and Auth0. See
 [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md).
 
 :::

--- a/docs/reference/5-admin-app/getting-started/readme.md
+++ b/docs/reference/5-admin-app/getting-started/readme.md
@@ -17,23 +17,24 @@ deployments. It consists of:
 - **Web Application**: React-based single-page application (SPA)
 - **Backend API**: Node.js/NestJS application
 - **Database**: PostgreSQL or SQL Server database for application data
-- **Authentication**: OpenID Connect (OIDC) integration (typically Keycloak)
+- **Authentication**: OpenID Connect (OIDC) integration (any OIDC provider; Keycloak is the bundled example)
 
 ### Required Components
 
 - **PostgreSQL or SQL Server Database** (Required) — an empty database created
   for the Admin App (the examples use the name `sbaa`)
-- **OIDC Provider** (Required) - Keycloak or similar see
-  - [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
+- **OIDC Provider** (Required) - Keycloak, Microsoft Entra ID, or Google Workspace; see
+  - [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md)
 - **Reverse Proxy** (Recommended for production) - Nginx, IIS, or similar
   - Provides a single public entry point for the Web Application and API (this avoids cross-origin/CORS between the two sites), plus caching, load balancing, and a place to enforce edge security (for example, a web application firewall).
   - Not required to obtain HTTPS: each installation path terminates TLS itself. The Windows install scripts deploy the API and Web Application as two IIS sites directly (no front-facing proxy) with TLS and enforcing security headers, and the app is architecturally optional behind a proxy by design, honoring `X-Forwarded-*` headers when used.
 
 :::tip
 
-This application runs with any Open ID Connect provider. Keycloak is the only
-fully supported provider in this release; Microsoft Entra ID and Google Workspace
-have been tested and gain full support in Admin App v4.1.
+This application runs with any Open ID Connect provider. The Ed-Fi Alliance has
+validated three end-to-end on the Windows/IIS deployment: Keycloak (the bundled
+example), Microsoft Entra ID, and Google Workspace. See
+[Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md).
 
 :::
 
@@ -95,6 +96,6 @@ before going to production.
 
 - [Roadmap to Success](./roadmap-to-success.md)
 - [Configuring Ed-Fi Admin App](../configuration/configuring-admin-app.md)
-- [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
+- [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md)
 - [Security Considerations](../configuration/security-considerations.md)
 - [Global Administration Tasks](../configuration/global-administration-tasks.md)

--- a/docs/reference/5-admin-app/getting-started/unix-installation.md
+++ b/docs/reference/5-admin-app/getting-started/unix-installation.md
@@ -68,11 +68,14 @@ This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQ
        CLIENT_SECRET: 'your-client-secret',
        MACHINE_AUDIENCE: 'edfiadminapp-api'
      },
+     // Identity provider (OIDC). The values below are the Keycloak example;
+     // for Microsoft Entra ID or Google Workspace, set issuer/clientId/clientSecret/scope
+     // per the identity-provider guide linked in "Next steps".
      SAMPLE_OIDC_CONFIG: {
       issuer: 'https://your-keycloak-server/auth/realms/edfi',
       clientId: 'edfiadminapp',
       clientSecret: 'your-client-secret',
-      scope: '',
+      scope: 'openid email profile',
      },
      //this should match with a user in your Idp
      ADMIN_USERNAME: 'admin@example.com',
@@ -92,6 +95,10 @@ This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQ
 
    :::tip
    `your-64-hex-char-encryption-key` can be generated with `openssl rand -hex 32` or `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
+   :::
+
+   :::note
+   This path uses **Keycloak** as the example OIDC provider. Because the Admin App uses generic OIDC discovery, [Microsoft Entra ID](../configuration/identity-provider/microsoft-entra-id.md) and [Google Workspace](../configuration/identity-provider/google-workspace.md) also work: set `issuer`/`clientId`/`clientSecret`/`scope` and `ADMIN_USERNAME` accordingly, and set the frontend's `VITE_OIDC_ID` and `VITE_IDP_ACCOUNT_URL` in `packages/fe/.env` **before** `npm run build:fe`. The redirect/callback URI is `<MY_URL>/api/auth/callback/<oidc-id>` (here, `https://your-domain.com/adminapp-api/api/auth/callback/<oidc-id>`).
    :::
 
 4. **Create systemd service**:

--- a/docs/reference/5-admin-app/getting-started/unix-installation.md
+++ b/docs/reference/5-admin-app/getting-started/unix-installation.md
@@ -69,8 +69,9 @@ This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQ
        MACHINE_AUDIENCE: 'edfiadminapp-api'
      },
      // Identity provider (OIDC). The values below are the Keycloak example;
-     // for Microsoft Entra ID or Google Workspace, set issuer/clientId/clientSecret/scope
-     // per the identity-provider guide linked in "Next steps".
+     // for Microsoft Entra ID, Google Workspace, or Auth0, set
+     // issuer/clientId/clientSecret/scope per the identity-provider guide
+     // linked in "Next steps".
      SAMPLE_OIDC_CONFIG: {
       issuer: 'https://your-keycloak-server/auth/realms/edfi',
       clientId: 'edfiadminapp',
@@ -98,7 +99,7 @@ This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQ
    :::
 
    :::note
-   This path uses **Keycloak** as the example OIDC provider. Because the Admin App uses generic OIDC discovery, [Microsoft Entra ID](../configuration/identity-provider/microsoft-entra-id.md) and [Google Workspace](../configuration/identity-provider/google-workspace.md) also work: set `issuer`/`clientId`/`clientSecret`/`scope` and `ADMIN_USERNAME` accordingly, and set the frontend's `VITE_OIDC_ID` and `VITE_IDP_ACCOUNT_URL` in `packages/fe/.env` **before** `npm run build:fe`. The redirect/callback URI is `<MY_URL>/api/auth/callback/<oidc-id>` (here, `https://your-domain.com/adminapp-api/api/auth/callback/<oidc-id>`).
+   This path uses **Keycloak** as the example OIDC provider. Because the Admin App uses generic OIDC discovery, [Microsoft Entra ID](../configuration/identity-provider/microsoft-entra-id.md), [Google Workspace](../configuration/identity-provider/google-workspace.md), and [Auth0](../configuration/identity-provider/auth0.md) also work: set `issuer`/`clientId`/`clientSecret`/`scope` and `ADMIN_USERNAME` accordingly, and set the frontend's `VITE_OIDC_ID` and `VITE_IDP_ACCOUNT_URL` in `packages/fe/.env` **before** `npm run build:fe`. The redirect/callback URI is `<MY_URL>/api/auth/callback/<oidc-id>` (here, `https://your-domain.com/adminapp-api/api/auth/callback/<oidc-id>`).
    :::
 
 4. **Create systemd service**:

--- a/docs/reference/5-admin-app/getting-started/unix-installation.md
+++ b/docs/reference/5-admin-app/getting-started/unix-installation.md
@@ -196,6 +196,6 @@ A fresh install has no users, teams, or environments yet. The Global Admin Quick
 
 - [Global Admin Quick Start](../user-guide/global-admin-quick-start/readme.md)
 - [Configuring Ed-Fi Admin App](../configuration/configuring-admin-app.md)
-- [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
+- [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md)
 - [Security Considerations](../configuration/security-considerations.md)
 - [Global Administration Tasks](../configuration/global-administration-tasks.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -69,7 +69,6 @@ The script prompts for `-SqlAdminPassword`, `-AppDbPassword`, and the rest, the 
 
 ```powershell
 .\install-all.ps1 -IdpProvider microsoft `
-  -SaPassword (Read-Host -AsSecureString 'SQL Server sa password') `
   -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
   -OidcIssuer 'https://login.microsoftonline.com/<tenant-id>/v2.0' `
   -OidcClientId '<application-id>' `
@@ -81,7 +80,6 @@ The script prompts for `-SqlAdminPassword`, `-AppDbPassword`, and the rest, the 
 
 ```powershell
 .\install-all.ps1 -IdpProvider google `
-  -SaPassword (Read-Host -AsSecureString 'SQL Server sa password') `
   -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
   -OidcClientId '<google-client-id>' `
   -OidcClientSecret (Read-Host -AsSecureString 'Google client secret') `

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -65,7 +65,7 @@ Pass a parameter only to change something the defaults do not cover. PostgreSQL 
 
 The script prompts for `-SqlAdminPassword`, `-AppDbPassword`, and the rest, the same as any other run. It provisions the Admin App login as a contained user, connects with encryption and validates the server certificate, and configures the API to do the same — nothing to set by hand. For a remote server that presents a self-signed certificate rather than a CA-issued one, add `-TrustServerCertificate`, which turns that validation off. Azure rejects a database password containing the login name, so avoid `edfi_adminapp` in the value; the script checks this up front.
 
-**Microsoft Entra ID, SQL Server** — an external OIDC provider. Register the application and its redirect URIs in Entra first, and make sure a user exists there whose email matches `-AdminUsername`:
+**Microsoft Entra ID, SQL Server** — an external OIDC provider. Register the application and its redirect URIs in Entra first (or script that step with `idp-entra-setup.ps1` — see [Microsoft Entra ID](../../configuration/identity-provider/microsoft-entra-id.md#part-a--register-the-application-in-microsoft-entra-id)), and make sure a user exists there whose email matches `-AdminUsername`:
 
 ```powershell
 .\install-all.ps1 -IdpProvider microsoft `

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -86,7 +86,18 @@ The script prompts for `-SqlAdminPassword`, `-AppDbPassword`, and the rest, the 
   -AdminUsername 'you@yourdomain.com'
 ```
 
-`-IdpProvider` accepts `keycloak`, `microsoft`, `google`, or `other` (a generic OIDC provider you register yourself). Pass `-OidcIssuer` and `-OidcClientId` for `microsoft` and `other`; for `keycloak` and `google` the issuer is defaulted. In every external-provider example, `-AdminUsername` is the email of the first (bootstrap) administrator — it must exactly match the `email` claim your identity provider returns for that user. See [Configuring an Identity Provider](../../configuration/identity-provider/readme.md) for how to register the application with each provider.
+**Auth0, SQL Server** — an external OIDC provider. Create the Single Page Web Application in the Auth0 dashboard first (see [Auth0](../../configuration/identity-provider/auth0.md)), and make sure an Auth0 user exists whose email matches `-AdminUsername`:
+
+```powershell
+.\install-all.ps1 -IdpProvider auth0 `
+  -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
+  -OidcIssuer 'https://your-tenant.us.auth0.com' `
+  -OidcClientId '<Single-Page-App-Client-ID>' `
+  -OidcClientSecret (Read-Host -AsSecureString 'Auth0 client secret') `
+  -AdminUsername 'you@yourorg.com'
+```
+
+`-IdpProvider` accepts `keycloak`, `microsoft`, `google`, `auth0`, or `other` (a generic OIDC provider you register yourself). Pass `-OidcIssuer` and `-OidcClientId` for `microsoft`, `auth0`, and `other`; for `keycloak` and `google` the issuer is defaulted. For `auth0`, either slash form of the issuer works — the installer normalizes it into the forms each setting expects. In every external-provider example, `-AdminUsername` is the email of the first (bootstrap) administrator — it must exactly match the `email` claim your identity provider returns for that user. See [Configuring an Identity Provider](../../configuration/identity-provider/readme.md) for how to register the application with each provider.
 
 :::note
 By default the sites use a self-signed certificate (auto-trusted on this machine only). To bind a real certificate, pass `-CertificateThumbprint`, or `-CertificatePfxPath` with `-CertificatePassword` (see [TLS and certificates](./manual.md#tls-and-certificates)). Yopass is off by default; add `-SetupYopassDocker` to stand up a local Yopass via Docker, or `-YopassUrl <url>` to point at an existing one.

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -65,6 +65,31 @@ Pass a parameter only to change something the defaults do not cover. PostgreSQL 
 
 The script prompts for `-SqlAdminPassword`, `-AppDbPassword`, and the rest, the same as any other run. It provisions the Admin App login as a contained user, connects with encryption and validates the server certificate, and configures the API to do the same — nothing to set by hand. For a remote server that presents a self-signed certificate rather than a CA-issued one, add `-TrustServerCertificate`, which turns that validation off. Azure rejects a database password containing the login name, so avoid `edfi_adminapp` in the value; the script checks this up front.
 
+**Microsoft Entra ID, SQL Server** — an external OIDC provider. Register the application and its redirect URIs in Entra first, and make sure a user exists there whose email matches `-AdminUsername`:
+
+```powershell
+.\install-all.ps1 -IdpProvider microsoft `
+  -SaPassword (Read-Host -AsSecureString 'SQL Server sa password') `
+  -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
+  -OidcIssuer 'https://login.microsoftonline.com/<tenant-id>/v2.0' `
+  -OidcClientId '<application-id>' `
+  -OidcClientSecret (Read-Host -AsSecureString 'Entra client secret') `
+  -AdminUsername 'you@yourtenant.onmicrosoft.com'
+```
+
+**Google Workspace, SQL Server** — an external OIDC provider. The issuer is defaulted for Google; register the OAuth client first:
+
+```powershell
+.\install-all.ps1 -IdpProvider google `
+  -SaPassword (Read-Host -AsSecureString 'SQL Server sa password') `
+  -AppDbPassword (Read-Host -AsSecureString 'Admin App DB login password') `
+  -OidcClientId '<google-client-id>' `
+  -OidcClientSecret (Read-Host -AsSecureString 'Google client secret') `
+  -AdminUsername 'you@yourdomain.com'
+```
+
+`-IdpProvider` accepts `keycloak`, `microsoft`, `google`, or `other` (a generic OIDC provider you register yourself). Pass `-OidcIssuer` and `-OidcClientId` for `microsoft` and `other`; for `keycloak` and `google` the issuer is defaulted. In every external-provider example, `-AdminUsername` is the email of the first (bootstrap) administrator — it must exactly match the `email` claim your identity provider returns for that user. See [Configuring an Identity Provider](../../configuration/identity-provider/readme.md) for how to register the application with each provider.
+
 :::note
 By default the sites use a self-signed certificate (auto-trusted on this machine only). To bind a real certificate, pass `-CertificateThumbprint`, or `-CertificatePfxPath` with `-CertificatePassword` (see [TLS and certificates](./manual.md#tls-and-certificates)). Yopass is off by default; add `-SetupYopassDocker` to stand up a local Yopass via Docker, or `-YopassUrl <url>` to point at an existing one.
 :::
@@ -109,6 +134,6 @@ A fresh install has no users, teams, or environments yet. The Global Admin Quick
 
 - [Global Admin Quick Start](../../user-guide/global-admin-quick-start/readme.md)
 - [Configuring Ed-Fi Admin App](../../configuration/configuring-admin-app.md)
-- [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md)
+- [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider/readme.md)
 - [Security Considerations](../../configuration/security-considerations.md)
 - [Global Administration Tasks](../../configuration/global-administration-tasks.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -96,7 +96,7 @@ Install the Node.js major version pinned in the Admin App's `package.json` (`eng
 
 ### Identity provider
 
-This guide uses **Keycloak**, running locally, as the example OIDC identity provider; Microsoft Entra ID and Google Workspace are also supported (see the guide linked below). Install a supported LTS JDK — Keycloak 26.6 supports OpenJDK 17, 21, or 25 — then download and start [Keycloak](https://www.keycloak.org/) and create the `edfi` realm, the `edfiadminapp` confidential client, and a test user.
+This guide uses **Keycloak**, running locally, as the example OIDC identity provider; Microsoft Entra ID, Google Workspace, and Auth0 are also supported (see the guide linked below). Install a supported LTS JDK — Keycloak 26.6 supports OpenJDK 17, 21, or 25 — then download and start [Keycloak](https://www.keycloak.org/) and create the `edfi` realm, the `edfiadminapp` confidential client, and a test user.
 
 :::note
 Register these in the Keycloak client (HTTPS, matching the default ports):

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -14,7 +14,7 @@ Prepare the following on the Windows host before deploying the API and Web Appli
 - **[IIS modules](#iis-modules)** — the URL Rewrite Module and an httpPlatform handler.
 - **[Database](#database)** — SQL Server (default) or PostgreSQL.
 - **[Node.js](#nodejs)** — the major version pinned in the Admin App's `package.json` (currently `>=22`).
-- **[Identity provider](#identity-provider)** — an OIDC provider; this guide uses a local Keycloak example.
+- **[Identity provider](../../configuration/identity-provider/readme.md)** — an OIDC provider; this guide uses a local Keycloak example.
 - **[TLS certificate](#tls-and-certificates)** — a CA-issued certificate, or a self-signed one for local use.
 - **[Yopass](#yopass-optional)** (optional) — for one-time credential links.
 
@@ -96,7 +96,7 @@ Install the Node.js major version pinned in the Admin App's `package.json` (`eng
 
 ### Identity provider
 
-This guide uses **Keycloak**, running locally, as the example OIDC identity provider. Install a supported LTS JDK — Keycloak 26.6 supports OpenJDK 17, 21, or 25 — then download and start [Keycloak](https://www.keycloak.org/) and create the `edfi` realm, the `edfiadminapp` confidential client, and a test user.
+This guide uses **Keycloak**, running locally, as the example OIDC identity provider; Microsoft Entra ID and Google Workspace are also supported (see the guide linked below). Install a supported LTS JDK — Keycloak 26.6 supports OpenJDK 17, 21, or 25 — then download and start [Keycloak](https://www.keycloak.org/) and create the `edfi` realm, the `edfiadminapp` confidential client, and a test user.
 
 :::note
 Register these in the Keycloak client (HTTPS, matching the default ports):
@@ -110,7 +110,7 @@ Register these in the Keycloak client (HTTPS, matching the default ports):
 A user must exist in Keycloak whose email/username claim matches the Admin App admin user (default `admin@example.com`). Java is required **only** for the local Keycloak example.
 :::
 
-For more detail, see [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md).
+For more detail, see [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider/readme.md).
 
 :::warning Keycloak does not survive a restart on its own
 A locally installed Keycloak does not come back when the host restarts. The API needs Keycloak already running when the API starts, so it has to start **after** Keycloak is accepting requests. If the API starts first, sign-in fails until the API is recycled.
@@ -507,6 +507,6 @@ A fresh install has no users, teams, or environments yet. The Global Admin Quick
 
 - [Global Admin Quick Start](../../user-guide/global-admin-quick-start/readme.md)
 - [Configuring Ed-Fi Admin App](../../configuration/configuring-admin-app.md)
-- [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md)
+- [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider/readme.md)
 - [Security Considerations](../../configuration/security-considerations.md)
 - [Global Administration Tasks](../../configuration/global-administration-tasks.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
@@ -13,7 +13,7 @@ This is one of three alternative installation paths. If you instead want to run 
 ## Before you start: decide three things
 
 1. **Database engine** — SQL Server (default) or PostgreSQL. You need only one.
-2. **Identity provider (IdP)** — the Admin App authenticates against an OIDC provider. This guide sets up **Keycloak**, running locally, as the example identity provider; the Admin App's auth engine uses generic OIDC discovery, so Microsoft Entra ID and Google Workspace are also supported. See [Configuring an Identity Provider](../../configuration/identity-provider/readme.md).
+2. **Identity provider (IdP)** — the Admin App authenticates against an OIDC provider. This guide sets up **Keycloak**, running locally, as the example identity provider; the Admin App's auth engine uses generic OIDC discovery, so Microsoft Entra ID, Google Workspace, and Auth0 are also supported. See [Configuring an Identity Provider](../../configuration/identity-provider/readme.md).
 3. **How much to automate** — pick one of the three installation paths below.
 
 :::info

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/readme.md
@@ -13,7 +13,7 @@ This is one of three alternative installation paths. If you instead want to run 
 ## Before you start: decide three things
 
 1. **Database engine** — SQL Server (default) or PostgreSQL. You need only one.
-2. **Identity provider** — the Admin App authenticates against an OIDC provider. This guide sets up **Keycloak**, running locally, as the example identity provider. The Admin App's auth engine uses generic OIDC discovery, but Keycloak is the identity provider documented for this release. See [Configuring an Identity Provider](../../configuration/identity-provider.md).
+2. **Identity provider (IdP)** — the Admin App authenticates against an OIDC provider. This guide sets up **Keycloak**, running locally, as the example identity provider; the Admin App's auth engine uses generic OIDC discovery, so Microsoft Entra ID and Google Workspace are also supported. See [Configuring an Identity Provider](../../configuration/identity-provider/readme.md).
 3. **How much to automate** — pick one of the three installation paths below.
 
 :::info

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
@@ -35,6 +35,6 @@ A fresh install has no users, teams, or environments yet. The Global Admin Quick
 
 - [Global Admin Quick Start](../../user-guide/global-admin-quick-start/readme.md)
 - [Configuring Ed-Fi Admin App](../../configuration/configuring-admin-app.md)
-- [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md)
+- [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider/readme.md)
 - [Security Considerations](../../configuration/security-considerations.md)
 - [Global Administration Tasks](../../configuration/global-administration-tasks.md)

--- a/docs/reference/5-admin-app/user-guide/readme.md
+++ b/docs/reference/5-admin-app/user-guide/readme.md
@@ -12,9 +12,7 @@ Before you begin, ensure you have:
 
 ## Logging in
 
-Admin App uses an OAuth2 identity provider (IdP) that supports Open ID Connect. The out-of-the-box experience uses an open source IdP called Keycloak. Your installation may use a different provider, such as Google or Microsoft Entra ID.
-
-<!-- TODO: add screenshot of keycloak -->
+Admin App uses an OAuth2 identity provider (IdP) that supports Open ID Connect. The Ed-Fi Alliance has validated three providers: Keycloak (the bundled default example), Microsoft Entra ID, and Google Workspace. Your installation may use any of them; see [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md).
 
 Your organization may have setup multi-factor authentication, requiring you to enter a one-time access code to finish signing in.
 

--- a/docs/reference/5-admin-app/user-guide/readme.md
+++ b/docs/reference/5-admin-app/user-guide/readme.md
@@ -12,7 +12,7 @@ Before you begin, ensure you have:
 
 ## Logging in
 
-Admin App uses an OAuth2 identity provider (IdP) that supports Open ID Connect. The Ed-Fi Alliance has validated three providers: Keycloak (the bundled default example), Microsoft Entra ID, and Google Workspace. Your installation may use any of them; see [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md).
+Admin App uses an OAuth2 identity provider (IdP) that supports Open ID Connect. The Ed-Fi Alliance has validated four providers: Keycloak (the bundled default example), Microsoft Entra ID, Google Workspace, and Auth0. Your installation may use any of them; see [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider/readme.md).
 
 Your organization may have setup multi-factor authentication, requiring you to enter a one-time access code to finish signing in.
 


### PR DESCRIPTION
Draft until Admin APP v4.1 is released.

## Summary

Adds provider-specific OIDC setup guides for **Microsoft Entra ID** and **Google Workspace**, restructures "Configuring an Identity Provider" into a category (one page per provider), and makes the surrounding Admin App docs identity-provider agnostic so they no longer read as Keycloak-only. Also adapts the **Docker Compose** and **Unix-like** install guides to the same generic OIDC structure (EDFI-2851).

## Tickets

- [[EDFI-2794](https://edfi.atlassian.net/browse/EDFI-2794)] Document Microsoft Entra ID and Google Workspace as OIDC providers (Windows IIS path)
- [[EDFI-2851](https://edfi.atlassian.net/browse/EDFI-2851)] Extend the Docker and Unix-like install guides to the generic OIDC provider structure
- [[EDFI-2795](https://edfi.atlassian.net/browse/EDFI-2795)] Automate Entra ID App Registration via Microsoft Graph (PowerShell)

## Dependency

Based on the `EDFI-2779_Windows_Server_Installation_Guide` branch (PR #537), not `main` — **merge after #537**. This branch builds on #537's Windows IIS guide restructure.

The EDFI-2795 content documents the `idp-entra-setup.ps1` helper, which ships in [Admin-App-Installation-Scripts PR #5](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts/pull/5). **Merge these docs together with that PR** so the documented script exists when the guide references it (both target the Admin App v4.1 release).

## What changed

**Identity provider docs restructured into a category** (`configuration/identity-provider/`):

- Parent overview — general IdP guidance, the table-driven configuration model, and links to each provider guide.
- `keycloak.md` — the existing Keycloak content, moved unchanged, as the bundled default example.
- `microsoft-entra-id.md` — **new**: App Registration, client secret, API permissions, the required `email` optional claim, single-tenant vs. multitenant, `production.js` and frontend configuration, end-to-end validation and triage.
- `google-workspace.md` — **new**: Google Cloud project, OAuth consent screen (Internal audience), OAuth client, `production.js` and frontend configuration, end-to-end validation and triage.

**Made the surrounding Admin App docs identity-provider agnostic:**

- Present Keycloak as the bundled default example alongside Microsoft Entra ID and Google Workspace, with links to the provider guides (`getting-started/readme`, `configuration/configuring-admin-app`, `user-guide/readme`, and the Windows IIS pages).
- Generalized the `VITE_IDP_ACCOUNT_URL` guidance to all three providers.
- Added Microsoft Entra ID and Google Workspace `install-all.ps1` examples to the Windows IIS **Automated** page.
- Documented the `idp-entra-setup.ps1` helper ([scripts PR #5](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts/pull/5)) as an automated alternative to the manual Entra App Registration (a Part A tip), cross-referenced from the Automated install page; and split the Entra directory-role prerequisites (Cloud Application Administrator to create the app vs. Privileged Role Administrator / Global Administrator to grant admin consent).

**Docker and Unix-like install guides (EDFI-2851):**

- Adapted both guides to the generic OIDC structure while keeping Keycloak as the bundled example, with agnostic provider notes linking to the Entra ID and Google Workspace guides.
- Docker: added `VITE_OIDC_ID` to the `.env` example; documented pointing the API at a non-Keycloak provider (`production.js-edfi` + `./start-services.ps1 -Rebuild`) and the deployment-specific redirect/callback URI.
- Unix-like: marked `SAMPLE_OIDC_CONFIG` as the Keycloak example, documented the callback URI and the build-time `VITE_OIDC_ID` / `VITE_IDP_ACCOUNT_URL` frontend variables.
- Aligned the Keycloak example `scope` to `openid email profile` across the configuration and install guides for consistency.

## Validation

- `markdownlint` clean; Docusaurus build passes with `onBrokenMarkdownLinks: 'throw'` (no broken internal links or anchors); all 14 image URLs return 200.
- Both provider guides were validated end-to-end on a native Windows/IIS deployment.
- Docker/Unix guide changes validated by lint + build (no broken links or anchors). A Docker end-to-end sign-in with a non-Keycloak provider is tracked as follow-up under EDFI-2851.

## Screenshots
<img width="1584" height="856" alt="image" src="https://github.com/user-attachments/assets/6fa9c7d8-8270-490a-853e-9b61e53aea2f" />

[EDFI-2794]: https://edfi.atlassian.net/browse/EDFI-2794


[EDFI-2851]: https://edfi.atlassian.net/browse/EDFI-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDFI-2795]: https://edfi.atlassian.net/browse/EDFI-2795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
