### PR TITLE
chore: Bump github/codeql-action to v4.37.7

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -72,10 +72,10 @@ jobs:
 
       - name: Initialize CodeQL
         if: success()
-        uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: javascript-typescript, actions
 
       - name: Perform CodeQL Analysis
         if: success()
-        uses: github/codeql-action/analyze@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -63,6 +63,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: scorecard.sarif


### PR DESCRIPTION
## Summary
- Updates `github/codeql-action/init`, `github/codeql-action/analyze`, and `github/codeql-action/upload-sarif` from v3.37.1 to v4.37.7 (SHA `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd`)
- Ran a full audit of all GitHub Actions `uses:` references against the Ed-Fi Alliance approved allowlist and GitHub's latest releases; all other actions (`actions/checkout`, `actions/setup-node`, `actions/cache`, `actions/upload-pages-artifact`, `actions/deploy-pages`, `actions/upload-artifact`, `actions/dependency-review-action`, `actions/github-script`, `ossf/scorecard-action`) were already at their latest approved versions

## Test plan
- [x] `actionlint` run locally against `.github/workflows/` — no issues
- [x] Confirm CI passes on this PR (CodeQL analysis job in particular)

Note: this branch/PR does not have an associated Jira ticket per the repo's normal convention — flagging in case one should be attached before merge.