### PR TITLE
[EDFI-2888] Document Azure SQL as an Admin App database option

### DIFF
--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -57,6 +57,14 @@ Pass a parameter only to change something the defaults do not cover. PostgreSQL 
 .\install-all.ps1 -DbEngine pgsql -UsePostgresDocker
 ```
 
+**Example — managed Azure SQL Database** (provision the logical server, a client-IP firewall rule, and an empty database in Azure first — see [Database](./manual.md#database)):
+
+```powershell
+.\install-all.ps1 -SqlServerHost myserver.database.windows.net -SqlAdminUsername sqladmin
+```
+
+The script prompts for `-SqlAdminPassword`, `-AppDbPassword`, and the rest, the same as any other run.
+
 :::note
 By default the sites use a self-signed certificate (auto-trusted on this machine only). To bind a real certificate, pass `-CertificateThumbprint`, or `-CertificatePfxPath` with `-CertificatePassword` (see [TLS and certificates](./manual.md#tls-and-certificates)). Yopass is off by default; add `-SetupYopassDocker` to stand up a local Yopass via Docker, or `-YopassUrl <url>` to point at an existing one.
 :::

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/automated.md
@@ -63,7 +63,7 @@ Pass a parameter only to change something the defaults do not cover. PostgreSQL 
 .\install-all.ps1 -SqlServerHost myserver.database.windows.net -SqlAdminUsername sqladmin
 ```
 
-The script prompts for `-SqlAdminPassword`, `-AppDbPassword`, and the rest, the same as any other run.
+The script prompts for `-SqlAdminPassword`, `-AppDbPassword`, and the rest, the same as any other run. It provisions the Admin App login as a contained user, connects with encryption and validates the server certificate, and configures the API to do the same — nothing to set by hand. For a remote server that presents a self-signed certificate rather than a CA-issued one, add `-TrustServerCertificate`, which turns that validation off. Azure rejects a database password containing the login name, so avoid `edfi_adminapp` in the value; the script checks this up front.
 
 :::note
 By default the sites use a self-signed certificate (auto-trusted on this machine only). To bind a real certificate, pass `-CertificateThumbprint`, or `-CertificatePfxPath` with `-CertificatePassword` (see [TLS and certificates](./manual.md#tls-and-certificates)). Yopass is off by default; add `-SetupYopassDocker` to stand up a local Yopass via Docker, or `-YopassUrl <url>` to point at an existing one.
@@ -71,7 +71,7 @@ By default the sites use a self-signed certificate (auto-trusted on this machine
 
 `install-all.ps1` is idempotent: if a step fails, fix the cause and re-run. `-SkipPhase1` (skip prerequisites) and `-SkipPhase2` (skip build) speed up re-runs.
 
-To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and its startup task, and unsets `JAVA_HOME`; leaves the JDK installed).
+To remove an install, use `uninstall.ps1` (generic) and, for the local Keycloak, `uninstall-keycloak.ps1` (removes Keycloak and its startup task, and unsets `JAVA_HOME`; leaves the JDK installed). Against a managed Azure SQL Database, pass the same `-SqlServerHost` and `-SqlAdminUsername`: the database itself is yours and is left untouched, and only the Admin App's contained user is removed.
 
 For the full list of parameters and configuration options, see the [`windows-install/README.md`](https://github.com/Ed-Fi-Exchange-OSS/Admin-App-Installation-Scripts/blob/main/windows-install/README.md) in the scripts repository, or run `Get-Help .\install-all.ps1 -Full`.
 

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -54,7 +54,7 @@ Without unlocking the `handlers` section, requests to the API return **HTTP 500.
 
 The Admin App supports PostgreSQL 16+ and SQL Server 2017+, and needs only one. This guide uses **SQL Server** by default on Windows; PostgreSQL is available via Docker (requires Docker Desktop in Linux-container mode).
 
-For SQL Server, run these steps as a Windows account that is a SQL Server sysadmin (Windows Authentication); the `sa` login is not required:
+For **SQL Server**, run these steps as a Windows account that is a SQL Server sysadmin (Windows Authentication); the `sa` login is not required:
 
 1. Enable **Mixed Mode (SQL Server and Windows) authentication** (the Node `mssql` driver connects with SQL authentication).
 2. Enable the **TCP/IP** protocol and confirm it listens on port **1433** (the driver requires TCP).
@@ -78,7 +78,17 @@ Some special characters are not currently supported in the Admin App database us
 Installing the Admin App database in its own SQL Server instance, separate from the ODS/API databases (`EdFi_Admin`, `EdFi_Security`), is recommended.
 :::
 
-For PostgreSQL, see [Configuring the Admin App](../../configuration/configuring-admin-app.md).
+For a managed **Azure SQL Database**, provision the logical server (with SQL authentication enabled and an admin login), a firewall rule for the client's public IP, and an empty database through the Azure portal or CLI first — the local-instance steps above (Mixed Mode, TCP/IP) do not apply. Then create the login as a _contained user_ in the target database, since Azure SQL supports neither `CREATE LOGIN` nor `USE`:
+
+```sql
+-- Connect to the target database as the server admin.
+CREATE USER [edfi_adminapp] WITH PASSWORD = N'YourStrong!AppPassw0rd';
+ALTER ROLE db_owner ADD MEMBER [edfi_adminapp];
+```
+
+Azure SQL rejects a password that contains the login name, so avoid `edfi_adminapp` in the value.
+
+For **PostgreSQL**, see [Configuring the Admin App](../../configuration/configuring-admin-app.md#postgresql-setup).
 
 ### Node.js
 
@@ -243,11 +253,11 @@ The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP 
 
    module.exports = {
      DB_ENGINE: 'mssql', // 'mssql' (this guide) or 'pgsql'
-     DB_TRUST_CERTIFICATE: true, // true for a local SQL Server using a self-signed certificate
+     DB_TRUST_CERTIFICATE: true, // true for a local SQL Server using a self-signed certificate; false for a managed Azure SQL Database (valid CA certificate)
      DB_TTL_IN_MINUTES: 120,
      DB_SSL: false,
      DB_SECRET_VALUE: {
-       MSSQL_DB_HOST: 'localhost',
+       MSSQL_DB_HOST: 'localhost', // or a managed Azure SQL Database FQDN, e.g. myserver.database.windows.net
        MSSQL_DB_PORT: 1433,
        MSSQL_DB_USERNAME: 'edfi_adminapp', // the least-privilege login, not sa
        MSSQL_DB_DATABASE: 'sbaa', // the database must already exist on the server

--- a/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
+++ b/docs/reference/5-admin-app/getting-started/windows-iis-installation/manual.md
@@ -78,10 +78,10 @@ Some special characters are not currently supported in the Admin App database us
 Installing the Admin App database in its own SQL Server instance, separate from the ODS/API databases (`EdFi_Admin`, `EdFi_Security`), is recommended.
 :::
 
-For a managed **Azure SQL Database**, provision the logical server (with SQL authentication enabled and an admin login), a firewall rule for the client's public IP, and an empty database through the Azure portal or CLI first — the local-instance steps above (Mixed Mode, TCP/IP) do not apply. Then create the login as a _contained user_ in the target database, since Azure SQL supports neither `CREATE LOGIN` nor `USE`:
+For a managed **Azure SQL Database**, provision the logical server (with SQL authentication enabled and an admin login), a firewall rule for the client's public IP, and an empty database through the Azure portal or CLI first — the local-instance steps above (Mixed Mode, TCP/IP) do not apply. Create the Admin App login as a _contained user_, which lives entirely in the application database and needs no login in `master`. Connect to that database first, since a session cannot switch databases on Azure SQL Database:
 
 ```sql
--- Connect to the target database as the server admin.
+-- Connected to the application database as the server admin.
 CREATE USER [edfi_adminapp] WITH PASSWORD = N'YourStrong!AppPassw0rd';
 ALTER ROLE db_owner ADD MEMBER [edfi_adminapp];
 ```
@@ -253,11 +253,11 @@ The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP 
 
    module.exports = {
      DB_ENGINE: 'mssql', // 'mssql' (this guide) or 'pgsql'
-     DB_TRUST_CERTIFICATE: true, // true for a local SQL Server using a self-signed certificate; false for a managed Azure SQL Database (valid CA certificate)
+     DB_TRUST_CERTIFICATE: true, // true for a local SQL Server using a self-signed certificate
      DB_TTL_IN_MINUTES: 120,
      DB_SSL: false,
      DB_SECRET_VALUE: {
-       MSSQL_DB_HOST: 'localhost', // or a managed Azure SQL Database FQDN, e.g. myserver.database.windows.net
+       MSSQL_DB_HOST: 'localhost',
        MSSQL_DB_PORT: 1433,
        MSSQL_DB_USERNAME: 'edfi_adminapp', // the least-privilege login, not sa
        MSSQL_DB_DATABASE: 'sbaa', // the database must already exist on the server
@@ -304,6 +304,19 @@ The API is deployed as a standalone IIS site, `EdFi-AdminApp-API`, with an HTTP 
      RATE_LIMIT_LIMIT: 10,
    };
    ```
+
+   For a managed **Azure SQL Database**, change the host and the two values that control the connection's encryption:
+
+   ```javascript
+     DB_TRUST_CERTIFICATE: false, // Azure SQL presents a CA-issued certificate: validate it
+     DB_SSL: true,                // request encryption; Azure SQL requires it
+     DB_SECRET_VALUE: {
+       MSSQL_DB_HOST: 'myserver.database.windows.net',
+       // the remaining values are unchanged
+     },
+   ```
+
+   `DB_SSL` is the driver's `encrypt` flag. Left at `false`, the API cannot connect to Azure SQL at all, because the server requires encryption; and `DB_TRUST_CERTIFICATE: false` only takes effect once encryption is requested.
 
 7. **Create the log directory**:
    - Create `C:\inetpub\EdFi-AdminApp-API\logs` (httpPlatform writes Node's stdout to `logs\node-stdout.log`).


### PR DESCRIPTION
## Summary

Documents deploying the Admin App database on a managed Azure SQL Database, alongside the existing local SQL Server and PostgreSQL options, in the Admin App v4 Windows IIS installation guide.

## What changed

- `manual.md` (Database prerequisites): a managed Azure SQL Database variant of the SQL Server steps.
- `automated.md`: an `install-all.ps1` example targeting Azure via `-SqlServerHost` / `-SqlAdminUsername`.

## Notes

- Verified with `npm run lint` and `npm run build` (no broken links).


[EDFI-2888]: https://edfi.atlassian.net/browse/EDFI-2888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ