### PR TITLE
fix: Skip CodeQL SARIF upload for merge_group events

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -79,3 +79,9 @@ jobs:
       - name: Perform CodeQL Analysis
         if: success()
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          # Merge group runs use an ephemeral gh-readonly-queue ref that no
+          # longer exists by the time results are uploaded, which fails the
+          # upload step. Skip uploading in that case; the analysis itself
+          # still runs and can still fail the job.
+          upload: ${{ github.event_name != 'merge_group' }}


### PR DESCRIPTION
The merge queue's gh-readonly-queue ref is ephemeral and no longer exists by the time the analyze step tries to upload results, causing the job to fail with "ref not found in this repository". Uploading is unnecessary for merge group checks anyway since the analysis result itself still gates the job.

This fix is in response to [this error](https://github.com/Ed-Fi-Alliance-OSS/ed-fi-alliance-oss.github.io/actions/runs/32062483346).