### PR TITLE
[EDFI-2855] Link the install guides to the Global Admin Quick Start

### DIFF
--- a/docs/reference/5-admin-app/getting-started/docker-installation.md
+++ b/docs/reference/5-admin-app/getting-started/docker-installation.md
@@ -158,6 +158,9 @@ Ensure this matches your actual Keycloak realm configuration and domain.
 
 ## Next steps
 
+A fresh install has no users, teams, or environments yet. The Global Admin Quick Start seeds that starter configuration, so it is the recommended next step.
+
+- [Global Admin Quick Start](../user-guide/global-admin-quick-start/readme.md)
 - [Configuring Ed-Fi Admin App](../configuration/configuring-admin-app.md)
 - [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
 - [Security Considerations](../configuration/security-considerations.md)

--- a/docs/reference/5-admin-app/getting-started/unix-installation.md
+++ b/docs/reference/5-admin-app/getting-started/unix-installation.md
@@ -192,6 +192,9 @@ This path uses **PostgreSQL**. The Admin App is database-engine-agnostic, but SQ
 
 ## Next steps
 
+A fresh install has no users, teams, or environments yet. The Global Admin Quick Start seeds that starter configuration, so it is the recommended next step.
+
+- [Global Admin Quick Start](../user-guide/global-admin-quick-start/readme.md)
 - [Configuring Ed-Fi Admin App](../configuration/configuring-admin-app.md)
 - [Configuring an Identity Provider for Ed-Fi Admin App](../configuration/identity-provider.md)
 - [Security Considerations](../configuration/security-considerations.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -97,6 +97,9 @@ This task belongs to the local Keycloak example. It is not registered when the A
 
 ## Next steps
 
+A fresh install has no users, teams, or environments yet. The Global Admin Quick Start seeds that starter configuration, so it is the recommended next step.
+
+- [Global Admin Quick Start](../../user-guide/global-admin-quick-start/readme.md)
 - [Configuring Ed-Fi Admin App](../../configuration/configuring-admin-app.md)
 - [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md)
 - [Security Considerations](../../configuration/security-considerations.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -480,6 +480,9 @@ Node.js, SQL Server, and IIS can remain in place.
 
 ## Next steps
 
+A fresh install has no users, teams, or environments yet. The Global Admin Quick Start seeds that starter configuration, so it is the recommended next step.
+
+- [Global Admin Quick Start](../../user-guide/global-admin-quick-start/readme.md)
 - [Configuring Ed-Fi Admin App](../../configuration/configuring-admin-app.md)
 - [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md)
 - [Security Considerations](../../configuration/security-considerations.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -450,6 +450,8 @@ The API additionally sets `X-Content-Type-Options` and `X-Frame-Options` in appl
 
 Open the Web Application at `https://localhost:4443` and sign in through the identity provider. For the local Keycloak example, use the Keycloak user you created — its email must match `ADMIN_USERNAME` in `production.js` (default `admin@example.com`). This first user is the bootstrap administrator; additional users must be granted access from within the Admin App afterward.
 
+The Admin App is now running, but it manages **Ed-Fi ODS/API** instances that run separately — this guide does not install an ODS/API. After signing in, connect a running ODS/API environment (ODS/API 6.x or 7.x) by its Discovery API URL. If that fails with a certificate error, see [Troubleshooting](../../troubleshooting.md#backend-troubleshooting).
+
 ## Production considerations
 
 The default install is suitable for a local or trusted-network deployment. Before exposing the Admin App more broadly:
@@ -477,12 +479,6 @@ To remove a manual install, reverse the steps:
 Node.js, SQL Server, and IIS can remain in place.
 
 ## Next steps
-
-The Admin App is now running, but it manages **Ed-Fi ODS/API** instances that run separately — this guide does not install an ODS/API. To start using the Admin App, sign in and connect a running ODS/API environment (ODS/API 6.x or 7.x) by its Discovery API URL.
-
-:::note
-If the ODS/API or Admin API presents a self-signed or dev certificate — common for a local ODS/API — adding an Environment fails with a certificate error (`DEPTH_ZERO_SELF_SIGNED_CERT`) in the API log (`logs\node-stdout.log`). Make Node trust the upstream certificate via `NODE_EXTRA_CA_CERTS`; see [Production considerations](#production-considerations).
-:::
 
 - [Configuring Ed-Fi Admin App](../../configuration/configuring-admin-app.md)
 - [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md)

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/semi-automated.md
@@ -28,3 +28,13 @@ On **Windows Server 2019/2022**, install the Windows Package Manager (`winget`) 
 | optional | `install-all.ps1` | Runs the whole sequence end to end (see [Automated](./automated.md)). | (whole install) |
 
 To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and its startup task, and unsets `JAVA_HOME`; leaves the JDK installed).
+
+## Next steps
+
+A fresh install has no users, teams, or environments yet. The Global Admin Quick Start seeds that starter configuration, so it is the recommended next step.
+
+- [Global Admin Quick Start](../../user-guide/global-admin-quick-start/readme.md)
+- [Configuring Ed-Fi Admin App](../../configuration/configuring-admin-app.md)
+- [Configuring an Identity Provider for Ed-Fi Admin App](../../configuration/identity-provider.md)
+- [Security Considerations](../../configuration/security-considerations.md)
+- [Global Administration Tasks](../../configuration/global-administration-tasks.md)

--- a/docs/reference/5-admin-app/user-guide/edorg-synchronization/readme.md
+++ b/docs/reference/5-admin-app/user-guide/edorg-synchronization/readme.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 2
 ---
 
 # Education Organization Sync

--- a/docs/reference/5-admin-app/user-guide/global-admin-quick-start/readme.md
+++ b/docs/reference/5-admin-app/user-guide/global-admin-quick-start/readme.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Quick Start
 
 After installing the Ed-Fi Admin App, a global administrator normally has to


### PR DESCRIPTION
## Summary

Points readers at the Global Admin Quick Start once they finish an install. Nothing in the docs linked to it, so the flow was reachable only through the sidebar. Adds that link to all five install pages, and corrects the sidebar order that listed Education Organization Sync ahead of the Quick Start.

## What changed

**Quick Start link on every install path (EDFI-2855)**

The Global Admin Quick Start is now the first `Next steps` entry on the three
Windows IIS pages (Automated, Semi-automated, Manual), Docker, and Unix-like.
Semi-automated had no `Next steps` section and now carries the same one as its
siblings. The link reads "Global Admin Quick Start" everywhere, since the Docker
page already uses "Quick Start" for its own Compose section.

**Sidebar order under User's Guide (EDFI-2780)**

The Quick Start now precedes Education Organization Sync. The
`edorg-synchronization` readme carried `sidebar_position: 0`, which orders the
category, while the Quick Start readme had no front matter and so fell into the
alphabetical group Docusaurus places after every positioned item. Both now
declare a position in their readme front matter, the mechanism the rest of the
repo uses.

**Manual guide Next steps (EDFI-2779)**

That section opened with a paragraph about the Admin App managing separately
running ODS/API instances, plus a note on `DEPTH_ZERO_SELF_SIGNED_CERT`, which
left it shaped differently from its two siblings. The paragraph moved to
`First sign-in`, where the reader has just signed in and has to connect an
environment. The note was dropped: `troubleshooting.md` already documents that
same error in its Error/Cause/Solution form.

<img width="848" height="335" alt="image" src="https://github.com/user-attachments/assets/5638556e-ddde-4a52-9a52-88b427f1e57c" />

<img width="390" height="525" alt="image" src="https://github.com/user-attachments/assets/e3e82b0c-a8da-4172-b779-827ffa023631" />
