### PR TITLE
[DATASTD-2642] Fix stale SEOA reference in Assessment Registration domain docs

### DIFF
--- a/dataStandard_versioned_docs/version-6/model-reference/assessment-registration-domain/best-practices.md
+++ b/dataStandard_versioned_docs/version-6/model-reference/assessment-registration-domain/best-practices.md
@@ -292,7 +292,7 @@ attributes.
 
 | Required | Must Have | Recommended | As Needed |
 |---|---|---|---|
-| AssessmentAdministration (key) <br/> StudentEducationOrganization Association (key) <br/> StudentSchoolAssociation | TestingEducationOrganization <br/> ReportingEducationOrganization | AssessmentAccommodation <br/> PlatformType <br/> AssessmentGradeLevel | StudentEducationOrganizationAssessmentAccommodation <br/> AssessmentCustomization |
+| AssessmentAdministration (key) <br/> StudentDemographic (key) <br/> StudentSchoolAssociation | TestingEducationOrganization <br/> ReportingEducationOrganization | AssessmentAccommodation <br/> PlatformType <br/> AssessmentGradeLevel | StudentEducationOrganizationAssessmentAccommodation <br/> AssessmentCustomization |
 
 <br/>
 

--- a/dataStandard_versioned_docs/version-6/model-reference/assessment-registration-domain/overview.md
+++ b/dataStandard_versioned_docs/version-6/model-reference/assessment-registration-domain/overview.md
@@ -24,7 +24,7 @@ The key entities in the Assessment Registration domain are:
   customization of an assessment. The entity has references to AssessmentAdministration,
   TestingEducationOrganization, ReportingEducationOrganization and
   StudentEducationOrganizationAssessmentAccommodation entities, and
-  StudentEducationOrganizationAssociation as well as StudentSchoolAssociation.
+  StudentDemographic as well as StudentSchoolAssociation.
 * An _AssessmentBatteryPart_ entity that defines the parts organized for administering
   the assessment for a comprehensive assessment of the student. It has reference to Assessment
   and the ObjectiveAssessment.


### PR DESCRIPTION
## Summary
- `overview.md` and `best-practices.md` for the Assessment Registration domain still described `StudentAssessmentRegistration` as keying off `StudentEducationOrganizationAssociation` (SEOA).
- DATASTD-2459 (DS v6.0) deleted that reference and replaced it with a `StudentDemographic` reference. `entities-references-and-descriptors.md` and the model diagrams (`.mmd` files) already reflected this; these two pages were never updated.
- This PR brings both pages in line with the current v6.0 model.

Jira: DATASTD-2642

## Test plan
- [x] `npm run build` completes with no broken-link errors
- [x] Confirmed via `entities-references-and-descriptors.md` and `AssessmentRegistration.mmd`/`AssessmentRegistration-simple.mmd` that `StudentDemographic` is the correct, currently-modeled reference
- [x] Confirmed pre-existing markdownlint table-formatting errors in `best-practices.md` are unrelated to this change (same count before/after)