### PR TITLE
[DMS-1278] Update public docs for raw upload-claims body

### DIFF
--- a/odsApi_versioned_docs/version-8/how-to-guides/how-to-create-and-manage-api-security-metadata.mdx
+++ b/odsApi_versioned_docs/version-8/how-to-guides/how-to-create-and-manage-api-security-metadata.mdx
@@ -470,6 +470,10 @@ array uses the same JSON array format described in [The Security Metadata
 Format](#the-security-metadata-format). Any new claim set referenced in the
 hierarchy must also appear in `claimSets`.
 
+`GET /management/current-claims` returns this same two-section document, and
+`POST /management/upload-claims` accepts it unchanged, so a document retrieved
+from the service can be edited and posted back exactly as it was downloaded.
+
 These management endpoints require a Configuration Service bearer token. Write
 operations (`POST /management/upload-claims`, `POST /management/reload-claims`)
 require the `edfi_admin_api/full_access` scope; the read operation
@@ -500,21 +504,19 @@ Invoke-RestMethod -Uri "http://localhost:8081/management/current-claims" `
 set names to the `claimSets` catalog as well.
 
 **Upload** the modified document to replace the active claims hierarchy. The
-endpoint requires the document wrapped in a top-level `claims` property, which
-the `@{ claims = ... }` hashtable adds before serializing:
+endpoint accepts the two-section document exactly as downloaded, so post the
+file contents directly as the request body:
 
 ```powershell
-$claims = Get-Content claims.json -Raw | ConvertFrom-Json
-$body = @{ claims = $claims } | ConvertTo-Json -Depth 100
-
 Invoke-RestMethod -Method Post `
   -Uri "http://localhost:8081/management/upload-claims" `
   -Headers @{ Authorization = "Bearer $($token.access_token)" } `
   -ContentType "application/json" `
-  -Body $body
+  -Body (Get-Content claims.json -Raw)
 ```
 
 The uploaded document must include both the `claimSets` catalog and the
-`claimsHierarchy` array, wrapped as `{"claims": {"claimSets": [...],
-"claimsHierarchy": [...]}}`. It atomically replaces the current configuration
-and re-seeds the `ResourceClaim` catalog with any new claim names.
+`claimsHierarchy` array as top-level properties, as
+`{"claimSets": [...], "claimsHierarchy": [...]}`. It atomically replaces the
+current configuration and re-seeds the `ResourceClaim` catalog with any new
+claim names.

--- a/odsApi_versioned_docs/version-8/platform-dev-guide/utilities/cms-hierarchy-tool.md
+++ b/odsApi_versioned_docs/version-8/platform-dev-guide/utilities/cms-hierarchy-tool.md
@@ -192,20 +192,21 @@ using the loading mode configured for your deployment.
 | **Filesystem** | Copy the output file to the directory set by `DMS_CONFIG_CLAIMS_DIRECTORY` before the service starts |
 | **Hybrid** | Place the fragment file in the directory set by `DMS_CONFIG_CLAIMS_DIRECTORY`; the embedded base loads automatically |
 | **Embedded** | Rebuild and redeploy the Configuration Service binary with the updated embedded `Claims.json` |
-| **Management API** | Wrap the hierarchy array in the two-section upload format and `POST` to `/management/upload-claims` |
+| **Management API** | Place the hierarchy array into the two-section upload document and `POST` that document directly to `/management/upload-claims` |
 
-For the management API upload, wrap the document produced by `Transform` in the
-two-section container **and** nest it under a top-level `claims` property (the
-`/management/upload-claims` endpoint requires this wrapper):
+The `Transform` command emits only the hierarchy array. For the management API
+upload, place that array into the two-section upload document as
+`claimsHierarchy`, add a `claimSets` entry for every claim set the hierarchy
+references, and post that document directly as the request body. Both sections
+are top-level properties; the endpoint does not accept an outer `claims`
+property:
 
 ```json
 {
-  "claims": {
-    "claimSets": [
-      { "claimSetName": "MyExtensionClaimSet", "isSystemReserved": false }
-    ],
-    "claimsHierarchy": [ ... ]
-  }
+  "claimSets": [
+    { "claimSetName": "MyExtensionClaimSet", "isSystemReserved": false }
+  ],
+  "claimsHierarchy": [ ... ]
 }
 ```
 


### PR DESCRIPTION
The v8 docs described `POST /management/upload-claims` as requiring the upload
document nested under a top-level `claims` property. The Configuration Service
binds the request body root directly and hands it to the upload service
unchanged, so the accepted body is the two-section document itself: top-level
`claimSets` and `claimsHierarchy`. The canonical claims schema declares both as
required with `additionalProperties: false`, so the documented wrapper is
rejected both as an unexpected property and as two missing required ones.

Two pages are corrected:

- **How To: Create and Manage API Security Metadata** — drops the
  `@{ claims = ... }` PowerShell step and posts the downloaded file directly.
  Adds a statement that `GET /management/current-claims` returns the same
  two-section document the upload endpoint accepts, so a retrieved document can
  be edited and posted back exactly as downloaded.
- **CmsHierarchy Tool** — removes the outer `claims` wrapper from the upload
  example. The `Transform` command still emits only the hierarchy array, and
  that array still belongs in the upload document as `claimsHierarchy` alongside
  a `claimSets` catalog; only the wrapper is gone.

Both revised examples were validated against the Configuration Service's
`JsonSchemaForClaims.json`.

Raised by review on Data-Management-Service PR #1204.

Note to consider: `npm run lint` already fails on `main` with pre-existing
markdownlint errors across older versioned docs. The two files changed here
report no errors, and there are none anywhere under `version-8`.
`npm run build` passes, including the broken-link check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)